### PR TITLE
feat: add reusable drawing rule presets

### DIFF
--- a/src/EasyLotteryDomain/Models/Config/DrawingRulePreset.cs
+++ b/src/EasyLotteryDomain/Models/Config/DrawingRulePreset.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+
+namespace EasyLotteryDomain.Models.Config
+{
+    public sealed class DrawingRulePreset
+    {
+        public string Name { get; set; } = "";
+
+        public string Description { get; set; } = "";
+
+        public Dictionary<string, int> LevelRates { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/src/EasyLotteryDomain/Models/Config/EasyLotteryConfigDocument.cs
+++ b/src/EasyLotteryDomain/Models/Config/EasyLotteryConfigDocument.cs
@@ -15,6 +15,8 @@ namespace EasyLotteryDomain.Models.Config
         public List<RouletteTemplate> RouletteTemplates { get; set; } = new();
 
         public List<ActivityResultRecord> ActivityResults { get; set; } = new();
+
+        public List<DrawingRulePreset> DrawingRulePresets { get; set; } = new();
     }
 
     public sealed class LotterySystemSettings

--- a/src/EasyLotteryWasm/Pages/Home.razor
+++ b/src/EasyLotteryWasm/Pages/Home.razor
@@ -16,6 +16,7 @@
 @inject IMessageService MessageService
 @inject IJSRuntime JSRuntime
 @inject YouTubeServiceHelper youTubeServiceHelper
+@inject IEasyLotteryConfigStore ConfigStore
 @inject ILogger<YouTubeServiceHelper> Logger
 @implements IDisposable
 
@@ -199,6 +200,71 @@
 
 <Divider />
 
+<Card>
+    <CardBody>
+        <CardTitle>
+            <h2>抽獎規則模板</h2>
+        </CardTitle>
+        <Row>
+            <Column ColumnSize="ColumnSize.Is4">
+                <Field>
+                    <FieldLabel>模板名稱</FieldLabel>
+                    <TextInput @bind-Value="@rulePresetName" Placeholder="例如：VIP 兩倍、一般一倍" />
+                </Field>
+                <Field>
+                    <FieldLabel>說明</FieldLabel>
+                    <TextInput @bind-Value="@rulePresetDescription" Placeholder="規則說明" />
+                </Field>
+                <div class="d-flex gap-2 flex-wrap">
+                    <Button Color="Color.Primary" Clicked="@SaveCurrentRulePresetAsync">儲存目前規則</Button>
+                    <Button Color="Color.Success" Clicked="@ApplySelectedRulePresetAsync" Disabled="@string.IsNullOrWhiteSpace(selectedRulePresetName)">套用模板</Button>
+                </div>
+            </Column>
+            <Column ColumnSize="ColumnSize.Is8">
+                <Field>
+                    <FieldLabel>已儲存模板</FieldLabel>
+                    <Select TValue="string" @bind-SelectedValue="@selectedRulePresetName">
+                        @foreach (var preset in drawingRulePresets)
+                        {
+                            <SelectItem Value="@preset.Name">@preset.Name</SelectItem>
+                        }
+                    </Select>
+                </Field>
+                @if (drawingRulePresets.Any())
+                {
+                    <Table FullWidth Striped Hoverable Bordered Responsive>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHeaderCell>名稱</TableHeaderCell>
+                                <TableHeaderCell>說明</TableHeaderCell>
+                                <TableHeaderCell>倍率內容</TableHeaderCell>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            @foreach (var preset in drawingRulePresets)
+                            {
+                                <TableRow>
+                                    <TableRowCell>@preset.Name</TableRowCell>
+                                    <TableRowCell>@preset.Description</TableRowCell>
+                                    <TableRowCell>
+                                        @string.Join("、", preset.LevelRates.OrderBy(x => x.Key).Select(x => $"{x.Key}×{x.Value}"))
+                                    </TableRowCell>
+                                </TableRow>
+                            }
+                        </TableBody>
+                    </Table>
+                }
+                else
+                {
+                    <div class="text-muted">尚未建立任何規則模板。</div>
+                }
+            </Column>
+        </Row>
+    </CardBody>
+</Card>
+
+<Divider />
+
 @if (Participants.Where(o=> !string.IsNullOrWhiteSpace(o.Level)).Any())
 {
     <Card>
@@ -336,6 +402,8 @@
         if (await youTubeServiceHelper.HasRefreshTokenAsync()) {
             await youTubeServiceHelper.RefreshTokenAsync();
         }
+
+        await LoadRulePresetsAsync();
     }
 
     private async void OnAuthStateChanged()

--- a/src/EasyLotteryWasm/Pages/Home.razor.cs
+++ b/src/EasyLotteryWasm/Pages/Home.razor.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using EasyLotteryDomain.Models.Config;
 using EasyLotteryDomain.Models.Pages;
 using EasyLotteryWasm.Models;
 using MiniExcelLibs;
@@ -27,6 +28,10 @@ public partial class Home
     private string participantDataText = "";
     private string prizeDataFormat = "json";
     private string prizeDataText = "";
+    private List<DrawingRulePreset> drawingRulePresets = new();
+    private string selectedRulePresetName = "";
+    private string rulePresetName = "";
+    private string rulePresetDescription = "";
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -44,6 +49,74 @@ public partial class Home
         {
             levelRate[level] = 1;
         }
+    }
+
+    private async Task LoadRulePresetsAsync()
+    {
+        var document = await ConfigStore.LoadAsync();
+        drawingRulePresets = document.DrawingRulePresets
+            .OrderBy(preset => preset.Name)
+            .ToList();
+
+        if (string.IsNullOrWhiteSpace(selectedRulePresetName) && drawingRulePresets.Any())
+        {
+            selectedRulePresetName = drawingRulePresets[0].Name;
+        }
+    }
+
+    private async Task SaveCurrentRulePresetAsync()
+    {
+        if (string.IsNullOrWhiteSpace(rulePresetName))
+        {
+            await MessageService.Warning("請輸入規則模板名稱。");
+            return;
+        }
+
+        var document = await ConfigStore.LoadAsync();
+        var preset = new DrawingRulePreset
+        {
+            Name = rulePresetName.Trim(),
+            Description = rulePresetDescription.Trim(),
+            LevelRates = new Dictionary<string, int>(levelRate, StringComparer.OrdinalIgnoreCase)
+        };
+
+        var existingIndex = document.DrawingRulePresets.FindIndex(item => string.Equals(item.Name, preset.Name, StringComparison.OrdinalIgnoreCase));
+        if (existingIndex >= 0)
+        {
+            document.DrawingRulePresets[existingIndex] = preset;
+        }
+        else
+        {
+            document.DrawingRulePresets.Add(preset);
+        }
+
+        await ConfigStore.SaveAsync(document);
+        await LoadRulePresetsAsync();
+        selectedRulePresetName = preset.Name;
+        await MessageService.Success($"已儲存規則模板「{preset.Name}」。");
+    }
+
+    private async Task ApplySelectedRulePresetAsync()
+    {
+        if (string.IsNullOrWhiteSpace(selectedRulePresetName))
+        {
+            await MessageService.Warning("請先選擇規則模板。");
+            return;
+        }
+
+        var document = await ConfigStore.LoadAsync();
+        var preset = document.DrawingRulePresets
+            .FirstOrDefault(item => string.Equals(item.Name, selectedRulePresetName, StringComparison.OrdinalIgnoreCase));
+
+        if (preset == null)
+        {
+            await MessageService.Warning("找不到指定的規則模板。");
+            return;
+        }
+
+        levelRate = new Dictionary<string, int>(preset.LevelRates, StringComparer.OrdinalIgnoreCase);
+        LoadDrawPrize();
+        await MessageService.Success($"已套用規則模板「{preset.Name}」。");
     }
 
     private async Task ExportParticipantsAsync()

--- a/src/EasyLotteryWasm/Services/YamlEasyLotteryConfigStore.cs
+++ b/src/EasyLotteryWasm/Services/YamlEasyLotteryConfigStore.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using EasyLotteryDomain.Models.Config;
 using EasyLotteryDomain.Models.Entities;
@@ -133,6 +135,7 @@ namespace EasyLotteryWasm.Services
             document.PokeTemplates ??= new List<PokeTemplate>();
             document.RouletteTemplates ??= new List<RouletteTemplate>();
             document.ActivityResults ??= new List<ActivityResultRecord>();
+            document.DrawingRulePresets ??= new List<DrawingRulePreset>();
 
             foreach (var template in document.PokeTemplates)
             {
@@ -147,6 +150,11 @@ namespace EasyLotteryWasm.Services
             foreach (var activityResult in document.ActivityResults)
             {
                 NormalizeActivityResult(activityResult);
+            }
+
+            foreach (var preset in document.DrawingRulePresets)
+            {
+                NormalizeDrawingRulePreset(preset);
             }
 
             document.IdSequence.NextPokeTemplateId = Math.Max(document.IdSequence.NextPokeTemplateId, document.PokeTemplates.Select(t => t.Id).DefaultIfEmpty(0).Max() + 1);
@@ -239,6 +247,18 @@ namespace EasyLotteryWasm.Services
             }
 
             activityResult.Items = orderedItems;
+        }
+
+        private static void NormalizeDrawingRulePreset(DrawingRulePreset preset)
+        {
+            preset.Name ??= "";
+            preset.Description ??= "";
+            preset.LevelRates ??= new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var key in preset.LevelRates.Keys.ToList())
+            {
+                preset.LevelRates[key] = Math.Max(1, preset.LevelRates[key]);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary\n- Add reusable drawing rule presets stored in the shared EasyLottery config document\n- Allow saving the current participant multiplier rules as a preset\n- Allow applying a saved preset back to the home draw screen\n- Persist presets through the existing YAML/localStorage config bridge\n\n## Verification\n- dotnet test EasyLottery.generated.sln --configuration Release\n\n## Related\n- Closes #26