### PR TITLE
feat: add youtube chat moderation controls

### DIFF
--- a/src/EasyLotteryDomain/Models/Pages/ChatRoomCatch.cs
+++ b/src/EasyLotteryDomain/Models/Pages/ChatRoomCatch.cs
@@ -16,7 +16,106 @@ namespace EasyLotteryDomain.Models.Pages
         [Required (ErrorMessage = "通關密語")]
         public string KeyWord { get; set; } = "";
 
+        public string WhiteList { get; set; } = "";
+
+        public string BlackList { get; set; } = "";
+
+        [Range(0, 86400, ErrorMessage = "同帳號冷卻需為 0 或以上的秒數")]
+        public int CooldownSeconds { get; set; } = 0;
+
         public DateTimeOffset LastMessageTime { get; set; } = DateTimeOffset.Now;
-       
+
+        public IReadOnlyList<string> GetKeywordTokens() => SplitRuleList(KeyWord);
+
+        public IReadOnlyList<string> GetWhiteListTokens() => SplitRuleList(WhiteList);
+
+        public IReadOnlyList<string> GetBlackListTokens() => SplitRuleList(BlackList);
+
+        public bool MatchesKeyword(string? messageText)
+        {
+            if (string.IsNullOrWhiteSpace(messageText))
+            {
+                return false;
+            }
+
+            var tokens = GetKeywordTokens();
+            if (tokens.Count == 0)
+            {
+                return false;
+            }
+
+            return tokens.Any(token =>
+                messageText.Contains(token, StringComparison.OrdinalIgnoreCase));
+        }
+
+        public bool IsMessageAllowed(
+            string? authorName,
+            string? messageText,
+            DateTimeOffset publishedAt,
+            IReadOnlyDictionary<string, DateTimeOffset> lastAcceptedMessageTimes,
+            out string reason)
+        {
+            reason = "";
+
+            var normalizedAuthor = Normalize(authorName);
+            if (string.IsNullOrWhiteSpace(normalizedAuthor))
+            {
+                reason = "找不到作者名稱";
+                return false;
+            }
+
+            if (!MatchesKeyword(messageText))
+            {
+                reason = "未符合關鍵字";
+                return false;
+            }
+
+            var blackList = new HashSet<string>(GetBlackListTokens(), StringComparer.OrdinalIgnoreCase);
+            if (blackList.Contains(normalizedAuthor))
+            {
+                reason = "命中黑名單";
+                return false;
+            }
+
+            var whiteList = GetWhiteListTokens();
+            if (whiteList.Count > 0 &&
+                !whiteList.Contains(normalizedAuthor, StringComparer.OrdinalIgnoreCase))
+            {
+                reason = "不在白名單";
+                return false;
+            }
+
+            if (CooldownSeconds > 0 &&
+                lastAcceptedMessageTimes.TryGetValue(normalizedAuthor, out var lastAcceptedAt))
+            {
+                var elapsed = publishedAt - lastAcceptedAt;
+                if (elapsed < TimeSpan.FromSeconds(CooldownSeconds))
+                {
+                    reason = "同帳號冷卻中";
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static IReadOnlyList<string> SplitRuleList(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return Array.Empty<string>();
+            }
+
+            return value
+                .Split(new[] { '\r', '\n', ',', ';', '|' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Where(token => !string.IsNullOrWhiteSpace(token))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+
+        private static string Normalize(string? value)
+        {
+            return value?.Trim() ?? string.Empty;
+        }
     }
 }

--- a/src/EasyLotteryWasm/Pages/Home.razor
+++ b/src/EasyLotteryWasm/Pages/Home.razor
@@ -121,12 +121,29 @@
                             </TextInput>
                         </Validation>
                         <Validation>
-                            <TextInput @bind-Value="@chatRoomCatch.KeyWord" Placeholder="請輸入通關密語" Disabled="@catchChat" >
+                            <TextInput @bind-Value="@chatRoomCatch.KeyWord" Placeholder="請輸入通關密語，可用逗號或換行分隔多組" Disabled="@catchChat" >
                                 <Feedback>
                                     <ValidationError />
                                 </Feedback>
                             </TextInput>
                         </Validation>
+                        <div class="mt-3">
+                            <div class="mb-1">白名單</div>
+                            <MemoInput @bind-Value="@chatRoomCatch.WhiteList" Rows="2" Placeholder="可輸入帳號名稱，逗號或換行分隔；留空表示全部允許" Disabled="@catchChat" />
+                        </div>
+                        <div class="mt-3">
+                            <div class="mb-1">黑名單</div>
+                            <MemoInput @bind-Value="@chatRoomCatch.BlackList" Rows="2" Placeholder="可輸入帳號名稱，逗號或換行分隔" Disabled="@catchChat" />
+                        </div>
+                        <div class="mt-3">
+                            <div class="mb-1">同帳號冷卻秒數</div>
+                            <Validation>
+                                <NumericInput TValue="int" @bind-Value="@chatRoomCatch.CooldownSeconds" Min="0" Max="86400" Disabled="@catchChat" />
+                                <Feedback>
+                                    <ValidationError />
+                                </Feedback>
+                            </Validation>
+                        </div>
                     </FieldBody>
                     <FieldBody ColumnSize="ColumnSize.Is2">
                         <Switch TValue="bool" Value="@catchChat" ValueChanged="@OnCatchChatChanged">
@@ -303,6 +320,7 @@
 
     private ChatRoomCatch chatRoomCatch = new ChatRoomCatch();
     private bool catchChat = false;
+    private Dictionary<string, DateTimeOffset> lastAcceptedMessageTimes = new(StringComparer.OrdinalIgnoreCase);
 
     private string toastMessage = "";
 
@@ -549,6 +567,7 @@
 
         // 重設最後訊息時間
         chatRoomCatch.LastMessageTime = DateTime.Now;
+        lastAcceptedMessageTimes.Clear();
         timer = new Timer(5000); // 設置每 5 秒觸發一次
         timer.Elapsed += OnTimerTick;
         timer.Start();
@@ -563,6 +582,7 @@
             timer.Stop();
             timer.Dispose();
         }
+        lastAcceptedMessageTimes.Clear();
     }
 
     // 每次 Timer 觸發時顯示訊息
@@ -572,27 +592,56 @@
         {
             Log.Information("DisplayMessage");
             var chatMessages = await youTubeServiceHelper.ListLiveChatMessageAsync(chatRoomCatch.ID);
-            var messages = chatMessages.Where(x => x.Snippet.PublishedAtDateTimeOffset > chatRoomCatch.LastMessageTime)
-                                        .Where(x => x.Snippet.DisplayMessage.Contains(chatRoomCatch.KeyWord))
-                                        .OrderByDescending(x => x.Snippet.PublishedAtDateTimeOffset).ToList();
+            var messages = chatMessages
+                .Where(x => (x.Snippet.PublishedAtDateTimeOffset ?? DateTimeOffset.MinValue) > chatRoomCatch.LastMessageTime)
+                .OrderBy(x => x.Snippet.PublishedAtDateTimeOffset ?? DateTimeOffset.MinValue)
+                .ToList();
 
             if(!messages.Any())
             {
                 toastMessage = "無訊息";
+                toastVisible = true;
+                StateHasChanged();
+                return;
             }
-            
+
+            var latestSeenTime = chatRoomCatch.LastMessageTime;
+            var acceptedCount = 0;
+
             foreach (var message in messages)
             {
-                Log.Information($"PublishedAtDateTimeOffset: { message.Snippet.PublishedAtDateTimeOffset}");
-                Log.Information($"lastMessageTime: { chatRoomCatch.LastMessageTime}");
-                toastMessage = $"{message.AuthorDetails.DisplayName}:{ message.Snippet.DisplayMessage}";
-                chatRoomCatch.LastMessageTime = message.Snippet.PublishedAtDateTimeOffset ?? chatRoomCatch.LastMessageTime;
-                if (!Participants.Any(x => x.Name == message.AuthorDetails.DisplayName)){
-                    Participants.Add(new Participant { Name = message.AuthorDetails.DisplayName, Level = "", IsWinner = false });
+                var publishedAt = message.Snippet.PublishedAtDateTimeOffset ?? latestSeenTime;
+                if (publishedAt > latestSeenTime)
+                {
+                    latestSeenTime = publishedAt;
+                }
+
+                var authorName = message.AuthorDetails?.DisplayName ?? "";
+                var displayMessage = message.Snippet?.DisplayMessage ?? "";
+
+                if (!chatRoomCatch.IsMessageAllowed(authorName, displayMessage, publishedAt, lastAcceptedMessageTimes, out var reason))
+                {
+                    Log.Information("Skip chat message from {Author}: {Reason}", authorName, reason);
+                    continue;
+                }
+
+                toastMessage = $"{authorName}:{displayMessage}";
+                lastAcceptedMessageTimes[authorName] = publishedAt;
+                acceptedCount++;
+
+                if (!Participants.Any(x => x.Name == authorName))
+                {
+                    Participants.Add(new Participant { Name = authorName, Level = "", IsWinner = false });
                 }
             }
-           
-            toastVisible = true; 
+
+            chatRoomCatch.LastMessageTime = latestSeenTime;
+            if (acceptedCount == 0)
+            {
+                toastMessage = "沒有符合規則的訊息";
+            }
+
+            toastVisible = true;
             StateHasChanged(); // 更新 UI
         });
     }

--- a/tests/EasyLotteryDomainTests/Models/ChatRoomCatchTest.cs
+++ b/tests/EasyLotteryDomainTests/Models/ChatRoomCatchTest.cs
@@ -21,6 +21,9 @@ namespace EasyLotteryDomainTests.Models
             Assert.AreEqual("", model.ID);
             Assert.AreEqual("", model.YoutubeUrl);
             Assert.AreEqual("", model.KeyWord);
+            Assert.AreEqual("", model.WhiteList);
+            Assert.AreEqual("", model.BlackList);
+            Assert.AreEqual(0, model.CooldownSeconds);
             Assert.IsTrue(model.LastMessageTime <= DateTimeOffset.Now);
         }
 
@@ -79,6 +82,92 @@ namespace EasyLotteryDomainTests.Models
             Assert.AreEqual("https://www.youtube.com/live/abc", model.YoutubeUrl);
             Assert.AreEqual("抽獎", model.KeyWord);
             Assert.AreEqual(now, model.LastMessageTime);
+        }
+
+        [TestMethod]
+        public void Moderation_AllowsMatchingWhitelistAndKeyword()
+        {
+            var model = new ChatRoomCatch
+            {
+                KeyWord = "抽獎",
+                WhiteList = "Alice,Bob",
+                BlackList = "Eve",
+                CooldownSeconds = 30
+            };
+
+            var previous = new Dictionary<string, DateTimeOffset>
+            {
+                { "Alice", DateTimeOffset.UtcNow.AddMinutes(-1) }
+            };
+
+            var allowed = model.IsMessageAllowed("Alice", "我想抽獎", DateTimeOffset.UtcNow, previous, out var reason);
+
+            Assert.IsTrue(allowed);
+            Assert.AreEqual("", reason);
+        }
+
+        [TestMethod]
+        public void Moderation_RejectsNonWhitelistedUser()
+        {
+            var model = new ChatRoomCatch
+            {
+                KeyWord = "抽獎",
+                WhiteList = "Alice,Bob"
+            };
+
+            var allowed = model.IsMessageAllowed("Charlie", "我想抽獎", DateTimeOffset.UtcNow, new Dictionary<string, DateTimeOffset>(), out var reason);
+
+            Assert.IsFalse(allowed);
+            Assert.AreEqual("不在白名單", reason);
+        }
+
+        [TestMethod]
+        public void Moderation_RejectsBlacklistedUser()
+        {
+            var model = new ChatRoomCatch
+            {
+                KeyWord = "抽獎",
+                BlackList = "Eve"
+            };
+
+            var allowed = model.IsMessageAllowed("Eve", "我要抽獎", DateTimeOffset.UtcNow, new Dictionary<string, DateTimeOffset>(), out var reason);
+
+            Assert.IsFalse(allowed);
+            Assert.AreEqual("命中黑名單", reason);
+        }
+
+        [TestMethod]
+        public void Moderation_RejectsWithinCooldown()
+        {
+            var model = new ChatRoomCatch
+            {
+                KeyWord = "抽獎",
+                CooldownSeconds = 60
+            };
+
+            var previous = new Dictionary<string, DateTimeOffset>
+            {
+                { "Alice", DateTimeOffset.UtcNow.AddSeconds(-10) }
+            };
+
+            var allowed = model.IsMessageAllowed("Alice", "我要抽獎", DateTimeOffset.UtcNow, previous, out var reason);
+
+            Assert.IsFalse(allowed);
+            Assert.AreEqual("同帳號冷卻中", reason);
+        }
+
+        [TestMethod]
+        public void KeywordMatching_SupportsMultipleRules()
+        {
+            var model = new ChatRoomCatch
+            {
+                KeyWord = "抽獎,抽我,得獎"
+            };
+
+            Assert.IsTrue(model.MatchesKeyword("我要抽獎"));
+            Assert.IsTrue(model.MatchesKeyword("請抽我"));
+            Assert.IsTrue(model.MatchesKeyword("恭喜得獎"));
+            Assert.IsFalse(model.MatchesKeyword("只是路過"));
         }
     }
 }


### PR DESCRIPTION
Closes #27\n\nAdds whitelist, blacklist, and same-account cooldown controls to the existing YouTube chat capture flow on the home page, with model-level moderation helpers and tests.