### PR TITLE
feat: add overtime overlay support

### DIFF
--- a/src/EasyLotteryAPI/Controllers/OvertimeController.cs
+++ b/src/EasyLotteryAPI/Controllers/OvertimeController.cs
@@ -1,0 +1,94 @@
+using EasyLotteryAPI.Services;
+using EasyLotteryDomain.Models.Overtime;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EasyLotteryAPI.Controllers
+{
+    public sealed class OvertimeSupportEventRequest
+    {
+        public OvertimeSupportSource Source { get; set; }
+
+        public string SourceLabel { get; set; } = "";
+
+        public string DisplayName { get; set; } = "";
+
+        public string Message { get; set; } = "";
+
+        public decimal? Amount { get; set; }
+
+        public string AmountDisplay { get; set; } = "";
+
+        public string Currency { get; set; } = "TWD";
+
+        public string AvatarUrl { get; set; } = "";
+
+        public string Color { get; set; } = "#ff85b4";
+
+        public string? ExternalId { get; set; }
+    }
+
+    [ApiController]
+    [Route("api/overtime")]
+    public class OvertimeController : ControllerBase
+    {
+        private readonly OvertimeFeedStore _store;
+
+        public OvertimeController(OvertimeFeedStore store)
+        {
+            _store = store;
+        }
+
+        [HttpGet("events")]
+        public ActionResult<IReadOnlyList<OvertimeSupportEvent>> GetEvents()
+        {
+            return Ok(_store.Snapshot());
+        }
+
+        [HttpPost("superchat")]
+        public ActionResult<OvertimeSupportEvent> PostSuperChat([FromBody] OvertimeSupportEventRequest request)
+        {
+            var entry = _store.Add(new OvertimeSupportEvent
+            {
+                Source = OvertimeSupportSource.SuperChat,
+                SourceLabel = string.IsNullOrWhiteSpace(request.SourceLabel) ? "YouTube SuperChat" : request.SourceLabel,
+                DisplayName = request.DisplayName,
+                Message = request.Message,
+                Amount = request.Amount,
+                AmountDisplay = request.AmountDisplay,
+                Currency = request.Currency,
+                AvatarUrl = request.AvatarUrl,
+                Color = request.Color,
+                ExternalId = request.ExternalId
+            });
+
+            return Ok(entry);
+        }
+
+        [HttpPost("ecpay")]
+        public ActionResult<OvertimeSupportEvent> PostEcpay([FromBody] OvertimeSupportEventRequest request)
+        {
+            var entry = _store.Add(new OvertimeSupportEvent
+            {
+                Source = OvertimeSupportSource.EcpayDonate,
+                SourceLabel = string.IsNullOrWhiteSpace(request.SourceLabel) ? "ECPay Donate" : request.SourceLabel,
+                DisplayName = request.DisplayName,
+                Message = request.Message,
+                Amount = request.Amount,
+                AmountDisplay = request.AmountDisplay,
+                Currency = request.Currency,
+                AvatarUrl = request.AvatarUrl,
+                Color = request.Color,
+                ExternalId = request.ExternalId
+            });
+
+            return Ok(entry);
+        }
+
+        [HttpDelete("events")]
+        public IActionResult Clear()
+        {
+            _store.Clear();
+            return NoContent();
+        }
+    }
+}

--- a/src/EasyLotteryAPI/EasyLotteryAPI.csproj
+++ b/src/EasyLotteryAPI/EasyLotteryAPI.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\EasyLotteryDomain\EasyLotteryDomain.csproj" />
     <PackageReference Include="Google.Apis.Youtube.v3" Version="1.73.0.4099" />
   </ItemGroup>
 

--- a/src/EasyLotteryAPI/Program.cs
+++ b/src/EasyLotteryAPI/Program.cs
@@ -5,6 +5,17 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddHttpContextAccessor();
 // 添加其他服務
 builder.Services.AddControllers();
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("EasyLotteryCors", policy =>
+    {
+        policy
+            .AllowAnyOrigin()
+            .AllowAnyHeader()
+            .AllowAnyMethod();
+    });
+});
+builder.Services.AddSingleton<OvertimeFeedStore>();
 
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
@@ -14,6 +25,7 @@ builder.Services.AddEndpointsApiExplorer();
 var app = builder.Build();
    app.UseAuthentication();
     app.UseRouting();
+app.UseCors("EasyLotteryCors");
     app.UseAuthorization();
 
 app.MapGet("/", () => Results.Content("""

--- a/src/EasyLotteryAPI/Services/OvertimeFeedStore.cs
+++ b/src/EasyLotteryAPI/Services/OvertimeFeedStore.cs
@@ -1,0 +1,59 @@
+using EasyLotteryDomain.Models.Overtime;
+
+namespace EasyLotteryAPI.Services
+{
+    public sealed class OvertimeFeedStore
+    {
+        private readonly object _gate = new();
+        private readonly List<OvertimeSupportEvent> _events = new();
+        private const int MaxEvents = 30;
+
+        public IReadOnlyList<OvertimeSupportEvent> Snapshot()
+        {
+            lock (_gate)
+            {
+                return _events
+                    .OrderByDescending(item => item.OccurredAtUtc)
+                    .ToList();
+            }
+        }
+
+        public OvertimeSupportEvent Add(OvertimeSupportEvent entry)
+        {
+            lock (_gate)
+            {
+                var normalized = Normalize(entry);
+                _events.Insert(0, normalized);
+                if (_events.Count > MaxEvents)
+                {
+                    _events.RemoveRange(MaxEvents, _events.Count - MaxEvents);
+                }
+
+                return normalized;
+            }
+        }
+
+        public void Clear()
+        {
+            lock (_gate)
+            {
+                _events.Clear();
+            }
+        }
+
+        private static OvertimeSupportEvent Normalize(OvertimeSupportEvent entry)
+        {
+            entry.Id = entry.Id == Guid.Empty ? Guid.NewGuid() : entry.Id;
+            entry.DisplayName = entry.DisplayName?.Trim() ?? "";
+            entry.Message = entry.Message?.Trim() ?? "";
+            entry.AmountDisplay = entry.AmountDisplay?.Trim() ?? "";
+            entry.Currency = string.IsNullOrWhiteSpace(entry.Currency) ? "TWD" : entry.Currency.Trim();
+            entry.SourceLabel = string.IsNullOrWhiteSpace(entry.SourceLabel) ? entry.Source.ToString() : entry.SourceLabel.Trim();
+            entry.Color = string.IsNullOrWhiteSpace(entry.Color) ? "#ff85b4" : entry.Color.Trim();
+            entry.AvatarUrl = entry.AvatarUrl?.Trim() ?? "";
+            entry.ExternalId = entry.ExternalId?.Trim();
+            entry.OccurredAtUtc = entry.OccurredAtUtc == default ? DateTimeOffset.UtcNow : entry.OccurredAtUtc;
+            return entry;
+        }
+    }
+}

--- a/src/EasyLotteryDomain/Models/Config/EasyLotteryConfigDocument.cs
+++ b/src/EasyLotteryDomain/Models/Config/EasyLotteryConfigDocument.cs
@@ -20,6 +20,7 @@ namespace EasyLotteryDomain.Models.Config
 
         public DrawingRuleSettings DrawingRules { get; set; } = new();
         public VisualStyleSettings VisualStyle { get; set; } = new();
+        public OvertimeOverlaySettings OvertimeOverlay { get; set; } = new();
     }
 
     public sealed class LotterySystemSettings

--- a/src/EasyLotteryDomain/Models/Config/OvertimeOverlaySettings.cs
+++ b/src/EasyLotteryDomain/Models/Config/OvertimeOverlaySettings.cs
@@ -1,0 +1,19 @@
+namespace EasyLotteryDomain.Models.Config
+{
+    public sealed class OvertimeOverlaySettings
+    {
+        public bool IsEnabled { get; set; } = false;
+
+        public string Title { get; set; } = "加班台";
+
+        public string Subtitle { get; set; } = "SuperChat / 綠界贊助";
+
+        public string ThemeKey { get; set; } = "festival-stage";
+
+        public int MaxVisibleItems { get; set; } = 8;
+
+        public bool ShowAmounts { get; set; } = true;
+
+        public bool ShowAvatars { get; set; } = true;
+    }
+}

--- a/src/EasyLotteryDomain/Models/Overtime/OvertimeSupportEvent.cs
+++ b/src/EasyLotteryDomain/Models/Overtime/OvertimeSupportEvent.cs
@@ -1,0 +1,36 @@
+namespace EasyLotteryDomain.Models.Overtime
+{
+    public enum OvertimeSupportSource
+    {
+        SuperChat = 1,
+        EcpayDonate = 2,
+        Manual = 3
+    }
+
+    public sealed class OvertimeSupportEvent
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+
+        public OvertimeSupportSource Source { get; set; }
+
+        public string SourceLabel { get; set; } = "";
+
+        public string DisplayName { get; set; } = "";
+
+        public string Message { get; set; } = "";
+
+        public decimal? Amount { get; set; }
+
+        public string AmountDisplay { get; set; } = "";
+
+        public string Currency { get; set; } = "TWD";
+
+        public string AvatarUrl { get; set; } = "";
+
+        public string Color { get; set; } = "#ff85b4";
+
+        public DateTimeOffset OccurredAtUtc { get; set; } = DateTimeOffset.UtcNow;
+
+        public string? ExternalId { get; set; }
+    }
+}

--- a/src/EasyLotteryWasm/Layout/NavMenu.razor
+++ b/src/EasyLotteryWasm/Layout/NavMenu.razor
@@ -64,6 +64,11 @@
                 </NavLink>
             </div>
             <div class="nav-item px-3 nav-sub-item">
+                <NavLink class="nav-link" href="system/overtime">
+                    加班台
+                </NavLink>
+            </div>
+            <div class="nav-item px-3 nav-sub-item">
                 <NavLink class="nav-link" href="system/youtube-login">
                     YouTube 登入
                 </NavLink>

--- a/src/EasyLotteryWasm/Models/OvertimeThemePreset.cs
+++ b/src/EasyLotteryWasm/Models/OvertimeThemePreset.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EasyLotteryWasm.Models
+{
+    public sealed record OvertimeThemePreset(
+        string Key,
+        string Name,
+        string Description,
+        string Emoji,
+        string BackgroundStart,
+        string BackgroundEnd,
+        string SurfaceColor,
+        string SurfaceBorderColor,
+        string AccentColor,
+        string AccentSoftColor,
+        string GlowColor)
+    {
+        public string BuildCssVariables()
+        {
+            return string.Join("; ", new[]
+            {
+                $"--overtime-background-start: {BackgroundStart}",
+                $"--overtime-background-end: {BackgroundEnd}",
+                $"--overtime-surface: {SurfaceColor}",
+                $"--overtime-surface-border: {SurfaceBorderColor}",
+                $"--overtime-accent: {AccentColor}",
+                $"--overtime-accent-soft: {AccentSoftColor}",
+                $"--overtime-glow: {GlowColor}"
+            });
+        }
+
+        public string BuildPreviewStyle()
+        {
+            return $"background: linear-gradient(135deg, {BackgroundStart}, {BackgroundEnd}); border-color: {SurfaceBorderColor};";
+        }
+
+        public static IReadOnlyList<OvertimeThemePreset> Catalog { get; } = new[]
+        {
+            new OvertimeThemePreset(
+                "festival-stage",
+                "祭典舞台",
+                "明亮、熱鬧、適合活動感很強的加班台。",
+                "🎪",
+                "#140d22",
+                "#311947",
+                "rgba(25, 17, 39, 0.92)",
+                "rgba(255, 207, 121, 0.35)",
+                "#ffd166",
+                "#ff7ab6",
+                "rgba(255, 209, 102, 0.46)"),
+            new OvertimeThemePreset(
+                "arcade-neon",
+                "霓虹街機",
+                "高對比、速度感強，像街機螢幕一樣俐落。",
+                "🎮",
+                "#060816",
+                "#0f1b3d",
+                "rgba(10, 16, 34, 0.92)",
+                "rgba(84, 240, 255, 0.3)",
+                "#4de1ff",
+                "#7cffcb",
+                "rgba(77, 225, 255, 0.42)"),
+            new OvertimeThemePreset(
+                "gacha-loot",
+                "扭蛋寶箱",
+                "偏向抽卡 / 開箱感，適合強調贊助與驚喜揭曉。",
+                "🎁",
+                "#1b102a",
+                "#3c1e57",
+                "rgba(40, 22, 63, 0.94)",
+                "rgba(255, 191, 105, 0.34)",
+                "#ffb84d",
+                "#ff8fc0",
+                "rgba(255, 184, 77, 0.48)")
+        };
+
+        public static OvertimeThemePreset GetByKey(string? key)
+        {
+            return Catalog.FirstOrDefault(item => string.Equals(item.Key, key, StringComparison.OrdinalIgnoreCase))
+                ?? Catalog[0];
+        }
+    }
+}

--- a/src/EasyLotteryWasm/Pages/Config/OvertimeOverlay.razor
+++ b/src/EasyLotteryWasm/Pages/Config/OvertimeOverlay.razor
@@ -1,0 +1,481 @@
+@page "/system/overtime"
+@using EasyLotteryDomain.Models.Config
+@using EasyLotteryDomain.Models.Overtime
+@using EasyLotteryWasm.Models
+@inject IEasyLotteryConfigStore ConfigStore
+@inject IMessageService MessageService
+@inject IConfiguration Configuration
+@inject NavigationManager NavigationManager
+@inject IJSRuntime JSRuntime
+@inject OvertimeFeedClient OvertimeFeedClient
+
+<PageTitle>加班台</PageTitle>
+
+@if (isLoading)
+{
+    <Card>
+        <CardBody>
+            <div class="text-muted">加班台設定載入中…</div>
+        </CardBody>
+    </Card>
+}
+else
+{
+    <Card class="overtime-settings-shell">
+        <CardBody>
+            <div class="overtime-page-header">
+                <div>
+                    <div class="overtime-eyebrow">LIVE SUPPORT OVERLAY</div>
+                    <h2 class="overtime-title">加班台設定</h2>
+                    <div class="overtime-subtitle">設定直播加班台樣式、啟用狀態與事件來源。</div>
+                </div>
+                <div class="overtime-actions">
+                    <Button Color="Color.Secondary" Clicked="@CopyOverlayUrlAsync">複製 OBS 網址</Button>
+                    <Button Color="Color.Secondary" Clicked="@CopySuperChatWebhookAsync">複製 SuperChat API</Button>
+                    <Button Color="Color.Secondary" Clicked="@CopyEcpayWebhookAsync">複製綠界 API</Button>
+                </div>
+            </div>
+
+            <Row>
+                <Column ColumnSize="ColumnSize.Is7">
+                    <Card class="overtime-config-card">
+                        <CardBody>
+                            <Row>
+                                <Column ColumnSize="ColumnSize.Is6">
+                                    <Field>
+                                        <FieldLabel>啟用加班台</FieldLabel>
+                                        <Switch TValue="bool" @bind-Value="@settings.IsEnabled">
+                                            @(settings.IsEnabled ? "已啟用" : "已停用")
+                                        </Switch>
+                                    </Field>
+                                </Column>
+                                <Column ColumnSize="ColumnSize.Is6">
+                                    <Field>
+                                        <FieldLabel>最大顯示筆數</FieldLabel>
+                                        <NumericInput TValue="int" @bind-Value="@settings.MaxVisibleItems" Min="1" Max="30" />
+                                    </Field>
+                                </Column>
+                            </Row>
+
+                            <Field>
+                                <FieldLabel>標題</FieldLabel>
+                                <TextInput @bind-Value="@settings.Title" Placeholder="例如：加班台" />
+                            </Field>
+
+                            <Field>
+                                <FieldLabel>副標題</FieldLabel>
+                                <TextInput @bind-Value="@settings.Subtitle" Placeholder="例如：SuperChat / 綠界贊助" />
+                            </Field>
+
+                            <Row>
+                                <Column ColumnSize="ColumnSize.Is6">
+                                    <Field>
+                                        <FieldLabel>顯示金額</FieldLabel>
+                                        <Switch TValue="bool" @bind-Value="@settings.ShowAmounts">
+                                            @(settings.ShowAmounts ? "顯示" : "隱藏")
+                                        </Switch>
+                                    </Field>
+                                </Column>
+                                <Column ColumnSize="ColumnSize.Is6">
+                                    <Field>
+                                        <FieldLabel>顯示頭像</FieldLabel>
+                                        <Switch TValue="bool" @bind-Value="@settings.ShowAvatars">
+                                            @(settings.ShowAvatars ? "顯示" : "隱藏")
+                                        </Switch>
+                                    </Field>
+                                </Column>
+                            </Row>
+
+                            <Field>
+                                <FieldLabel>目前選用風格</FieldLabel>
+                                <Select TValue="string" @bind-SelectedValue="@selectedThemeKey">
+                                    @foreach (var preset in presets)
+                                    {
+                                        <SelectItem Value="@preset.Key">@preset.Name</SelectItem>
+                                    }
+                                </Select>
+                            </Field>
+
+                            <div class="d-flex gap-2 flex-wrap mt-4">
+                                <Button Color="Color.Primary" Clicked="@SaveAsync">儲存設定</Button>
+                                <Button Color="Color.Success" Clicked="@SendDemoSuperChatAsync">送出示範 SuperChat</Button>
+                                <Button Color="Color.Warning" Clicked="@SendDemoEcpayAsync">送出示範綠界 Donate</Button>
+                                <Button Color="Color.Danger" Clicked="@ClearFeedAsync">清除加班台訊息</Button>
+                            </div>
+                        </CardBody>
+                    </Card>
+                </Column>
+
+                <Column ColumnSize="ColumnSize.Is5">
+                    <Card class="overtime-preview-card" style="@CurrentTheme.BuildPreviewStyle()">
+                        <CardBody>
+                            <div class="overtime-preview-eyebrow">PREVIEW</div>
+                            <div class="overtime-preview-title">@settings.Title</div>
+                            <div class="overtime-preview-subtitle">@settings.Subtitle</div>
+                            <div class="overtime-preview-badges">
+                                <span class="overtime-preview-badge">@CurrentTheme.Emoji @CurrentTheme.Name</span>
+                                <span class="overtime-preview-badge">最大 @settings.MaxVisibleItems 筆</span>
+                            </div>
+                            <div class="overtime-preview-sample">
+                                <div class="overtime-preview-sample-header">
+                                    <span class="sample-avatar">VT</span>
+                                    <div>
+                                        <div class="sample-name">示範觀眾</div>
+                                        <div class="sample-source">YouTube SuperChat</div>
+                                    </div>
+                                </div>
+                                <div class="sample-message">祝直播順利，這裡是示範訊息。</div>
+                                <div class="sample-amount">NT$ 300</div>
+                            </div>
+                        </CardBody>
+                    </Card>
+                </Column>
+            </Row>
+
+            <div class="mt-4">
+                <h5 class="mb-3">風格模板</h5>
+                <Row>
+                    @foreach (var preset in presets)
+                    {
+                        <Column ColumnSize="ColumnSize.Is4">
+                            <Card class="theme-card @(string.Equals(selectedThemeKey, preset.Key, StringComparison.OrdinalIgnoreCase) ? "selected" : "")"
+                                  style="@preset.BuildPreviewStyle()"
+                                  @onclick="@(() => SelectTheme(preset.Key))">
+                                <CardBody>
+                                    <div class="theme-card-header">
+                                        <div class="theme-card-emoji">@preset.Emoji</div>
+                                        <div class="theme-card-title">@preset.Name</div>
+                                    </div>
+                                    <div class="theme-card-desc">@preset.Description</div>
+                                    <div class="theme-card-key">@preset.Key</div>
+                                </CardBody>
+                            </Card>
+                        </Column>
+                    }
+                </Row>
+            </div>
+
+            <div class="mt-4">
+                <h5 class="mb-3">介面連結</h5>
+                <Table FullWidth Striped Hoverable Bordered Responsive>
+                    <TableBody>
+                        <TableRow>
+                            <TableRowCell>OBS 來源網址</TableRowCell>
+                            <TableRowCell class="text-break">@OverlayUrl</TableRowCell>
+                            <TableRowCell>
+                                <Button Size="Size.Small" Color="Color.Secondary" Clicked="@CopyOverlayUrlAsync">複製</Button>
+                            </TableRowCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableRowCell>SuperChat API</TableRowCell>
+                            <TableRowCell class="text-break">@SuperChatWebhookUrl</TableRowCell>
+                            <TableRowCell>
+                                <Button Size="Size.Small" Color="Color.Secondary" Clicked="@CopySuperChatWebhookAsync">複製</Button>
+                            </TableRowCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableRowCell>綠界 Donate API</TableRowCell>
+                            <TableRowCell class="text-break">@EcpayWebhookUrl</TableRowCell>
+                            <TableRowCell>
+                                <Button Size="Size.Small" Color="Color.Secondary" Clicked="@CopyEcpayWebhookAsync">複製</Button>
+                            </TableRowCell>
+                        </TableRow>
+                    </TableBody>
+                </Table>
+            </div>
+        </CardBody>
+    </Card>
+}
+
+<style>
+    .overtime-settings-shell {
+        background: linear-gradient(180deg, rgba(7, 10, 24, 0.98), rgba(16, 20, 43, 0.96));
+        color: #ecf2ff;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    .overtime-page-header {
+        display: flex;
+        justify-content: space-between;
+        gap: 16px;
+        flex-wrap: wrap;
+        margin-bottom: 20px;
+    }
+
+    .overtime-eyebrow,
+    .overtime-preview-eyebrow {
+        font-size: 0.72rem;
+        font-weight: 800;
+        letter-spacing: 0.2em;
+        opacity: 0.72;
+        text-transform: uppercase;
+    }
+
+    .overtime-title {
+        margin: 4px 0 6px;
+        font-size: 2rem;
+        font-weight: 900;
+    }
+
+    .overtime-subtitle {
+        color: rgba(236, 242, 255, 0.78);
+    }
+
+    .overtime-actions {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        align-items: flex-start;
+        justify-content: flex-end;
+    }
+
+    .overtime-config-card,
+    .overtime-preview-card,
+    .theme-card {
+        border-radius: 20px;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        box-shadow: 0 24px 60px rgba(0, 0, 0, 0.18);
+    }
+
+    .overtime-preview-card {
+        min-height: 100%;
+        color: white;
+        overflow: hidden;
+    }
+
+    .overtime-preview-title {
+        margin-top: 8px;
+        font-size: 1.6rem;
+        font-weight: 900;
+    }
+
+    .overtime-preview-subtitle {
+        margin-top: 4px;
+        opacity: 0.84;
+    }
+
+    .overtime-preview-badges {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        margin-top: 14px;
+    }
+
+    .overtime-preview-badge {
+        display: inline-flex;
+        align-items: center;
+        padding: 6px 10px;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.14);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        font-size: 0.85rem;
+        font-weight: 700;
+    }
+
+    .overtime-preview-sample {
+        margin-top: 18px;
+        padding: 16px;
+        border-radius: 18px;
+        background: rgba(8, 12, 24, 0.26);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        backdrop-filter: blur(12px);
+    }
+
+    .overtime-preview-sample-header {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+    }
+
+    .sample-avatar {
+        width: 42px;
+        height: 42px;
+        border-radius: 14px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 900;
+        background: rgba(255, 255, 255, 0.2);
+    }
+
+    .sample-name {
+        font-weight: 800;
+    }
+
+    .sample-source {
+        opacity: 0.8;
+        font-size: 0.86rem;
+    }
+
+    .sample-message {
+        margin-top: 14px;
+        line-height: 1.6;
+    }
+
+    .sample-amount {
+        margin-top: 12px;
+        font-size: 1.35rem;
+        font-weight: 900;
+        color: var(--overtime-accent, #ffd166);
+    }
+
+    .theme-card {
+        cursor: pointer;
+        color: white;
+        overflow: hidden;
+        transition: transform 0.18s ease, box-shadow 0.18s ease;
+        min-height: 172px;
+    }
+
+    .theme-card:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 28px 60px rgba(0, 0, 0, 0.24);
+    }
+
+    .theme-card.selected {
+        outline: 3px solid var(--overtime-accent, #ffd166);
+        transform: translateY(-2px);
+    }
+
+    .theme-card-header {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        margin-bottom: 10px;
+    }
+
+    .theme-card-emoji {
+        width: 42px;
+        height: 42px;
+        border-radius: 14px;
+        background: rgba(255, 255, 255, 0.18);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.25rem;
+    }
+
+    .theme-card-title {
+        font-size: 1.08rem;
+        font-weight: 900;
+    }
+
+    .theme-card-desc {
+        line-height: 1.55;
+        opacity: 0.9;
+    }
+
+    .theme-card-key {
+        margin-top: 12px;
+        font-size: 0.82rem;
+        opacity: 0.74;
+        word-break: break-all;
+    }
+</style>
+
+@code {
+    private bool isLoading = true;
+    private EasyLotteryConfigDocument document = new();
+    private OvertimeOverlaySettings settings = new();
+    private IReadOnlyList<OvertimeThemePreset> presets = OvertimeThemePreset.Catalog;
+    private string selectedThemeKey = OvertimeThemePreset.Catalog[0].Key;
+    private string OverlayUrl => NavigationManager.ToAbsoluteUri("/obs/overtime").ToString();
+
+    private string ApiBaseUrl => Configuration["Api:BaseUrl"] ?? "http://localhost:5297/";
+
+    private string SuperChatWebhookUrl => new Uri(new Uri(ApiBaseUrl, UriKind.Absolute), "api/overtime/superchat").ToString();
+
+    private string EcpayWebhookUrl => new Uri(new Uri(ApiBaseUrl, UriKind.Absolute), "api/overtime/ecpay").ToString();
+
+    private OvertimeThemePreset CurrentTheme => OvertimeThemePreset.GetByKey(selectedThemeKey);
+
+    protected override async Task OnInitializedAsync()
+    {
+        document = await ConfigStore.LoadAsync();
+        settings = document.OvertimeOverlay ?? new OvertimeOverlaySettings();
+        selectedThemeKey = string.IsNullOrWhiteSpace(settings.ThemeKey) ? OvertimeThemePreset.Catalog[0].Key : settings.ThemeKey;
+        isLoading = false;
+    }
+
+    private void SelectTheme(string key)
+    {
+        selectedThemeKey = key;
+        settings.ThemeKey = key;
+    }
+
+    private async Task SaveAsync()
+    {
+        document.OvertimeOverlay = settings;
+        document.OvertimeOverlay.ThemeKey = selectedThemeKey;
+        await ConfigStore.SaveAsync(document);
+        await MessageService.Success("已儲存加班台設定。");
+    }
+
+    private async Task CopyOverlayUrlAsync()
+    {
+        await JSRuntime.InvokeVoidAsync("easyLotteryClipboard.copyText", OverlayUrl);
+        await MessageService.Success("已複製 OBS 網址。");
+    }
+
+    private async Task CopySuperChatWebhookAsync()
+    {
+        await JSRuntime.InvokeVoidAsync("easyLotteryClipboard.copyText", SuperChatWebhookUrl);
+        await MessageService.Success("已複製 SuperChat API。");
+    }
+
+    private async Task CopyEcpayWebhookAsync()
+    {
+        await JSRuntime.InvokeVoidAsync("easyLotteryClipboard.copyText", EcpayWebhookUrl);
+        await MessageService.Success("已複製綠界 API。");
+    }
+
+    private async Task SendDemoSuperChatAsync()
+    {
+        var entry = await OvertimeFeedClient.PostSuperChatAsync(new OvertimeSupportEvent
+        {
+            Source = OvertimeSupportSource.SuperChat,
+            SourceLabel = "YouTube SuperChat",
+            DisplayName = "示範觀眾",
+            Message = "祝直播順利，這是示範 SuperChat。",
+            Amount = 300m,
+            AmountDisplay = "NT$300",
+            Currency = "TWD",
+            AvatarUrl = "https://placehold.co/96x96/png",
+            Color = "#ff7ab6",
+            ExternalId = Guid.NewGuid().ToString("N")
+        });
+
+        if (entry != null)
+        {
+            await MessageService.Success("已送出示範 SuperChat。");
+        }
+    }
+
+    private async Task SendDemoEcpayAsync()
+    {
+        var entry = await OvertimeFeedClient.PostEcpayDonateAsync(new OvertimeSupportEvent
+        {
+            Source = OvertimeSupportSource.EcpayDonate,
+            SourceLabel = "ECPay Donate",
+            DisplayName = "示範贊助者",
+            Message = "綠界示範贊助。",
+            Amount = 500m,
+            AmountDisplay = "NT$500",
+            Currency = "TWD",
+            AvatarUrl = "https://placehold.co/96x96/png?text=EC",
+            Color = "#ffd166",
+            ExternalId = Guid.NewGuid().ToString("N")
+        });
+
+        if (entry != null)
+        {
+            await MessageService.Success("已送出示範綠界 Donate。");
+        }
+    }
+
+    private async Task ClearFeedAsync()
+    {
+        await OvertimeFeedClient.ClearAsync();
+        await MessageService.Success("已清除加班台訊息。");
+    }
+}

--- a/src/EasyLotteryWasm/Pages/Config/OvertimeOverlay.razor
+++ b/src/EasyLotteryWasm/Pages/Config/OvertimeOverlay.razor
@@ -138,7 +138,7 @@ else
                     @foreach (var preset in presets)
                     {
                         <Column ColumnSize="ColumnSize.Is4">
-                            <Card class="theme-card @(string.Equals(selectedThemeKey, preset.Key, StringComparison.OrdinalIgnoreCase) ? "selected" : "")"
+                            <Card class="@ThemeCardClass(preset.Key)"
                                   style="@preset.BuildPreviewStyle()"
                                   @onclick="@(() => SelectTheme(preset.Key))">
                                 <CardBody>
@@ -477,5 +477,12 @@ else
     {
         await OvertimeFeedClient.ClearAsync();
         await MessageService.Success("已清除加班台訊息。");
+    }
+
+    private string ThemeCardClass(string key)
+    {
+        return string.Equals(selectedThemeKey, key, StringComparison.OrdinalIgnoreCase)
+            ? "theme-card selected"
+            : "theme-card";
     }
 }

--- a/src/EasyLotteryWasm/Pages/Home.razor
+++ b/src/EasyLotteryWasm/Pages/Home.razor
@@ -1,5 +1,6 @@
 ﻿@page "/"
 @using EasyLotteryDomain.Models.Youtube
+@using EasyLotteryDomain.Models.Overtime
 @using EasyLotteryWasm.Models
 @using Google.Apis.YouTube.v3
 @using System.Web
@@ -16,6 +17,7 @@
 @inject IMessageService MessageService
 @inject IJSRuntime JSRuntime
 @inject YouTubeServiceHelper youTubeServiceHelper
+@inject OvertimeFeedClient OvertimeFeedClient
 @inject IEasyLotteryConfigStore ConfigStore
 @inject ILogger<YouTubeServiceHelper> Logger
 @implements IDisposable
@@ -734,6 +736,48 @@
         lastAcceptedMessageTimes.Clear();
     }
 
+    private async Task PublishSupportEventAsync(Google.Apis.YouTube.v3.Data.LiveChatMessage message, string authorName, string displayMessage)
+    {
+        var snippetType = message.Snippet?.Type?.ToString() ?? "";
+        if (!snippetType.Contains("SuperChatEvent", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var superChatDetails = message.Snippet?.SuperChatDetails;
+        if (superChatDetails == null)
+        {
+            return;
+        }
+
+        decimal? amount = superChatDetails.AmountMicros.HasValue
+            ? superChatDetails.AmountMicros.Value / 1_000_000m
+            : null;
+
+        var entry = new OvertimeSupportEvent
+        {
+            Source = OvertimeSupportSource.SuperChat,
+            SourceLabel = "YouTube SuperChat",
+            DisplayName = string.IsNullOrWhiteSpace(authorName) ? "YouTube 觀眾" : authorName,
+            Message = string.IsNullOrWhiteSpace(superChatDetails.UserComment) ? displayMessage : superChatDetails.UserComment,
+            Amount = amount,
+            AmountDisplay = superChatDetails.AmountDisplayString ?? "",
+            Currency = string.IsNullOrWhiteSpace(superChatDetails.Currency) ? "TWD" : superChatDetails.Currency,
+            AvatarUrl = message.AuthorDetails?.ProfileImageUrl ?? "",
+            Color = "#ff7ab6",
+            ExternalId = message.Id
+        };
+
+        try
+        {
+            await OvertimeFeedClient.PostSuperChatAsync(entry);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to publish overtime support event for SuperChat");
+        }
+    }
+
     // 每次 Timer 觸發時顯示訊息
     private void OnTimerTick(object? source, ElapsedEventArgs e)
     {
@@ -782,6 +826,8 @@
                 {
                     Participants.Add(new Participant { Name = authorName, Level = "", IsWinner = false });
                 }
+
+                await PublishSupportEventAsync(message, authorName, displayMessage);
             }
 
             chatRoomCatch.LastMessageTime = latestSeenTime;

--- a/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
+++ b/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
@@ -379,7 +379,7 @@ else
         line-height: 1.55;
     }
 
-    @media (max-width: 992px) {
+    @@media (max-width: 992px) {
         .overtime-feed {
             grid-template-columns: 1fr;
         }

--- a/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
+++ b/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
@@ -1,0 +1,477 @@
+@page "/obs/overtime"
+@layout ObsLayout
+@using EasyLotteryDomain.Models.Config
+@using EasyLotteryDomain.Models.Overtime
+@using EasyLotteryWasm.Layout
+@using EasyLotteryWasm.Models
+@inject IEasyLotteryConfigStore ConfigStore
+@inject OvertimeFeedClient OvertimeFeedClient
+@inject NavigationManager NavigationManager
+@inject IJSRuntime JSRuntime
+
+<PageTitle>加班台 - OBS</PageTitle>
+
+@if (isLoading)
+{
+    <div class="overtime-state">
+        <div class="overtime-state-title">載入加班台中…</div>
+    </div>
+}
+else
+{
+    <div class="overtime-overlay" style="@ThemeStyle">
+        <div class="overtime-shell">
+            <div class="overtime-topbar">
+                <div>
+                    <div class="overtime-eyebrow">SUPPORT OVERLAY</div>
+                    <div class="overtime-title">@settings.Title</div>
+                    <div class="overtime-subtitle">@settings.Subtitle</div>
+                </div>
+                <div class="overtime-topbar-actions">
+                    <button class="overtime-secondary-btn" @onclick="@CopyOverlayUrlAsync">複製來源網址</button>
+                    <button class="overtime-secondary-btn" @onclick="@ReloadAsync">重新載入</button>
+                </div>
+            </div>
+
+            <div class="overtime-status-panel">
+                <span class="overtime-status-pill">風格：@CurrentTheme.Name</span>
+                <span class="overtime-status-pill">最大顯示：@settings.MaxVisibleItems 筆</span>
+                <span class="overtime-status-pill">金額：@(settings.ShowAmounts ? "顯示" : "隱藏")</span>
+                <span class="overtime-status-pill">頭像：@(settings.ShowAvatars ? "顯示" : "隱藏")</span>
+                <span class="overtime-status-pill">來源：@OverlayUrl</span>
+            </div>
+
+            @if (!settings.IsEnabled)
+            {
+                <div class="overtime-disabled-panel">
+                    <div class="overtime-disabled-title">加班台尚未啟用</div>
+                    <div class="overtime-disabled-subtitle">請到「系統配置 / 加班台」開啟後，這個畫面才會開始顯示 SuperChat 與綠界 Donate。</div>
+                </div>
+            }
+            else if (!events.Any())
+            {
+                <div class="overtime-empty-panel">
+                    <div class="overtime-empty-title">目前還沒有事件</div>
+                    <div class="overtime-empty-subtitle">當收到 SuperChat 或綠界贊助時，訊息會在這裡出現。</div>
+                </div>
+            }
+            else
+            {
+                <div class="overtime-feed">
+                    @foreach (var item in events.Take(settings.MaxVisibleItems))
+                    {
+                        <article class="overtime-card">
+                            <div class="overtime-card-left">
+                                @if (settings.ShowAvatars && !string.IsNullOrWhiteSpace(item.AvatarUrl))
+                                {
+                                    <img class="overtime-avatar" src="@item.AvatarUrl" alt="@item.DisplayName" />
+                                }
+                                else
+                                {
+                                    <div class="overtime-avatar fallback">@GetAvatarFallback(item.DisplayName)</div>
+                                }
+                            </div>
+                            <div class="overtime-card-main">
+                                <div class="overtime-card-head">
+                                    <div>
+                                        <div class="overtime-card-name">@item.DisplayName</div>
+                                        <div class="overtime-card-source">@item.SourceLabel</div>
+                                    </div>
+                                    <div class="overtime-card-time">@item.OccurredAtUtc.ToLocalTime().ToString("HH:mm:ss")</div>
+                                </div>
+                                @if (!string.IsNullOrWhiteSpace(item.Message))
+                                {
+                                    <div class="overtime-card-message">@item.Message</div>
+                                }
+                                <div class="overtime-card-footer">
+                                    <span class="overtime-card-tag">@item.Source</span>
+                                    @if (settings.ShowAmounts && !string.IsNullOrWhiteSpace(item.AmountDisplay))
+                                    {
+                                        <span class="overtime-card-amount">@item.AmountDisplay</span>
+                                    }
+                                    else if (settings.ShowAmounts && item.Amount.HasValue)
+                                    {
+                                        <span class="overtime-card-amount">@item.Amount.Value.ToString("0.##") @item.Currency</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="overtime-card-amount muted">金額已隱藏</span>
+                                    }
+                                </div>
+                            </div>
+                        </article>
+                    }
+                </div>
+            }
+        </div>
+    </div>
+}
+
+<style>
+    html, body, #app, .obs-layout {
+        background: transparent !important;
+        margin: 0;
+        padding: 0;
+    }
+
+    .overtime-overlay {
+        width: 100vw;
+        height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 20px;
+        box-sizing: border-box;
+    }
+
+    .overtime-shell {
+        width: min(100%, 1220px);
+        height: min(100%, 860px);
+        display: flex;
+        flex-direction: column;
+        gap: 14px;
+        color: white;
+        border-radius: 32px;
+        padding: 20px;
+        background:
+            radial-gradient(circle at top left, rgba(255, 255, 255, 0.16), transparent 36%),
+            linear-gradient(135deg, color-mix(in srgb, var(--overtime-background-start) 92%, black), var(--overtime-background-end));
+        box-shadow: 0 28px 80px rgba(0, 0, 0, 0.36);
+        border: 1px solid var(--overtime-surface-border);
+        position: relative;
+        overflow: hidden;
+    }
+
+    .overtime-shell::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background:
+            radial-gradient(circle at 15% 20%, color-mix(in srgb, var(--overtime-glow) 35%, transparent), transparent 28%),
+            radial-gradient(circle at 85% 20%, color-mix(in srgb, var(--overtime-accent-soft) 30%, transparent), transparent 30%);
+        pointer-events: none;
+        opacity: 0.7;
+    }
+
+    .overtime-shell > * {
+        position: relative;
+        z-index: 1;
+    }
+
+    .overtime-topbar {
+        display: flex;
+        justify-content: space-between;
+        gap: 16px;
+        flex-wrap: wrap;
+        padding: 18px 20px;
+        border-radius: 24px;
+        background: color-mix(in srgb, var(--overtime-surface) 88%, transparent);
+        border: 1px solid var(--overtime-surface-border);
+    }
+
+    .overtime-eyebrow {
+        font-size: 0.72rem;
+        font-weight: 800;
+        letter-spacing: 0.24em;
+        opacity: 0.7;
+        text-transform: uppercase;
+    }
+
+    .overtime-title {
+        margin-top: 4px;
+        font-size: 2.1rem;
+        font-weight: 900;
+        line-height: 1.1;
+    }
+
+    .overtime-subtitle {
+        margin-top: 4px;
+        font-size: 0.98rem;
+        opacity: 0.86;
+    }
+
+    .overtime-topbar-actions {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        align-items: flex-start;
+        justify-content: flex-end;
+    }
+
+    .overtime-secondary-btn {
+        appearance: none;
+        border: 1px solid rgba(255, 255, 255, 0.18);
+        background: rgba(255, 255, 255, 0.12);
+        color: white;
+        border-radius: 12px;
+        padding: 10px 14px;
+        font-weight: 800;
+        cursor: pointer;
+        transition: transform 0.18s ease, background 0.18s ease;
+    }
+
+    .overtime-secondary-btn:hover {
+        transform: translateY(-1px);
+        background: rgba(255, 255, 255, 0.18);
+    }
+
+    .overtime-status-panel {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    .overtime-status-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 7px 12px;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.12);
+        border: 1px solid rgba(255, 255, 255, 0.14);
+        font-size: 0.84rem;
+        font-weight: 800;
+    }
+
+    .overtime-feed {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+        overflow: hidden;
+    }
+
+    .overtime-card,
+    .overtime-disabled-panel,
+    .overtime-empty-panel {
+        border-radius: 24px;
+        padding: 16px 18px;
+        background: color-mix(in srgb, var(--overtime-surface) 88%, transparent);
+        border: 1px solid var(--overtime-surface-border);
+        box-shadow: 0 18px 48px rgba(0, 0, 0, 0.14);
+    }
+
+    .overtime-card {
+        display: flex;
+        gap: 14px;
+        align-items: flex-start;
+    }
+
+    .overtime-avatar {
+        width: 64px;
+        height: 64px;
+        border-radius: 18px;
+        object-fit: cover;
+        border: 2px solid rgba(255, 255, 255, 0.26);
+        box-shadow: 0 10px 24px rgba(0, 0, 0, 0.22);
+    }
+
+    .overtime-avatar.fallback {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background: linear-gradient(135deg, var(--overtime-accent), var(--overtime-accent-soft));
+        color: #08111d;
+        font-weight: 900;
+        font-size: 1.35rem;
+    }
+
+    .overtime-card-main {
+        flex: 1;
+        min-width: 0;
+    }
+
+    .overtime-card-head {
+        display: flex;
+        justify-content: space-between;
+        gap: 10px;
+        align-items: flex-start;
+    }
+
+    .overtime-card-name {
+        font-size: 1.06rem;
+        font-weight: 900;
+    }
+
+    .overtime-card-source {
+        margin-top: 2px;
+        font-size: 0.82rem;
+        opacity: 0.78;
+    }
+
+    .overtime-card-time {
+        font-size: 0.8rem;
+        opacity: 0.72;
+        white-space: nowrap;
+    }
+
+    .overtime-card-message {
+        margin-top: 10px;
+        line-height: 1.55;
+        font-size: 0.98rem;
+        opacity: 0.96;
+        word-break: break-word;
+    }
+
+    .overtime-card-footer {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-top: 12px;
+    }
+
+    .overtime-card-tag,
+    .overtime-card-amount {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        padding: 6px 10px;
+        font-size: 0.82rem;
+        font-weight: 800;
+        background: rgba(255, 255, 255, 0.12);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+    }
+
+    .overtime-card-amount {
+        color: var(--overtime-accent);
+    }
+
+    .overtime-card-amount.muted {
+        color: rgba(255, 255, 255, 0.72);
+    }
+
+    .overtime-state {
+        min-width: 320px;
+        max-width: 640px;
+        margin: 24px;
+        padding: 22px 28px;
+        border-radius: 18px;
+        background: rgba(15, 23, 42, 0.9);
+        color: white;
+        text-align: center;
+        box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+    }
+
+    .overtime-state-title {
+        font-size: 1.2rem;
+        font-weight: 700;
+    }
+
+    .overtime-disabled-panel,
+    .overtime-empty-panel {
+        min-height: 180px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        gap: 8px;
+    }
+
+    .overtime-disabled-title,
+    .overtime-empty-title {
+        font-size: 1.3rem;
+        font-weight: 900;
+    }
+
+    .overtime-disabled-subtitle,
+    .overtime-empty-subtitle {
+        opacity: 0.84;
+        line-height: 1.55;
+    }
+
+    @media (max-width: 992px) {
+        .overtime-feed {
+            grid-template-columns: 1fr;
+        }
+    }
+</style>
+
+@code {
+    private bool isLoading = true;
+    private System.Timers.Timer? refreshTimer;
+    private bool isRefreshing;
+    private EasyLotteryConfigDocument document = new();
+    private OvertimeOverlaySettings settings = new();
+    private IReadOnlyList<OvertimeSupportEvent> events = [];
+    private OvertimeThemePreset CurrentTheme => OvertimeThemePreset.GetByKey(settings.ThemeKey);
+    private string OverlayUrl => NavigationManager.ToAbsoluteUri("/obs/overtime").ToString();
+    private string ThemeStyle => CurrentTheme.BuildCssVariables();
+
+    protected override async Task OnInitializedAsync()
+    {
+        await ReloadAsync();
+
+        refreshTimer = new System.Timers.Timer(2500);
+        refreshTimer.Elapsed += OnTimerElapsed;
+        refreshTimer.AutoReset = true;
+        refreshTimer.Start();
+    }
+
+    private async void OnTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        if (isRefreshing)
+        {
+            return;
+        }
+
+        isRefreshing = true;
+        try
+        {
+            await InvokeAsync(async () =>
+            {
+                await ReloadEventsAsync();
+                StateHasChanged();
+            });
+        }
+        finally
+        {
+            isRefreshing = false;
+        }
+    }
+
+    private async Task ReloadAsync()
+    {
+        isLoading = true;
+        document = await ConfigStore.LoadAsync();
+        settings = document.OvertimeOverlay ?? new OvertimeOverlaySettings();
+        settings.ThemeKey = string.IsNullOrWhiteSpace(settings.ThemeKey) ? OvertimeThemePreset.Catalog[0].Key : settings.ThemeKey;
+        await ReloadEventsAsync();
+        isLoading = false;
+    }
+
+    private async Task ReloadEventsAsync()
+    {
+        try
+        {
+            events = await OvertimeFeedClient.GetEventsAsync();
+        }
+        catch
+        {
+            events = [];
+        }
+    }
+
+    private async Task CopyOverlayUrlAsync()
+    {
+        await JSRuntime.InvokeVoidAsync("easyLotteryClipboard.copyText", OverlayUrl);
+    }
+
+    private static string GetAvatarFallback(string? displayName)
+    {
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            return "?";
+        }
+
+        return displayName.Trim().Substring(0, 1).ToUpperInvariant();
+    }
+
+    public void Dispose()
+    {
+        if (refreshTimer != null)
+        {
+            refreshTimer.Elapsed -= OnTimerElapsed;
+            refreshTimer.Dispose();
+        }
+    }
+}

--- a/src/EasyLotteryWasm/Program.cs
+++ b/src/EasyLotteryWasm/Program.cs
@@ -29,12 +29,14 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddDistributedMemoryCache();
 
-builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+var apiBaseUrl = builder.Configuration["Api:BaseUrl"] ?? "http://localhost:5297/";
+builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(apiBaseUrl) });
 
 builder.Services.AddScoped<IEasyLotteryConfigStore, YamlEasyLotteryConfigStore>();
 builder.Services.AddScoped<SystemSettingsService>();
 builder.Services.AddScoped<ActivityResultService>();
 builder.Services.AddScoped<VisualStyleService>();
+builder.Services.AddScoped<OvertimeFeedClient>();
 
 // 添加服務
 builder.Services.AddScoped<YouTubeServiceHelper>();
@@ -42,14 +44,12 @@ builder.Services.AddScoped<PokeService>();
 builder.Services.AddScoped<RouletteService>();
 
 builder.Services
-    .AddBlazorise( options =>
+    .AddBlazorise(options =>
     {
         options.Immediate = true;
     })
     .AddBootstrap5Providers()
     .AddFontAwesomeIcons();
-
-
 
 builder.Logging.AddSerilog(Log.Logger);
 

--- a/src/EasyLotteryWasm/Services/OvertimeFeedClient.cs
+++ b/src/EasyLotteryWasm/Services/OvertimeFeedClient.cs
@@ -1,0 +1,40 @@
+using System.Net.Http.Json;
+using EasyLotteryDomain.Models.Overtime;
+
+namespace EasyLotteryWasm.Services
+{
+    public sealed class OvertimeFeedClient
+    {
+        private readonly HttpClient _httpClient;
+
+        public OvertimeFeedClient(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+        }
+
+        public async Task<IReadOnlyList<OvertimeSupportEvent>> GetEventsAsync(CancellationToken cancellationToken = default)
+        {
+            var events = await _httpClient.GetFromJsonAsync<List<OvertimeSupportEvent>>("api/overtime/events", cancellationToken);
+            return events ?? [];
+        }
+
+        public async Task<OvertimeSupportEvent?> PostSuperChatAsync(OvertimeSupportEvent eventItem, CancellationToken cancellationToken = default)
+        {
+            var response = await _httpClient.PostAsJsonAsync("api/overtime/superchat", eventItem, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<OvertimeSupportEvent>(cancellationToken);
+        }
+
+        public async Task<OvertimeSupportEvent?> PostEcpayDonateAsync(OvertimeSupportEvent eventItem, CancellationToken cancellationToken = default)
+        {
+            var response = await _httpClient.PostAsJsonAsync("api/overtime/ecpay", eventItem, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<OvertimeSupportEvent>(cancellationToken);
+        }
+
+        public async Task ClearAsync(CancellationToken cancellationToken = default)
+        {
+            await _httpClient.DeleteAsync("api/overtime/events", cancellationToken);
+        }
+    }
+}

--- a/src/EasyLotteryWasm/Services/YamlEasyLotteryConfigStore.cs
+++ b/src/EasyLotteryWasm/Services/YamlEasyLotteryConfigStore.cs
@@ -140,6 +140,13 @@ namespace EasyLotteryWasm.Services
             document.DrawingRules ??= new DrawingRuleSettings();
             document.VisualStyle ??= new VisualStyleSettings();
             document.VisualStyle.ActiveThemeKey = VisualStyleCatalog.NormalizeKey(document.VisualStyle.ActiveThemeKey);
+            document.OvertimeOverlay ??= new OvertimeOverlaySettings();
+            document.OvertimeOverlay.Title = document.OvertimeOverlay.Title.Trim();
+            document.OvertimeOverlay.Subtitle = document.OvertimeOverlay.Subtitle.Trim();
+            document.OvertimeOverlay.ThemeKey = string.IsNullOrWhiteSpace(document.OvertimeOverlay.ThemeKey)
+                ? "festival-stage"
+                : document.OvertimeOverlay.ThemeKey.Trim();
+            document.OvertimeOverlay.MaxVisibleItems = Math.Max(1, document.OvertimeOverlay.MaxVisibleItems);
 
             foreach (var template in document.PokeTemplates)
             {

--- a/src/EasyLotteryWasm/_Imports.razor
+++ b/src/EasyLotteryWasm/_Imports.razor
@@ -10,6 +10,8 @@
 @using EasyLotteryWasm.Models
 @using EasyLotteryWasm.Layout
 @using EasyLotteryWasm.Shared
+@using EasyLotteryWasm.Services
 @using EasyLotteryDomain.Services
+@using EasyLotteryDomain.Models.Config
 @using Blazorise
 @using Serilog

--- a/src/EasyLotteryWasm/wwwroot/appsettings.json
+++ b/src/EasyLotteryWasm/wwwroot/appsettings.json
@@ -44,5 +44,8 @@
     "CredentialsBase64": "",
     "RedirectUri": "",
     "RefreshToken": ""
+  },
+  "Api": {
+    "BaseUrl": "http://localhost:5297/"
   }
 }


### PR DESCRIPTION
## Summary
- Add a configurable overtime overlay for live support events.
- Add a reusable theme catalog with three presets: Festival Stage, Neon Arcade, and Gacha Loot Box.
- Add an OBS-friendly overtime overlay page that can display SuperChat and ECPay donate events.

## What changed
- Added overtime configuration to the shared config document.
- Added a new system settings page for enabling the overlay, editing its title/subtitle, choosing a theme, and copying the overlay / API URLs.
- Added an OBS overlay page that polls overtime events and renders a live support feed.
- Added an API-backed overtime feed store and controller for SuperChat and ECPay donate events.
- Hooked the existing YouTube chat capture flow so SuperChat messages are published to the overtime feed automatically.
- Added demo actions so the overlay can be tested quickly from the settings page.

## Why
- The app already had live chat capture, but no dedicated overtime / support overlay for stream use.
- This gives streamers a VTuber-friendly support surface without mixing it into the main lottery UI.
- The built-in theme presets make the overlay feel like part of the stream presentation instead of a plain admin page.

## Verification
- `dotnet test EasyLottery.generated.sln --configuration Release`
- Result: build and tests passed.

## Notes
- SuperChat events captured from the live chat flow are forwarded into the overtime feed automatically.
- ECPay donate events can be posted to the new overtime endpoint, and the settings page provides the URL for external integration.
- This implements issue #44.