### PR TITLE
feat: add versioned backup and restore

### DIFF
--- a/src/EasyLotteryDomain/Models/Config/EasyLotteryBackupPackage.cs
+++ b/src/EasyLotteryDomain/Models/Config/EasyLotteryBackupPackage.cs
@@ -1,0 +1,11 @@
+namespace EasyLotteryDomain.Models.Config
+{
+    public sealed class EasyLotteryBackupPackage
+    {
+        public int BackupVersion { get; set; } = 1;
+
+        public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+
+        public EasyLotteryConfigDocument Document { get; set; } = new();
+    }
+}

--- a/src/EasyLotteryDomain/Services/EasyLotteryBackupService.cs
+++ b/src/EasyLotteryDomain/Services/EasyLotteryBackupService.cs
@@ -1,0 +1,100 @@
+using System.Text.Json;
+using EasyLotteryDomain.Models.Config;
+
+namespace EasyLotteryDomain.Services
+{
+    public sealed class EasyLotteryBackupService
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+        {
+            WriteIndented = true
+        };
+
+        private readonly IEasyLotteryConfigStore _configStore;
+
+        public EasyLotteryBackupService(IEasyLotteryConfigStore configStore)
+        {
+            _configStore = configStore;
+        }
+
+        public async Task<EasyLotteryBackupPackage> CreateBackupAsync(CancellationToken cancellationToken = default)
+        {
+            var document = await _configStore.LoadAsync(cancellationToken);
+
+            return new EasyLotteryBackupPackage
+            {
+                BackupVersion = 1,
+                CreatedAtUtc = DateTime.UtcNow,
+                Document = document
+            };
+        }
+
+        public async Task RestoreAsync(string json, CancellationToken cancellationToken = default)
+        {
+            if (TryDeserializeBackupPackage(json, out var package))
+            {
+                await _configStore.SaveAsync(package!.Document, cancellationToken);
+                return;
+            }
+
+            var legacyDocument = JsonSerializer.Deserialize<EasyLotteryConfigDocument>(json, JsonOptions);
+            if (legacyDocument is null)
+            {
+                throw new InvalidOperationException("無法解析備份內容。");
+            }
+
+            await _configStore.SaveAsync(legacyDocument, cancellationToken);
+        }
+
+        public string SerializeBackup(EasyLotteryBackupPackage package)
+        {
+            return JsonSerializer.Serialize(package, JsonOptions);
+        }
+
+        public static bool TryDeserializeBackupPackage(string json, out EasyLotteryBackupPackage? package)
+        {
+            package = null;
+
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return false;
+            }
+
+            try
+            {
+                using var jsonDocument = JsonDocument.Parse(json);
+                var root = jsonDocument.RootElement;
+                if (root.ValueKind != JsonValueKind.Object || !HasProperty(root, "document"))
+                {
+                    return false;
+                }
+
+                package = JsonSerializer.Deserialize<EasyLotteryBackupPackage>(json, JsonOptions);
+                if (package is null || package.BackupVersion <= 0 || package.Document is null)
+                {
+                    package = null;
+                    return false;
+                }
+
+                return true;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+        }
+
+        private static bool HasProperty(JsonElement root, string propertyName)
+        {
+            foreach (var property in root.EnumerateObject())
+            {
+                if (string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/EasyLotteryWasm/Layout/NavMenu.razor
+++ b/src/EasyLotteryWasm/Layout/NavMenu.razor
@@ -59,6 +59,11 @@
                 </NavLink>
             </div>
             <div class="nav-item px-3 nav-sub-item">
+                <NavLink class="nav-link" href="system/backup">
+                    備份還原
+                </NavLink>
+            </div>
+            <div class="nav-item px-3 nav-sub-item">
                 <NavLink class="nav-link" href="system/youtube-login">
                     YouTube 登入
                 </NavLink>

--- a/src/EasyLotteryWasm/Pages/Config/BackupSettings.razor
+++ b/src/EasyLotteryWasm/Pages/Config/BackupSettings.razor
@@ -1,0 +1,143 @@
+@page "/system/backup"
+
+@inject EasyLotteryBackupService BackupService
+@inject IMessageService MessageService
+@inject IJSRuntime JSRuntime
+@using System.Text
+
+<PageTitle>備份還原</PageTitle>
+
+<Card>
+    <CardHeader>
+        <CardTitle>備份還原</CardTitle>
+    </CardHeader>
+    <CardBody>
+        <CardText>
+            <p>這裡可以將目前的設定、模板與活動結果一起備份，也可以從備份檔還原整份資料。</p>
+            <p>備份格式會包含版本資訊，並保留相容於既有資料格式的還原能力。</p>
+        </CardText>
+
+        <Row>
+            <Column ColumnSize="ColumnSize.Is6">
+                <Card Margin="Margin.Is3.FromBottom">
+                    <CardBody>
+                        <CardTitle><h5>建立備份</h5></CardTitle>
+                        <CardText>
+                            下載內容會包含：
+                            <ul>
+                                <li>系統設定</li>
+                                <li>戳戳樂模板</li>
+                                <li>轉盤模板</li>
+                                <li>抽獎規則模板</li>
+                                <li>活動結果</li>
+                                <li>流水號</li>
+                            </ul>
+                        </CardText>
+                        <Button Color="Color.Primary" Clicked="@ExportBackupAsync">下載版本化備份</Button>
+                    </CardBody>
+                </Card>
+            </Column>
+            <Column ColumnSize="ColumnSize.Is6">
+                <Card Margin="Margin.Is3.FromBottom">
+                    <CardBody>
+                        <CardTitle><h5>還原備份</h5></CardTitle>
+                        <CardText>
+                            <p class="text-danger mb-2">還原會直接覆蓋目前的所有設定、模板與活動結果。</p>
+                        </CardText>
+                        <InputFile OnChange="OnBackupFileSelected" />
+                        <div class="d-flex gap-2 flex-wrap mt-3">
+                            <Button Color="Color.Warning" Clicked="@RestoreBackupAsync" Disabled="@(!canRestore)">還原備份</Button>
+                            <Button Color="Color.Secondary" Clicked="@ClearSelectedBackupAsync" Disabled="@string.IsNullOrWhiteSpace(backupFileName) && string.IsNullOrWhiteSpace(backupText)">清除檔案</Button>
+                        </div>
+                        @if (!string.IsNullOrWhiteSpace(backupFileName))
+                        {
+                            <p class="mt-3 mb-1"><strong>已選取檔案：</strong>@backupFileName</p>
+                        }
+                        @if (!string.IsNullOrWhiteSpace(backupSummary))
+                        {
+                            <p class="mb-0"><strong>備份摘要：</strong>@backupSummary</p>
+                        }
+                    </CardBody>
+                </Card>
+            </Column>
+        </Row>
+    </CardBody>
+</Card>
+
+@code {
+    private string backupText = "";
+    private string backupFileName = "";
+    private string backupSummary = "";
+    private bool canRestore => !string.IsNullOrWhiteSpace(backupText);
+
+    private async Task ExportBackupAsync()
+    {
+        var package = await BackupService.CreateBackupAsync();
+        var json = BackupService.SerializeBackup(package);
+        var fileName = $"easy-lottery-backup-v{package.BackupVersion}-{package.CreatedAtUtc:yyyyMMdd-HHmmss}.json";
+
+        await JSRuntime.InvokeVoidAsync("easyLotteryDownload.downloadText", fileName, json, "application/json;charset=utf-8");
+        await MessageService.Success("已下載版本化備份。");
+    }
+
+    private async Task OnBackupFileSelected(InputFileChangeEventArgs e)
+    {
+        try
+        {
+            var file = e.File;
+            using var stream = file.OpenReadStream(maxAllowedSize: 2 * 1024 * 1024);
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+            backupText = await reader.ReadToEndAsync();
+            backupFileName = file.Name;
+            backupSummary = BuildSummary(backupText);
+            await MessageService.Success("已載入備份檔，請確認後再還原。");
+        }
+        catch (Exception ex)
+        {
+            backupText = "";
+            backupFileName = "";
+            backupSummary = "";
+            await MessageService.Error($"讀取備份檔失敗：{ex.Message}");
+        }
+    }
+
+    private async Task RestoreBackupAsync()
+    {
+        if (string.IsNullOrWhiteSpace(backupText))
+        {
+            await MessageService.Warning("請先選擇備份檔案。");
+            return;
+        }
+
+        await BackupService.RestoreAsync(backupText);
+        await MessageService.Success("已還原備份。");
+
+        backupText = "";
+        backupFileName = "";
+        backupSummary = "";
+    }
+
+    private Task ClearSelectedBackupAsync()
+    {
+        backupText = "";
+        backupFileName = "";
+        backupSummary = "";
+        return Task.CompletedTask;
+    }
+
+    private static string BuildSummary(string json)
+    {
+        if (!EasyLotteryBackupService.TryDeserializeBackupPackage(json, out var package) || package is null)
+        {
+            return "無法辨識版本化備份格式，將以相容模式嘗試還原。";
+        }
+
+        return $"版本 {package.BackupVersion}，建立於 {FormatDate(package.CreatedAtUtc)}";
+    }
+
+    private static string FormatDate(DateTime dateTime)
+    {
+        var local = dateTime.Kind == DateTimeKind.Utc ? dateTime.ToLocalTime() : dateTime;
+        return local.ToString("yyyy/MM/dd HH:mm:ss");
+    }
+}

--- a/src/EasyLotteryWasm/Program.cs
+++ b/src/EasyLotteryWasm/Program.cs
@@ -32,6 +32,7 @@ builder.Services.AddDistributedMemoryCache();
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 
 builder.Services.AddScoped<IEasyLotteryConfigStore, YamlEasyLotteryConfigStore>();
+builder.Services.AddScoped<EasyLotteryBackupService>();
 builder.Services.AddScoped<SystemSettingsService>();
 builder.Services.AddScoped<ActivityResultService>();
 

--- a/tests/EasyLotteryDomainTests/Services/EasyLotteryBackupServiceTests.cs
+++ b/tests/EasyLotteryDomainTests/Services/EasyLotteryBackupServiceTests.cs
@@ -1,0 +1,122 @@
+using System.Text.Json;
+using EasyLotteryDomain.Models.Config;
+using EasyLotteryDomain.Services;
+using EasyLotteryDomainTests.Helpers;
+
+namespace EasyLotteryDomainTests.Services
+{
+    [TestClass]
+    public class EasyLotteryBackupServiceTests
+    {
+        [TestMethod]
+        public async Task CreateBackupAsync_ReturnsVersionedPackageWithDocument()
+        {
+            var store = new InMemoryEasyLotteryConfigStore();
+            await store.SaveAsync(new EasyLotteryConfigDocument
+            {
+                ConfigVersion = 7,
+                SystemSettings = new LotterySystemSettings
+                {
+                    OpenAIKey = "test-key"
+                },
+                DrawingRules = new DrawingRuleSettings
+                {
+                    LevelRates = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["VIP"] = 5
+                    }
+                }
+            });
+
+            var service = new EasyLotteryBackupService(store);
+
+            var package = await service.CreateBackupAsync();
+
+            Assert.AreEqual(1, package.BackupVersion);
+            Assert.IsNotNull(package.Document);
+            Assert.AreEqual(7, package.Document.ConfigVersion);
+            Assert.AreEqual("test-key", package.Document.SystemSettings.OpenAIKey);
+            Assert.AreEqual(5, package.Document.DrawingRules.LevelRates["VIP"]);
+            Assert.AreNotEqual(default, package.CreatedAtUtc);
+        }
+
+        [TestMethod]
+        public async Task RestoreAsync_RestoresVersionedBackupPackage()
+        {
+            var store = new InMemoryEasyLotteryConfigStore();
+            var service = new EasyLotteryBackupService(store);
+            var package = new EasyLotteryBackupPackage
+            {
+                BackupVersion = 1,
+                CreatedAtUtc = new DateTime(2026, 3, 27, 1, 2, 3, DateTimeKind.Utc),
+                Document = new EasyLotteryConfigDocument
+                {
+                    ConfigVersion = 9,
+                    DrawingRulePresets = new List<DrawingRulePreset>
+                    {
+                        new()
+                        {
+                            Name = "Night Mode",
+                            Description = "黑夜版本",
+                            LevelRates = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+                            {
+                                ["A"] = 2,
+                                ["B"] = 3
+                            }
+                        }
+                    },
+                    ActivityResults = new List<ActivityResultRecord>
+                    {
+                        new()
+                        {
+                            Id = 99,
+                            ActivityType = ActivityResultType.PokeBox,
+                            ActivityName = "活動結果"
+                        }
+                    }
+                }
+            };
+
+            var json = service.SerializeBackup(package);
+
+            await service.RestoreAsync(json);
+
+            var restored = await store.LoadAsync();
+            Assert.AreEqual(9, restored.ConfigVersion);
+            Assert.AreEqual(1, restored.DrawingRulePresets.Count);
+            Assert.AreEqual("Night Mode", restored.DrawingRulePresets[0].Name);
+            Assert.AreEqual(2, restored.DrawingRulePresets[0].LevelRates["A"]);
+            Assert.AreEqual(1, restored.ActivityResults.Count);
+            Assert.AreEqual(99, restored.ActivityResults[0].Id);
+        }
+
+        [TestMethod]
+        public async Task RestoreAsync_AcceptsLegacyDocumentJson()
+        {
+            var store = new InMemoryEasyLotteryConfigStore();
+            var service = new EasyLotteryBackupService(store);
+            var document = new EasyLotteryConfigDocument
+            {
+                ConfigVersion = 3,
+                DrawingRules = new DrawingRuleSettings
+                {
+                    LevelRates = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["VIP"] = 8
+                    }
+                }
+            };
+
+            var json = JsonSerializer.Serialize(document, new JsonSerializerOptions(JsonSerializerDefaults.Web)
+            {
+                WriteIndented = true
+            });
+
+            await service.RestoreAsync(json);
+
+            var restored = await store.LoadAsync();
+            Assert.AreEqual(3, restored.ConfigVersion);
+            Assert.AreEqual(8, restored.DrawingRules.LevelRates["VIP"]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add a versioned backup package for the shared EasyLottery config document.
- Add a backup / restore page for exporting and importing the whole configuration state.
- Keep the existing YAML storage format untouched while adding a separate backup format.

## What changed
- Added `EasyLotteryBackupPackage` with `BackupVersion`, `CreatedAtUtc`, and the shared `EasyLotteryConfigDocument`.
- Added `EasyLotteryBackupService` to create and restore backups.
- Added a new `/system/backup` page with download and restore actions.
- Added a navigation entry under system settings.
- Added tests for versioned backup export, versioned restore, and legacy raw document restore.

## Why
- Templates, settings, and activity results all live in the shared config document, so backing up that document covers all important state.
- A versioned envelope gives us room to evolve the backup format later without breaking restore.
- The restore path accepts the new backup envelope and the legacy raw config JSON to avoid locking users into only one format.

## Verification
- `dotnet restore EasyLottery.generated.sln`
- `dotnet test EasyLottery.generated.sln --configuration Release --no-restore`
- Result: all API and domain tests passed.

## Notes
- This implements issue #29.
- Current backup exports are versioned JSON packages, while the existing YAML persistence remains unchanged.
- The restore flow overwrites the current config document, so the UI warns before applying it.