### PR TITLE
feat: add duplicate template actions

### DIFF
--- a/src/EasyLotteryDomain/Services/PokeService.cs
+++ b/src/EasyLotteryDomain/Services/PokeService.cs
@@ -60,6 +60,48 @@ namespace EasyLotteryDomain.Services
             await _configStore.SaveAsync(document);
         }
 
+        public async Task<PokeTemplate> DuplicateTemplateAsync(int id)
+        {
+            var document = await _configStore.LoadAsync();
+            var source = document.PokeTemplates.FirstOrDefault(t => t.Id == id)
+                ?? throw new InvalidOperationException($"Template {id} not found.");
+
+            var duplicate = new PokeTemplate
+            {
+                Name = BuildDuplicateName(source.Name, document.PokeTemplates.Select(t => t.Name)),
+                Description = source.Description,
+                GridRows = source.GridRows,
+                GridColumns = source.GridColumns,
+                Mode = source.Mode,
+                AllowRePoking = source.AllowRePoking,
+                MaxPokeCount = source.MaxPokeCount,
+                BackgroundImageUrl = source.BackgroundImageUrl,
+                FontFamily = source.FontFamily,
+                OverlayWidth = source.OverlayWidth,
+                OverlayHeight = source.OverlayHeight,
+                Animation = source.Animation,
+                PokeSoundUrl = source.PokeSoundUrl,
+                OpenSoundUrl = source.OpenSoundUrl,
+                IsBuiltIn = false,
+                Cells = source.Cells
+                    .OrderBy(cell => cell.Index)
+                    .Select(cell => new PokeCell
+                    {
+                        Index = cell.Index,
+                        Title = cell.Title,
+                        SubTitle = cell.SubTitle,
+                        ImageUrl = cell.ImageUrl,
+                        RevealedImageUrl = cell.RevealedImageUrl,
+                        RevealedColor = cell.RevealedColor,
+                        IsRevealed = false,
+                        RevealedAt = null
+                    })
+                    .ToList()
+            };
+
+            return await CreateTemplateAsync(duplicate);
+        }
+
         public async Task<List<PokeTemplate>> ListTemplatesAsync()
         {
             var document = await LoadDocumentAsync(ensureBuiltIns: true);
@@ -246,6 +288,28 @@ namespace EasyLotteryDomain.Services
             }
 
             template.Cells = orderedCells;
+        }
+
+        private static string BuildDuplicateName(string sourceName, IEnumerable<string> existingNames)
+        {
+            var baseName = string.IsNullOrWhiteSpace(sourceName)
+                ? "複製模板"
+                : $"{sourceName} - 複製";
+
+            if (!existingNames.Contains(baseName))
+            {
+                return baseName;
+            }
+
+            var suffix = 2;
+            var candidate = $"{baseName} {suffix}";
+            while (existingNames.Contains(candidate))
+            {
+                suffix++;
+                candidate = $"{baseName} {suffix}";
+            }
+
+            return candidate;
         }
 
         public static List<PokeTemplate> BuildDefaultTemplates()

--- a/src/EasyLotteryDomain/Services/RouletteService.cs
+++ b/src/EasyLotteryDomain/Services/RouletteService.cs
@@ -62,6 +62,42 @@ namespace EasyLotteryDomain.Services
             await _configStore.SaveAsync(document);
         }
 
+        public async Task<RouletteTemplate> DuplicateTemplateAsync(int id)
+        {
+            var document = await _configStore.LoadAsync();
+            var source = document.RouletteTemplates.FirstOrDefault(t => t.Id == id)
+                ?? throw new InvalidOperationException($"Template {id} not found.");
+
+            var duplicate = new RouletteTemplate
+            {
+                Name = BuildDuplicateName(source.Name, document.RouletteTemplates.Select(t => t.Name)),
+                Description = source.Description,
+                SegmentCount = source.SegmentCount,
+                SpinDurationSec = source.SpinDurationSec,
+                EasingFunction = source.EasingFunction,
+                InitialAngleDeg = source.InitialAngleDeg,
+                CenterImageUrl = source.CenterImageUrl,
+                BackgroundImageUrl = source.BackgroundImageUrl,
+                PointerImageUrl = source.PointerImageUrl,
+                SpinSoundUrl = source.SpinSoundUrl,
+                WinSoundUrl = source.WinSoundUrl,
+                IsBuiltIn = false,
+                Segments = source.Segments
+                    .OrderBy(segment => segment.Index)
+                    .Select(segment => new RouletteSegment
+                    {
+                        Index = segment.Index,
+                        Title = segment.Title,
+                        ImageUrl = segment.ImageUrl,
+                        Color = segment.Color,
+                        Probability = segment.Probability
+                    })
+                    .ToList()
+            };
+
+            return await CreateTemplateAsync(duplicate);
+        }
+
         public async Task<List<RouletteTemplate>> ListTemplatesAsync()
         {
             var document = await LoadDocumentAsync(ensureBuiltIns: true);
@@ -247,6 +283,28 @@ namespace EasyLotteryDomain.Services
             }
 
             template.Segments = orderedSegments;
+        }
+
+        private static string BuildDuplicateName(string sourceName, IEnumerable<string> existingNames)
+        {
+            var baseName = string.IsNullOrWhiteSpace(sourceName)
+                ? "複製模板"
+                : $"{sourceName} - 複製";
+
+            if (!existingNames.Contains(baseName))
+            {
+                return baseName;
+            }
+
+            var suffix = 2;
+            var candidate = $"{baseName} {suffix}";
+            while (existingNames.Contains(candidate))
+            {
+                suffix++;
+                candidate = $"{baseName} {suffix}";
+            }
+
+            return candidate;
         }
 
         public static List<RouletteTemplate> BuildDefaultTemplates()

--- a/src/EasyLotteryWasm/Pages/PokeBox/PokeBox.razor
+++ b/src/EasyLotteryWasm/Pages/PokeBox/PokeBox.razor
@@ -49,6 +49,7 @@ else
                         <div class="d-flex gap-1">
                             <Button Size="Size.Small" Color="Color.Success" Clicked="@(() => NavigateToPreview(t.Id))">預覽</Button>
                             <Button Size="Size.Small" Color="Color.Warning" Clicked="@(() => NavigateToEditor(t.Id))">編輯</Button>
+                            <Button Size="Size.Small" Color="Color.Primary" Clicked="@(() => DuplicateTemplate(t.Id))">複製</Button>
                             <Button Size="Size.Small" Color="Color.Info" Clicked="@(() => ExportTemplate(t.Id))">匯出</Button>
                             @if (!t.IsBuiltIn)
                             {
@@ -118,6 +119,14 @@ else
     {
         await PokeService.DeleteTemplateAsync(id);
         await LoadTemplates();
+    }
+
+    private async Task DuplicateTemplate(int id)
+    {
+        var duplicate = await PokeService.DuplicateTemplateAsync(id);
+        await LoadTemplates();
+        NavigationManager.NavigateTo($"/pokebox/editor/{duplicate.Id}");
+        await MessageService.Success($"已建立複本「{duplicate.Name}」。");
     }
 
     private async Task ExportTemplate(int id)

--- a/src/EasyLotteryWasm/Pages/Roulette/Roulette.razor
+++ b/src/EasyLotteryWasm/Pages/Roulette/Roulette.razor
@@ -49,6 +49,7 @@ else
                         <div class="d-flex gap-1">
                             <Button Size="Size.Small" Color="Color.Success" Clicked="@(() => NavigateToPreview(t.Id))">預覽</Button>
                             <Button Size="Size.Small" Color="Color.Warning" Clicked="@(() => NavigateToEditor(t.Id))">編輯</Button>
+                            <Button Size="Size.Small" Color="Color.Primary" Clicked="@(() => DuplicateTemplate(t.Id))">複製</Button>
                             <Button Size="Size.Small" Color="Color.Info" Clicked="@(() => ExportTemplate(t.Id))">匯出</Button>
                             @if (!t.IsBuiltIn)
                             {
@@ -118,6 +119,14 @@ else
     {
         await RouletteService.DeleteTemplateAsync(id);
         await LoadTemplates();
+    }
+
+    private async Task DuplicateTemplate(int id)
+    {
+        var duplicate = await RouletteService.DuplicateTemplateAsync(id);
+        await LoadTemplates();
+        NavigationManager.NavigateTo($"/roulette/editor/{duplicate.Id}");
+        await MessageService.Success($"已建立複本「{duplicate.Name}」。");
     }
 
     private async Task ExportTemplate(int id)

--- a/tests/EasyLotteryDomainTests/Services/PokeServiceTests.cs
+++ b/tests/EasyLotteryDomainTests/Services/PokeServiceTests.cs
@@ -83,6 +83,62 @@ namespace EasyLotteryDomainTests.Services
             Assert.IsNull(loaded);
         }
 
+        [TestMethod]
+        public async Task DuplicateTemplate_CreatesEditableCopy()
+        {
+            var svc = new PokeService(new InMemoryEasyLotteryConfigStore());
+
+            var template = new PokeTemplate
+            {
+                Name = "Original",
+                Description = "Base template",
+                GridRows = 2,
+                GridColumns = 3,
+                Mode = PokeMode.Manual,
+                AllowRePoking = true,
+                MaxPokeCount = 4,
+                BackgroundImageUrl = "/bg.png",
+                FontFamily = "Noto Sans TC",
+                OverlayWidth = 1280,
+                OverlayHeight = 720,
+                Animation = PokeAnimation.Flash,
+                PokeSoundUrl = "/poke.mp3",
+                OpenSoundUrl = "/open.mp3",
+                Cells = new List<PokeCell>
+                {
+                    new PokeCell { Index = 0, Title = "A", SubTitle = "One", ImageUrl = "/a.png", RevealedImageUrl = "/ra.png", RevealedColor = "#111111", IsRevealed = true, RevealedAt = DateTime.UtcNow },
+                    new PokeCell { Index = 1, Title = "B", SubTitle = "Two", ImageUrl = "/b.png", RevealedImageUrl = "/rb.png", RevealedColor = "#222222" }
+                }
+            };
+            var created = await svc.CreateTemplateAsync(template);
+
+            var duplicate = await svc.DuplicateTemplateAsync(created.Id);
+            var loaded = await svc.LoadTemplateAsync(duplicate.Id);
+
+            Assert.IsNotNull(loaded);
+            Assert.AreNotEqual(created.Id, duplicate.Id);
+            Assert.AreEqual("Original - 複製", duplicate.Name);
+            Assert.IsFalse(duplicate.IsBuiltIn);
+            Assert.AreEqual(template.Description, duplicate.Description);
+            Assert.AreEqual(template.GridRows, duplicate.GridRows);
+            Assert.AreEqual(template.GridColumns, duplicate.GridColumns);
+            Assert.AreEqual(template.Mode, duplicate.Mode);
+            Assert.AreEqual(template.AllowRePoking, duplicate.AllowRePoking);
+            Assert.AreEqual(template.MaxPokeCount, duplicate.MaxPokeCount);
+            Assert.AreEqual(template.BackgroundImageUrl, duplicate.BackgroundImageUrl);
+            Assert.AreEqual(template.FontFamily, duplicate.FontFamily);
+            Assert.AreEqual(template.OverlayWidth, duplicate.OverlayWidth);
+            Assert.AreEqual(template.OverlayHeight, duplicate.OverlayHeight);
+            Assert.AreEqual(template.Animation, duplicate.Animation);
+            Assert.AreEqual(template.PokeSoundUrl, duplicate.PokeSoundUrl);
+            Assert.AreEqual(template.OpenSoundUrl, duplicate.OpenSoundUrl);
+            Assert.AreEqual(2, duplicate.Cells.Count);
+            Assert.IsTrue(duplicate.Cells.All(cell => !cell.IsRevealed));
+            Assert.IsTrue(duplicate.Cells.All(cell => cell.RevealedAt == null));
+            Assert.AreEqual("A", duplicate.Cells[0].Title);
+            Assert.AreEqual("B", duplicate.Cells[1].Title);
+        }
+
         // ── Poke Logic ────────────────────────────────────────────────────────
 
         [TestMethod]

--- a/tests/EasyLotteryDomainTests/Services/RouletteServiceTests.cs
+++ b/tests/EasyLotteryDomainTests/Services/RouletteServiceTests.cs
@@ -100,6 +100,56 @@ namespace EasyLotteryDomainTests.Services
             Assert.IsNull(loaded);
         }
 
+        [TestMethod]
+        public async Task DuplicateTemplate_CreatesEditableCopy()
+        {
+            var svc = new RouletteService(new InMemoryEasyLotteryConfigStore());
+
+            var template = new RouletteTemplate
+            {
+                Name = "Original",
+                Description = "Base wheel",
+                SegmentCount = 4,
+                SpinDurationSec = 7.5,
+                EasingFunction = "ease-in-out",
+                InitialAngleDeg = 15,
+                CenterImageUrl = "/center.png",
+                BackgroundImageUrl = "/bg.png",
+                PointerImageUrl = "/pointer.png",
+                SpinSoundUrl = "/spin.mp3",
+                WinSoundUrl = "/win.mp3",
+                Segments = new List<RouletteSegment>
+                {
+                    new RouletteSegment { Index = 0, Title = "A", ImageUrl = "/a.png", Color = "#111111", Probability = 10 },
+                    new RouletteSegment { Index = 1, Title = "B", ImageUrl = "/b.png", Color = "#222222", Probability = 20 }
+                }
+            };
+            var created = await svc.CreateTemplateAsync(template);
+
+            var duplicate = await svc.DuplicateTemplateAsync(created.Id);
+            var loaded = await svc.LoadTemplateAsync(duplicate.Id);
+
+            Assert.IsNotNull(loaded);
+            Assert.AreNotEqual(created.Id, duplicate.Id);
+            Assert.AreEqual("Original - 複製", duplicate.Name);
+            Assert.IsFalse(duplicate.IsBuiltIn);
+            Assert.AreEqual(template.Description, duplicate.Description);
+            Assert.AreEqual(template.SegmentCount, duplicate.SegmentCount);
+            Assert.AreEqual(template.SpinDurationSec, duplicate.SpinDurationSec);
+            Assert.AreEqual(template.EasingFunction, duplicate.EasingFunction);
+            Assert.AreEqual(template.InitialAngleDeg, duplicate.InitialAngleDeg);
+            Assert.AreEqual(template.CenterImageUrl, duplicate.CenterImageUrl);
+            Assert.AreEqual(template.BackgroundImageUrl, duplicate.BackgroundImageUrl);
+            Assert.AreEqual(template.PointerImageUrl, duplicate.PointerImageUrl);
+            Assert.AreEqual(template.SpinSoundUrl, duplicate.SpinSoundUrl);
+            Assert.AreEqual(template.WinSoundUrl, duplicate.WinSoundUrl);
+            Assert.AreEqual(2, duplicate.Segments.Count);
+            Assert.AreEqual("A", duplicate.Segments[0].Title);
+            Assert.AreEqual("B", duplicate.Segments[1].Title);
+            Assert.AreEqual(10, duplicate.Segments[0].Probability);
+            Assert.AreEqual(20, duplicate.Segments[1].Probability);
+        }
+
         // ── Spin Algorithm ────────────────────────────────────────────────────
 
         [TestMethod]


### PR DESCRIPTION
Closes #22\n\nAdds duplicate actions to Poke Box and Roulette template lists, with domain-level copy helpers and tests.