### PR TITLE
feat: add draft and published template status

### DIFF
--- a/src/EasyLotteryDomain/Models/Entities/PokeBox.cs
+++ b/src/EasyLotteryDomain/Models/Entities/PokeBox.cs
@@ -57,6 +57,8 @@ namespace EasyLotteryDomain.Models.Entities
 
         public bool IsBuiltIn { get; set; } = false;
 
+        public TemplatePublicationStatus PublicationStatus { get; set; } = TemplatePublicationStatus.Published;
+
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
         public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;

--- a/src/EasyLotteryDomain/Models/Entities/Roulette.cs
+++ b/src/EasyLotteryDomain/Models/Entities/Roulette.cs
@@ -39,6 +39,8 @@ namespace EasyLotteryDomain.Models.Entities
 
         public bool IsBuiltIn { get; set; } = false;
 
+        public TemplatePublicationStatus PublicationStatus { get; set; } = TemplatePublicationStatus.Published;
+
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
         public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;

--- a/src/EasyLotteryDomain/Models/Entities/TemplatePublicationStatus.cs
+++ b/src/EasyLotteryDomain/Models/Entities/TemplatePublicationStatus.cs
@@ -1,0 +1,8 @@
+namespace EasyLotteryDomain.Models.Entities
+{
+    public enum TemplatePublicationStatus
+    {
+        Published = 0,
+        Draft = 1
+    }
+}

--- a/src/EasyLotteryDomain/Services/PokeService.cs
+++ b/src/EasyLotteryDomain/Services/PokeService.cs
@@ -83,6 +83,7 @@ namespace EasyLotteryDomain.Services
                 PokeSoundUrl = source.PokeSoundUrl,
                 OpenSoundUrl = source.OpenSoundUrl,
                 IsBuiltIn = false,
+                PublicationStatus = TemplatePublicationStatus.Draft,
                 Cells = source.Cells
                     .OrderBy(cell => cell.Index)
                     .Select(cell => new PokeCell
@@ -106,7 +107,8 @@ namespace EasyLotteryDomain.Services
         {
             var document = await LoadDocumentAsync(ensureBuiltIns: true);
             return document.PokeTemplates
-                .OrderByDescending(t => t.UpdatedAt)
+                .OrderBy(t => t.PublicationStatus)
+                .ThenByDescending(t => t.UpdatedAt)
                 .ToList();
         }
 
@@ -115,6 +117,18 @@ namespace EasyLotteryDomain.Services
             var document = await LoadDocumentAsync(ensureBuiltIns: true);
             return document.PokeTemplates
                 .FirstOrDefault(t => t.Id == id);
+        }
+
+        public async Task<PokeTemplate> SetPublicationStatusAsync(int id, TemplatePublicationStatus status)
+        {
+            var document = await _configStore.LoadAsync();
+            var template = document.PokeTemplates.FirstOrDefault(t => t.Id == id)
+                ?? throw new InvalidOperationException($"Template {id} not found.");
+
+            template.PublicationStatus = status;
+            template.UpdatedAt = DateTime.UtcNow;
+            await _configStore.SaveAsync(document);
+            return template;
         }
 
         // ── Poke Logic ────────────────────────────────────────────────────────
@@ -208,6 +222,7 @@ namespace EasyLotteryDomain.Services
             // Reset IDs so EF treats them as new records
             template.Id = 0;
             template.IsBuiltIn = false;
+            template.PublicationStatus = TemplatePublicationStatus.Draft;
             foreach (var cell in template.Cells)
             {
                 cell.Id = 0;
@@ -333,6 +348,7 @@ namespace EasyLotteryDomain.Services
                 Mode = PokeMode.Random,
                 Animation = PokeAnimation.Burst,
                 IsBuiltIn = true,
+                PublicationStatus = TemplatePublicationStatus.Published,
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow,
             };
@@ -351,6 +367,7 @@ namespace EasyLotteryDomain.Services
                 Mode = PokeMode.Random,
                 Animation = PokeAnimation.Bounce,
                 IsBuiltIn = true,
+                PublicationStatus = TemplatePublicationStatus.Published,
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow,
             };
@@ -369,6 +386,7 @@ namespace EasyLotteryDomain.Services
                 Mode = PokeMode.Random,
                 Animation = PokeAnimation.Flash,
                 IsBuiltIn = true,
+                PublicationStatus = TemplatePublicationStatus.Published,
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow,
             };

--- a/src/EasyLotteryDomain/Services/RouletteService.cs
+++ b/src/EasyLotteryDomain/Services/RouletteService.cs
@@ -82,6 +82,7 @@ namespace EasyLotteryDomain.Services
                 SpinSoundUrl = source.SpinSoundUrl,
                 WinSoundUrl = source.WinSoundUrl,
                 IsBuiltIn = false,
+                PublicationStatus = TemplatePublicationStatus.Draft,
                 Segments = source.Segments
                     .OrderBy(segment => segment.Index)
                     .Select(segment => new RouletteSegment
@@ -102,7 +103,8 @@ namespace EasyLotteryDomain.Services
         {
             var document = await LoadDocumentAsync(ensureBuiltIns: true);
             return document.RouletteTemplates
-                .OrderByDescending(t => t.UpdatedAt)
+                .OrderBy(t => t.PublicationStatus)
+                .ThenByDescending(t => t.UpdatedAt)
                 .ToList();
         }
 
@@ -111,6 +113,18 @@ namespace EasyLotteryDomain.Services
             var document = await LoadDocumentAsync(ensureBuiltIns: true);
             return document.RouletteTemplates
                 .FirstOrDefault(t => t.Id == id);
+        }
+
+        public async Task<RouletteTemplate> SetPublicationStatusAsync(int id, TemplatePublicationStatus status)
+        {
+            var document = await _configStore.LoadAsync();
+            var template = document.RouletteTemplates.FirstOrDefault(t => t.Id == id)
+                ?? throw new InvalidOperationException($"Template {id} not found.");
+
+            template.PublicationStatus = status;
+            template.UpdatedAt = DateTime.UtcNow;
+            await _configStore.SaveAsync(document);
+            return template;
         }
 
         // ── Spin Algorithm ────────────────────────────────────────────────────
@@ -214,6 +228,7 @@ namespace EasyLotteryDomain.Services
 
             template.Id = 0;
             template.IsBuiltIn = false;
+            template.PublicationStatus = TemplatePublicationStatus.Draft;
             foreach (var seg in template.Segments)
             {
                 seg.Id = 0;
@@ -328,6 +343,7 @@ namespace EasyLotteryDomain.Services
                 SpinDurationSec = 5.0,
                 EasingFunction = "ease-out-cubic",
                 IsBuiltIn = true,
+                PublicationStatus = TemplatePublicationStatus.Published,
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow,
             };
@@ -347,6 +363,7 @@ namespace EasyLotteryDomain.Services
                 SpinDurationSec = 4.0,
                 EasingFunction = "ease-out-cubic",
                 IsBuiltIn = true,
+                PublicationStatus = TemplatePublicationStatus.Published,
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow,
             };
@@ -365,6 +382,7 @@ namespace EasyLotteryDomain.Services
                 SpinDurationSec = 6.0,
                 EasingFunction = "ease-out-cubic",
                 IsBuiltIn = true,
+                PublicationStatus = TemplatePublicationStatus.Published,
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow,
             };

--- a/src/EasyLotteryWasm/Pages/PokeBox/PokeBox.razor
+++ b/src/EasyLotteryWasm/Pages/PokeBox/PokeBox.razor
@@ -30,6 +30,7 @@ else
             <TableRow>
                 <TableHeaderCell>名稱</TableHeaderCell>
                 <TableHeaderCell>說明</TableHeaderCell>
+                <TableHeaderCell>狀態</TableHeaderCell>
                 <TableHeaderCell>格數</TableHeaderCell>
                 <TableHeaderCell>模式</TableHeaderCell>
                 <TableHeaderCell>動畫</TableHeaderCell>
@@ -42,6 +43,11 @@ else
                 <TableRow>
                     <TableRowCell>@t.Name @(t.IsBuiltIn ? "🔒" : "")</TableRowCell>
                     <TableRowCell>@t.Description</TableRowCell>
+                    <TableRowCell>
+                        <Badge Color="@(t.PublicationStatus == TemplatePublicationStatus.Draft ? Color.Warning : Color.Success)">
+                            @(t.PublicationStatus == TemplatePublicationStatus.Draft ? "草稿" : "已發布")
+                        </Badge>
+                    </TableRowCell>
                     <TableRowCell>@t.GridRows × @t.GridColumns</TableRowCell>
                     <TableRowCell>@(t.Mode == PokeMode.Random ? "隨機" : "手動")</TableRowCell>
                     <TableRowCell>@t.Animation</TableRowCell>
@@ -49,6 +55,9 @@ else
                         <div class="d-flex gap-1">
                             <Button Size="Size.Small" Color="Color.Success" Clicked="@(() => NavigateToPreview(t.Id))">預覽</Button>
                             <Button Size="Size.Small" Color="Color.Warning" Clicked="@(() => NavigateToEditor(t.Id))">編輯</Button>
+                            <Button Size="Size.Small" Color="@(t.PublicationStatus == TemplatePublicationStatus.Draft ? Color.Success : Color.Secondary)" Clicked="@(() => TogglePublicationStatus(t))">
+                                @(t.PublicationStatus == TemplatePublicationStatus.Draft ? "發布" : "轉草稿")
+                            </Button>
                             <Button Size="Size.Small" Color="Color.Primary" Clicked="@(() => DuplicateTemplate(t.Id))">複製</Button>
                             <Button Size="Size.Small" Color="Color.Info" Clicked="@(() => ExportTemplate(t.Id))">匯出</Button>
                             @if (!t.IsBuiltIn)
@@ -127,6 +136,17 @@ else
         await LoadTemplates();
         NavigationManager.NavigateTo($"/pokebox/editor/{duplicate.Id}");
         await MessageService.Success($"已建立複本「{duplicate.Name}」。");
+    }
+
+    private async Task TogglePublicationStatus(PokeTemplate template)
+    {
+        var nextStatus = template.PublicationStatus == TemplatePublicationStatus.Draft
+            ? TemplatePublicationStatus.Published
+            : TemplatePublicationStatus.Draft;
+
+        await PokeService.SetPublicationStatusAsync(template.Id, nextStatus);
+        await LoadTemplates();
+        await MessageService.Success(nextStatus == TemplatePublicationStatus.Published ? "已發布模板。" : "已轉為草稿。");
     }
 
     private async Task ExportTemplate(int id)

--- a/src/EasyLotteryWasm/Pages/PokeBox/PokeBoxEditor.razor
+++ b/src/EasyLotteryWasm/Pages/PokeBox/PokeBoxEditor.razor
@@ -83,9 +83,15 @@ else
             </Card>
 
             <div class="mt-3 d-flex gap-2">
-                <Button Color="Color.Primary" Clicked="@Save">儲存</Button>
+                <Button Color="Color.Primary" Clicked="@SaveDraft">儲存草稿</Button>
+                <Button Color="Color.Success" Clicked="@Publish">發布</Button>
                 <Button Color="Color.Secondary" Clicked="@ApplyGrid">套用格數（重設格子）</Button>
                 <Button Color="Color.Light" Clicked="@GoBack">返回</Button>
+            </div>
+            <div class="mt-2">
+                <Badge Color="@(template.PublicationStatus == TemplatePublicationStatus.Draft ? Color.Warning : Color.Success)">
+                    @(template.PublicationStatus == TemplatePublicationStatus.Draft ? "目前為草稿" : "目前已發布")
+                </Badge>
             </div>
         </div>
 
@@ -133,7 +139,10 @@ else
     {
         if (Id == 0)
         {
-            template = new PokeTemplate();
+            template = new PokeTemplate
+            {
+                PublicationStatus = TemplatePublicationStatus.Draft
+            };
             ApplyGridToTemplate();
         }
         else
@@ -178,6 +187,20 @@ else
                 .Take(total)
                 .ToList();
         }
+    }
+
+    private async Task SaveDraft()
+    {
+        if (template == null) return;
+        template.PublicationStatus = TemplatePublicationStatus.Draft;
+        await Save();
+    }
+
+    private async Task Publish()
+    {
+        if (template == null) return;
+        template.PublicationStatus = TemplatePublicationStatus.Published;
+        await Save();
     }
 
     private async Task Save()

--- a/src/EasyLotteryWasm/Pages/Roulette/Roulette.razor
+++ b/src/EasyLotteryWasm/Pages/Roulette/Roulette.razor
@@ -30,6 +30,7 @@ else
             <TableRow>
                 <TableHeaderCell>名稱</TableHeaderCell>
                 <TableHeaderCell>說明</TableHeaderCell>
+                <TableHeaderCell>狀態</TableHeaderCell>
                 <TableHeaderCell>格數</TableHeaderCell>
                 <TableHeaderCell>旋轉時間</TableHeaderCell>
                 <TableHeaderCell>Easing</TableHeaderCell>
@@ -42,6 +43,11 @@ else
                 <TableRow>
                     <TableRowCell>@t.Name @(t.IsBuiltIn ? "🔒" : "")</TableRowCell>
                     <TableRowCell>@t.Description</TableRowCell>
+                    <TableRowCell>
+                        <Badge Color="@(t.PublicationStatus == TemplatePublicationStatus.Draft ? Color.Warning : Color.Success)">
+                            @(t.PublicationStatus == TemplatePublicationStatus.Draft ? "草稿" : "已發布")
+                        </Badge>
+                    </TableRowCell>
                     <TableRowCell>@t.SegmentCount</TableRowCell>
                     <TableRowCell>@t.SpinDurationSec 秒</TableRowCell>
                     <TableRowCell>@t.EasingFunction</TableRowCell>
@@ -49,6 +55,9 @@ else
                         <div class="d-flex gap-1">
                             <Button Size="Size.Small" Color="Color.Success" Clicked="@(() => NavigateToPreview(t.Id))">預覽</Button>
                             <Button Size="Size.Small" Color="Color.Warning" Clicked="@(() => NavigateToEditor(t.Id))">編輯</Button>
+                            <Button Size="Size.Small" Color="@(t.PublicationStatus == TemplatePublicationStatus.Draft ? Color.Success : Color.Secondary)" Clicked="@(() => TogglePublicationStatus(t))">
+                                @(t.PublicationStatus == TemplatePublicationStatus.Draft ? "發布" : "轉草稿")
+                            </Button>
                             <Button Size="Size.Small" Color="Color.Primary" Clicked="@(() => DuplicateTemplate(t.Id))">複製</Button>
                             <Button Size="Size.Small" Color="Color.Info" Clicked="@(() => ExportTemplate(t.Id))">匯出</Button>
                             @if (!t.IsBuiltIn)
@@ -127,6 +136,17 @@ else
         await LoadTemplates();
         NavigationManager.NavigateTo($"/roulette/editor/{duplicate.Id}");
         await MessageService.Success($"已建立複本「{duplicate.Name}」。");
+    }
+
+    private async Task TogglePublicationStatus(RouletteTemplate template)
+    {
+        var nextStatus = template.PublicationStatus == TemplatePublicationStatus.Draft
+            ? TemplatePublicationStatus.Published
+            : TemplatePublicationStatus.Draft;
+
+        await RouletteService.SetPublicationStatusAsync(template.Id, nextStatus);
+        await LoadTemplates();
+        await MessageService.Success(nextStatus == TemplatePublicationStatus.Published ? "已發布模板。" : "已轉為草稿。");
     }
 
     private async Task ExportTemplate(int id)

--- a/src/EasyLotteryWasm/Pages/Roulette/RouletteEditor.razor
+++ b/src/EasyLotteryWasm/Pages/Roulette/RouletteEditor.razor
@@ -81,9 +81,15 @@ else
             </Card>
 
             <div class="mt-3 d-flex gap-2">
-                <Button Color="Color.Primary" Clicked="@Save">儲存</Button>
+                <Button Color="Color.Primary" Clicked="@SaveDraft">儲存草稿</Button>
+                <Button Color="Color.Success" Clicked="@Publish">發布</Button>
                 <Button Color="Color.Secondary" Clicked="@ApplySegmentCount">套用格數（重設格子）</Button>
                 <Button Color="Color.Light" Clicked="@GoBack">返回</Button>
+            </div>
+            <div class="mt-2">
+                <Badge Color="@(template.PublicationStatus == TemplatePublicationStatus.Draft ? Color.Warning : Color.Success)">
+                    @(template.PublicationStatus == TemplatePublicationStatus.Draft ? "目前為草稿" : "目前已發布")
+                </Badge>
             </div>
         </div>
 
@@ -141,7 +147,10 @@ else
     {
         if (Id == 0)
         {
-            template = new RouletteTemplate();
+            template = new RouletteTemplate
+            {
+                PublicationStatus = TemplatePublicationStatus.Draft
+            };
             ApplySegmentsToTemplate();
         }
         else
@@ -188,6 +197,20 @@ else
                 .Take(count)
                 .ToList();
         }
+    }
+
+    private async Task SaveDraft()
+    {
+        if (template == null) return;
+        template.PublicationStatus = TemplatePublicationStatus.Draft;
+        await Save();
+    }
+
+    private async Task Publish()
+    {
+        if (template == null) return;
+        template.PublicationStatus = TemplatePublicationStatus.Published;
+        await Save();
     }
 
     private async Task Save()

--- a/tests/EasyLotteryDomainTests/Services/PokeServiceTests.cs
+++ b/tests/EasyLotteryDomainTests/Services/PokeServiceTests.cs
@@ -119,6 +119,7 @@ namespace EasyLotteryDomainTests.Services
             Assert.AreNotEqual(created.Id, duplicate.Id);
             Assert.AreEqual("Original - 複製", duplicate.Name);
             Assert.IsFalse(duplicate.IsBuiltIn);
+            Assert.AreEqual(TemplatePublicationStatus.Draft, duplicate.PublicationStatus);
             Assert.AreEqual(template.Description, duplicate.Description);
             Assert.AreEqual(template.GridRows, duplicate.GridRows);
             Assert.AreEqual(template.GridColumns, duplicate.GridColumns);
@@ -137,6 +138,21 @@ namespace EasyLotteryDomainTests.Services
             Assert.IsTrue(duplicate.Cells.All(cell => cell.RevealedAt == null));
             Assert.AreEqual("A", duplicate.Cells[0].Title);
             Assert.AreEqual("B", duplicate.Cells[1].Title);
+        }
+
+        [TestMethod]
+        public async Task SetPublicationStatus_UpdatesTemplateStatus()
+        {
+            var svc = new PokeService(new InMemoryEasyLotteryConfigStore());
+
+            var created = await svc.CreateTemplateAsync(new PokeTemplate { Name = "Status" });
+
+            var updated = await svc.SetPublicationStatusAsync(created.Id, TemplatePublicationStatus.Draft);
+
+            Assert.AreEqual(TemplatePublicationStatus.Draft, updated.PublicationStatus);
+            var loaded = await svc.LoadTemplateAsync(created.Id);
+            Assert.IsNotNull(loaded);
+            Assert.AreEqual(TemplatePublicationStatus.Draft, loaded.PublicationStatus);
         }
 
         // ── Poke Logic ────────────────────────────────────────────────────────

--- a/tests/EasyLotteryDomainTests/Services/RouletteServiceTests.cs
+++ b/tests/EasyLotteryDomainTests/Services/RouletteServiceTests.cs
@@ -133,6 +133,7 @@ namespace EasyLotteryDomainTests.Services
             Assert.AreNotEqual(created.Id, duplicate.Id);
             Assert.AreEqual("Original - 複製", duplicate.Name);
             Assert.IsFalse(duplicate.IsBuiltIn);
+            Assert.AreEqual(TemplatePublicationStatus.Draft, duplicate.PublicationStatus);
             Assert.AreEqual(template.Description, duplicate.Description);
             Assert.AreEqual(template.SegmentCount, duplicate.SegmentCount);
             Assert.AreEqual(template.SpinDurationSec, duplicate.SpinDurationSec);
@@ -148,6 +149,21 @@ namespace EasyLotteryDomainTests.Services
             Assert.AreEqual("B", duplicate.Segments[1].Title);
             Assert.AreEqual(10, duplicate.Segments[0].Probability);
             Assert.AreEqual(20, duplicate.Segments[1].Probability);
+        }
+
+        [TestMethod]
+        public async Task SetPublicationStatus_UpdatesTemplateStatus()
+        {
+            var svc = new RouletteService(new InMemoryEasyLotteryConfigStore());
+
+            var created = await svc.CreateTemplateAsync(new RouletteTemplate { Name = "Status" });
+
+            var updated = await svc.SetPublicationStatusAsync(created.Id, TemplatePublicationStatus.Draft);
+
+            Assert.AreEqual(TemplatePublicationStatus.Draft, updated.PublicationStatus);
+            var loaded = await svc.LoadTemplateAsync(created.Id);
+            Assert.IsNotNull(loaded);
+            Assert.AreEqual(TemplatePublicationStatus.Draft, loaded.PublicationStatus);
         }
 
         // ── Spin Algorithm ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary\n- Add a publication status to Poke Box and Roulette templates\n- Allow templates to be saved as drafts and published later\n- Show draft/published badges in template lists and editors\n- Default new and duplicated/imported templates to draft for safer editing\n\n## Verification\n- dotnet test EasyLottery.generated.sln --configuration Release\n\n## Related\n- Closes #28