### PR TITLE
feat: add participant groups and tags

### DIFF
--- a/src/EasyLotteryWasm/Pages/Home.razor
+++ b/src/EasyLotteryWasm/Pages/Home.razor
@@ -189,7 +189,23 @@
                 <FieldBody ColumnSize="ColumnSize.Is2">
                     <TextInput @bind-Value="@CustomParticipantName" Placeholder="請輸入參加者名稱" />
                 </FieldBody>
-                 <FieldBody ColumnSize="ColumnSize.Is2">
+            </Field>
+            <Field Horizontal>
+                <FieldLabel ColumnSize="ColumnSize.Is2">
+                    所屬群組
+                </FieldLabel>
+                <FieldBody ColumnSize="ColumnSize.Is2">
+                    <TextInput @bind-Value="@CustomParticipantGroup" Placeholder="例如：VIP、備用" />
+                </FieldBody>
+            </Field>
+            <Field Horizontal>
+                <FieldLabel ColumnSize="ColumnSize.Is2">
+                    標籤
+                </FieldLabel>
+                <FieldBody ColumnSize="ColumnSize.Is2">
+                    <TextInput @bind-Value="@CustomParticipantTags" Placeholder="例如：A區,高倍率" />
+                </FieldBody>
+                <FieldBody ColumnSize="ColumnSize.Is2">
                     <Button Color="Color.Primary" @onclick="AddParticipant">新增參加者</Button>
                 </FieldBody>
             </Field>
@@ -428,20 +444,34 @@
                     </ul>
                 </TableRowCell>
                 <TableRowCell>
+                    <div class="d-flex gap-2 align-items-center flex-wrap mb-2">
+                        <span class="text-muted">群組篩選</span>
+                        <select class="form-select form-select-sm" style="max-width: 220px;" @bind="participantGroupFilter">
+                            <option value="">全部</option>
+                            <option value="未分組">未分組</option>
+                            @foreach (var group in ParticipantGroups)
+                            {
+                                <option value="@group">@group</option>
+                            }
+                        </select>
+                        <span class="text-muted">共 @FilteredParticipants.Count() / @Participants.Count 筆</span>
+                    </div>
                     <ul>
-                        @foreach (var participant in Participants)
+                        @foreach (var participant in FilteredParticipants)
                         {
                             <li style="@(Winners.Any(x=>x.Member.Name == participant.Name) ? "color: gray;" : "color: black;")">
-                                @if(string.IsNullOrWhiteSpace(participant.Level))
-                                {
-                                    <span> @participant.Name </span>
-                                }
-                                else
-                                {
-                                   <span> (@participant.Level)@participant.Name </span>  
-                                }
+                                @RenderParticipantLabel(participant)
                                 @if(!Winners.Any(x=>x.Member.Name == participant.Name)){
                                   <Button Size="Size.Small" @onclick="() => RemoveParticipant(participant.Name)"><Icon Name="IconName.Delete" /></Button>
+                                }
+                                @if (participant.Tags.Any())
+                                {
+                                    <div class="d-flex gap-1 flex-wrap mt-1">
+                                        @foreach (var tag in participant.Tags)
+                                        {
+                                            <Badge Color="Color.Info">@tag</Badge>
+                                        }
+                                    </div>
                                 }
                             </li>
                         }
@@ -453,18 +483,11 @@
                         <ul>
                             @foreach (var winner in Winners)
                             {
-                                <li>恭喜 
+                                <li>恭喜
                                     <span style="color:red;">
-                                        @if(string.IsNullOrWhiteSpace(winner.Member.Level))
-                                        {
-                                            @winner.Member.Name
-                                        }
-                                        else
-                                        {
-                                            <span>(@winner.Member.Level)@winner.Member.Name</span>
-                                        }
-                                    </span> 獲得了 
-                                    <span style="color:red;">@winner.Prize </span> 
+                                        @RenderParticipantLabel(winner.Member)
+                                    </span> 獲得了
+                                    <span style="color:red;">@winner.Prize</span>
                                 </li>
                             }
                         </ul>
@@ -525,6 +548,10 @@
 
         public string Level { get; init; } = "";
 
+        public string Group { get; init; } = "";
+
+        public List<string> Tags { get; init; } = new();
+
         public bool IsWinner { get; set; }
     }
 
@@ -546,6 +573,12 @@
     // 自訂參加者名稱
     private string CustomParticipantName { get; set; } = "";
 
+    private string CustomParticipantGroup { get; set; } = "";
+
+    private string CustomParticipantTags { get; set; } = "";
+
+    private string participantGroupFilter = "";
+
     // 參加者
     private List<Participant> Participants {get;set;} = new();
 
@@ -556,6 +589,82 @@
     private Dictionary<string, int> levelRate = new Dictionary<string, int>();
 
     private List<YoutubeMemberInfo> YTMembers = new();
+
+    private IEnumerable<Participant> FilteredParticipants =>
+        string.IsNullOrWhiteSpace(participantGroupFilter)
+            ? Participants
+            : Participants.Where(participant =>
+                string.Equals(GetParticipantGroup(participant), participantGroupFilter, StringComparison.OrdinalIgnoreCase));
+
+    private List<string> ParticipantGroups =>
+        Participants
+            .Select(GetParticipantGroup)
+            .Where(group => !string.IsNullOrWhiteSpace(group))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(group => group)
+            .ToList();
+
+    private void UpdateParticipantGroupFilter()
+    {
+        if (!string.IsNullOrWhiteSpace(participantGroupFilter))
+        {
+            if (!ParticipantGroups.Any(group => string.Equals(group, participantGroupFilter, StringComparison.OrdinalIgnoreCase)))
+            {
+                participantGroupFilter = "";
+            }
+        }
+    }
+
+    private static Participant NormalizeParticipant(Participant participant)
+    {
+        return participant with
+        {
+            Name = participant.Name?.Trim() ?? "",
+            Level = participant.Level?.Trim() ?? "",
+            Group = participant.Group?.Trim() ?? "",
+            Tags = NormalizeTags(participant.Tags)
+        };
+    }
+
+    private static List<string> NormalizeTags(IEnumerable<string>? tags)
+    {
+        return (tags ?? [])
+            .Select(tag => tag.Trim())
+            .Where(tag => !string.IsNullOrWhiteSpace(tag))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static List<string> ParseTags(string? tagsText)
+    {
+        if (string.IsNullOrWhiteSpace(tagsText))
+        {
+            return [];
+        }
+
+        return tagsText
+            .Split(new[] { ',', '，', '\n', '\r', ';', '|' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(tag => !string.IsNullOrWhiteSpace(tag))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static string GetParticipantGroup(Participant participant)
+    {
+        return string.IsNullOrWhiteSpace(participant.Group) ? "未分組" : participant.Group.Trim();
+    }
+
+    private static string RenderParticipantLabel(Participant participant)
+    {
+        var name = string.IsNullOrWhiteSpace(participant.Level)
+            ? participant.Name
+            : $"({participant.Level}){participant.Name}";
+        var group = GetParticipantGroup(participant);
+
+        return string.IsNullOrWhiteSpace(group) || group == "未分組"
+            ? name
+            : $"[{group}] {name}";
+    }
 
     // 抽獎
     private void OnDrawPrize()
@@ -615,7 +724,17 @@
             return;
         }
 
-        Participants.Add(new Participant { Name =  CustomParticipantName });
+        Participants.Add(new Participant
+        {
+            Name = CustomParticipantName.Trim(),
+            Group = CustomParticipantGroup.Trim(),
+            Tags = ParseTags(CustomParticipantTags)
+        });
+
+        CustomParticipantName = "";
+        CustomParticipantGroup = "";
+        CustomParticipantTags = "";
+        UpdateParticipantGroupFilter();
     }
 
     // 移除參加者
@@ -624,6 +743,7 @@
         if (Participants.Any(x => x.Name == name))
         {
             Participants.RemoveAll(x => x.Name == name);
+            UpdateParticipantGroupFilter();
         }
     }
 
@@ -633,6 +753,7 @@
         if (Participants.Any())
         {
             Participants.Clear();
+            participantGroupFilter = "";
         }
     }
 
@@ -780,7 +901,8 @@
 
                 if (!Participants.Any(x => x.Name == authorName))
                 {
-                    Participants.Add(new Participant { Name = authorName, Level = "", IsWinner = false });
+                    Participants.Add(new Participant { Name = authorName, Level = "", Group = "聊天室", Tags = new List<string>(), IsWinner = false });
+                    UpdateParticipantGroupFilter();
                 }
             }
 

--- a/src/EasyLotteryWasm/Pages/Home.razor.cs
+++ b/src/EasyLotteryWasm/Pages/Home.razor.cs
@@ -16,6 +16,10 @@ public partial class Home
 
         public string? Level { get; set; }
 
+        public string? Group { get; set; }
+
+        public string? Tags { get; set; }
+
         public bool IsWinner { get; set; }
     }
 
@@ -245,6 +249,7 @@ public partial class Home
 
             Participants = importedParticipants;
             Winners.Clear();
+            UpdateParticipantGroupFilter();
             EnsureLevelRatesForLevels(importedParticipants.Select(participant => participant.Level));
             await PersistLevelRatesAsync();
             await MessageService.Success($"已匯入 {Participants.Count} 筆參加者資料。");
@@ -356,8 +361,9 @@ public partial class Home
             EnsureLevelRatesForLevels(YTMembers.Select(member => member.Level));
 
             Participants = YTMembers.SelectMany(x => Enumerable.Repeat(
-                new Participant { Name = x.Name, Level = x.Level, IsWinner = false },
+                new Participant { Name = x.Name, Level = x.Level, Group = "YT會員", Tags = new List<string>(), IsWinner = false },
                 levelRate.TryGetValue(x.Level, out var rate) ? rate : 1)).ToList();
+            UpdateParticipantGroupFilter();
         }
 
         await PersistLevelRatesAsync();
@@ -389,7 +395,8 @@ public partial class Home
 
     private static List<Participant> ParseParticipantsJson(string content)
     {
-        return JsonSerializer.Deserialize<List<Participant>>(content) ?? new List<Participant>();
+        var participants = JsonSerializer.Deserialize<List<Participant>>(content) ?? new List<Participant>();
+        return participants.Select(NormalizeParticipant).ToList();
     }
 
     private static List<string> ParsePrizesJson(string content)
@@ -408,8 +415,11 @@ public partial class Home
             {
                 Name = row.Name?.Trim() ?? "",
                 Level = row.Level?.Trim() ?? "",
+                Group = row.Group?.Trim() ?? "",
+                Tags = ParseTags(row.Tags),
                 IsWinner = row.IsWinner
             })
+            .Select(NormalizeParticipant)
             .ToList();
     }
 
@@ -426,12 +436,15 @@ public partial class Home
 
     private static string BuildParticipantsCsv(IEnumerable<Participant> participants)
     {
-        var lines = new List<string> { "Name,Level,IsWinner" };
+        var lines = new List<string> { "Name,Level,Group,Tags,IsWinner" };
         foreach (var participant in participants)
         {
+            var tags = string.Join("|", participant.Tags ?? []);
             lines.Add(string.Join(",",
                 EscapeCsv(participant.Name),
                 EscapeCsv(participant.Level),
+                EscapeCsv(participant.Group),
+                EscapeCsv(tags),
                 participant.IsWinner ? "true" : "false"));
         }
 


### PR DESCRIPTION
## Summary
- Add group and tag support to participants so winners can be organized more flexibly.
- Add a participant group filter in the main draw page so larger lists are easier to manage.
- Keep the existing draw flow intact while expanding the participant import/export format.

## What changed
- Extended the participant model with `Group` and `Tags`.
- Added manual entry fields for participant group and tags.
- Added a group filter for the participant list, including a count of filtered items.
- Displayed group and tag information in the participant list and winner list.
- Updated participant CSV import/export to include `Group` and `Tags`.
- Preserved tags and group data when importing JSON participant data.
- Assigned YouTube-captured participants to a default `聊天室` group.

## Why
- The app previously only supported a flat participant list.
- Activities that need VIP, backup, or category-based participants need stronger organization tools.
- Groups and tags make it easier to manage large or multi-round events without changing the existing draw logic.

## Verification
- `dotnet restore EasyLottery.generated.sln`
- `dotnet test EasyLottery.generated.sln --configuration Release --no-restore`
- Result: build and tests passed.

## Notes
- This keeps the current raffle selection flow unchanged.
- CSV export now includes the additional participant metadata fields.
- This implements issue #25.