### PR TITLE
fix: sync tauri package version

### DIFF
--- a/src/EasyLottery/src-tauri/Cargo.lock
+++ b/src/EasyLottery/src-tauri/Cargo.lock
@@ -608,7 +608,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "easylottery"
-version = "1.1.0"
+version = "1.2.7"
 dependencies = [
  "serde",
  "serde_json",

--- a/src/EasyLottery/src-tauri/Cargo.toml
+++ b/src/EasyLottery/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "easylottery"
-version = "1.1.0"
+version = "1.2.7"
 description = "A Lottery App"
 authors = ["Makaku_Ch"]
 edition = "2021"


### PR DESCRIPTION
## Summary\n- Sync the Tauri Rust package version with the Tauri bundle version.\n- Keep the release metadata aligned at 1.2.7.\n\n## Verification\n- dotnet test EasyLottery.generated.sln --configuration Release\n- Result: 10/10 API tests passed, 68/68 domain tests passed\n\n## Notes\n- This change only updates version metadata in the Tauri package manifest and lockfile.\n- No product behavior was changed.