### PR TITLE
feat: add audit trail for templates and settings

### DIFF
--- a/src/EasyLotteryDomain/Models/Config/EasyLotteryConfigDocument.cs
+++ b/src/EasyLotteryDomain/Models/Config/EasyLotteryConfigDocument.cs
@@ -21,6 +21,7 @@ namespace EasyLotteryDomain.Models.Config
         public DrawingRuleSettings DrawingRules { get; set; } = new();
         public VisualStyleSettings VisualStyle { get; set; } = new();
         public OvertimeOverlaySettings OvertimeOverlay { get; set; } = new();
+        public List<ChangeAuditRecord> AuditRecords { get; set; } = new();
     }
 
     public sealed class LotterySystemSettings
@@ -28,6 +29,8 @@ namespace EasyLotteryDomain.Models.Config
         public YouTubeApiSettings YouTube { get; set; } = new();
 
         public string OpenAIKey { get; set; } = "";
+
+        public AuditSettings Audit { get; set; } = new();
     }
 
     public sealed class YouTubeApiSettings
@@ -52,10 +55,34 @@ namespace EasyLotteryDomain.Models.Config
         public int NextRouletteSegmentId { get; set; } = 1;
 
         public int NextActivityResultId { get; set; } = 1;
+
+        public int NextAuditRecordId { get; set; } = 1;
     }
 
     public sealed class DrawingRuleSettings
     {
         public Dictionary<string, int> LevelRates { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+    }
+
+    public sealed class AuditSettings
+    {
+        public string ActorName { get; set; } = "本機操作";
+    }
+
+    public sealed class ChangeAuditRecord
+    {
+        public int Id { get; set; }
+
+        public DateTime ChangedAtUtc { get; set; } = DateTime.UtcNow;
+
+        public string ChangedBy { get; set; } = "本機操作";
+
+        public string Category { get; set; } = "";
+
+        public string Action { get; set; } = "";
+
+        public string TargetName { get; set; } = "";
+
+        public string Details { get; set; } = "";
     }
 }

--- a/src/EasyLotteryDomain/Services/EasyLotteryAuditService.cs
+++ b/src/EasyLotteryDomain/Services/EasyLotteryAuditService.cs
@@ -1,0 +1,64 @@
+using EasyLotteryDomain.Models.Config;
+
+namespace EasyLotteryDomain.Services
+{
+    public sealed class EasyLotteryAuditService
+    {
+        private const int MaxAuditRecords = 200;
+
+        private readonly IEasyLotteryConfigStore _configStore;
+
+        public EasyLotteryAuditService(IEasyLotteryConfigStore configStore)
+        {
+            _configStore = configStore;
+        }
+
+        public async Task<List<ChangeAuditRecord>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            var document = await _configStore.LoadAsync(cancellationToken);
+            return document.AuditRecords
+                .OrderByDescending(record => record.ChangedAtUtc)
+                .ThenByDescending(record => record.Id)
+                .ToList();
+        }
+
+        public async Task RecordAsync(
+            string category,
+            string action,
+            string targetName,
+            string details = "",
+            string? changedBy = null,
+            CancellationToken cancellationToken = default)
+        {
+            var document = await _configStore.LoadAsync(cancellationToken);
+            var actorName = string.IsNullOrWhiteSpace(changedBy)
+                ? document.SystemSettings?.Audit?.ActorName
+                : changedBy;
+
+            var record = new ChangeAuditRecord
+            {
+                Id = document.IdSequence.NextAuditRecordId++,
+                ChangedAtUtc = DateTime.UtcNow,
+                ChangedBy = string.IsNullOrWhiteSpace(actorName) ? "本機操作" : actorName.Trim(),
+                Category = category.Trim(),
+                Action = action.Trim(),
+                TargetName = targetName.Trim(),
+                Details = details.Trim()
+            };
+
+            document.AuditRecords.Add(record);
+            if (document.AuditRecords.Count > MaxAuditRecords)
+            {
+                document.AuditRecords = document.AuditRecords
+                    .OrderByDescending(item => item.ChangedAtUtc)
+                    .ThenByDescending(item => item.Id)
+                    .Take(MaxAuditRecords)
+                    .OrderBy(item => item.ChangedAtUtc)
+                    .ThenBy(item => item.Id)
+                    .ToList();
+            }
+
+            await _configStore.SaveAsync(document, cancellationToken);
+        }
+    }
+}

--- a/src/EasyLotteryDomain/Services/PokeService.cs
+++ b/src/EasyLotteryDomain/Services/PokeService.cs
@@ -10,12 +10,14 @@ namespace EasyLotteryDomain.Services
     public class PokeService
     {
         private readonly IEasyLotteryConfigStore _configStore;
+        private readonly EasyLotteryAuditService? _auditService;
 
         private static readonly Random _random = Random.Shared;
 
-        public PokeService(IEasyLotteryConfigStore configStore)
+        public PokeService(IEasyLotteryConfigStore configStore, EasyLotteryAuditService? auditService = null)
         {
             _configStore = configStore;
+            _auditService = auditService;
         }
 
         // ── CRUD ──────────────────────────────────────────────────────────────
@@ -30,6 +32,7 @@ namespace EasyLotteryDomain.Services
             document.IdSequence.NextPokeCellId = Math.Max(document.IdSequence.NextPokeCellId, template.Cells.Select(c => c.Id).DefaultIfEmpty(document.IdSequence.NextPokeCellId - 1).Max() + 1);
             document.PokeTemplates.Add(template);
             await _configStore.SaveAsync(document);
+            await RecordAuditAsync(document, "建立戳戳樂模板", template.Name, $"模板 ID {template.Id}");
             return template;
         }
 
@@ -49,6 +52,7 @@ namespace EasyLotteryDomain.Services
             var existingIndex = document.PokeTemplates.FindIndex(t => t.Id == template.Id);
             document.PokeTemplates[existingIndex] = template;
             await _configStore.SaveAsync(document);
+            await RecordAuditAsync(document, "更新戳戳樂模板", template.Name, $"模板 ID {template.Id}");
         }
 
         public async Task DeleteTemplateAsync(int id)
@@ -58,6 +62,7 @@ namespace EasyLotteryDomain.Services
                 ?? throw new InvalidOperationException($"Template {id} not found.");
             document.PokeTemplates.Remove(template);
             await _configStore.SaveAsync(document);
+            await RecordAuditAsync(document, "刪除戳戳樂模板", template.Name, $"模板 ID {template.Id}");
         }
 
         public async Task<PokeTemplate> DuplicateTemplateAsync(int id)
@@ -100,7 +105,9 @@ namespace EasyLotteryDomain.Services
                     .ToList()
             };
 
-            return await CreateTemplateAsync(duplicate);
+            var created = await CreateTemplateAsync(duplicate);
+            await RecordAuditAsync(document, "複製戳戳樂模板", created.Name, $"來源模板 ID {source.Id}");
+            return created;
         }
 
         public async Task<List<PokeTemplate>> ListTemplatesAsync()
@@ -128,6 +135,7 @@ namespace EasyLotteryDomain.Services
             template.PublicationStatus = status;
             template.UpdatedAt = DateTime.UtcNow;
             await _configStore.SaveAsync(document);
+            await RecordAuditAsync(document, status == TemplatePublicationStatus.Published ? "發布戳戳樂模板" : "轉為戳戳樂草稿", template.Name, $"模板 ID {template.Id}");
             return template;
         }
 
@@ -246,6 +254,7 @@ namespace EasyLotteryDomain.Services
             }
 
             await _configStore.SaveAsync(document);
+            await RecordAuditAsync(document, "建立內建戳戳樂模板", "預設模板", "初始化 3 組內建模板");
         }
 
         // ── Helpers ───────────────────────────────────────────────────────────
@@ -325,6 +334,14 @@ namespace EasyLotteryDomain.Services
             }
 
             return candidate;
+        }
+
+        private async Task RecordAuditAsync(EasyLotteryDomain.Models.Config.EasyLotteryConfigDocument document, string action, string targetName, string details)
+        {
+            if (_auditService != null)
+            {
+                await _auditService.RecordAsync("Template", action, targetName, details, changedBy: document.SystemSettings.Audit.ActorName);
+            }
         }
 
         public static List<PokeTemplate> BuildDefaultTemplates()

--- a/src/EasyLotteryDomain/Services/RouletteService.cs
+++ b/src/EasyLotteryDomain/Services/RouletteService.cs
@@ -10,14 +10,16 @@ namespace EasyLotteryDomain.Services
     public class RouletteService
     {
         private readonly IEasyLotteryConfigStore _configStore;
+        private readonly EasyLotteryAuditService? _auditService;
         private static readonly Random _random = Random.Shared;
 
         private const double MinRevolutions = 5;
         private const double SegmentOffsetFactor = 0.6;
 
-        public RouletteService(IEasyLotteryConfigStore configStore)
+        public RouletteService(IEasyLotteryConfigStore configStore, EasyLotteryAuditService? auditService = null)
         {
             _configStore = configStore;
+            _auditService = auditService;
         }
 
         // ── CRUD ──────────────────────────────────────────────────────────────
@@ -32,6 +34,7 @@ namespace EasyLotteryDomain.Services
             document.IdSequence.NextRouletteSegmentId = Math.Max(document.IdSequence.NextRouletteSegmentId, template.Segments.Select(s => s.Id).DefaultIfEmpty(document.IdSequence.NextRouletteSegmentId - 1).Max() + 1);
             document.RouletteTemplates.Add(template);
             await _configStore.SaveAsync(document);
+            await RecordAuditAsync(document, "建立轉盤模板", template.Name, $"模板 ID {template.Id}");
             return template;
         }
 
@@ -51,6 +54,7 @@ namespace EasyLotteryDomain.Services
             var existingIndex = document.RouletteTemplates.FindIndex(t => t.Id == template.Id);
             document.RouletteTemplates[existingIndex] = template;
             await _configStore.SaveAsync(document);
+            await RecordAuditAsync(document, "更新轉盤模板", template.Name, $"模板 ID {template.Id}");
         }
 
         public async Task DeleteTemplateAsync(int id)
@@ -60,6 +64,7 @@ namespace EasyLotteryDomain.Services
                 ?? throw new InvalidOperationException($"Template {id} not found.");
             document.RouletteTemplates.Remove(template);
             await _configStore.SaveAsync(document);
+            await RecordAuditAsync(document, "刪除轉盤模板", template.Name, $"模板 ID {template.Id}");
         }
 
         public async Task<RouletteTemplate> DuplicateTemplateAsync(int id)
@@ -96,7 +101,9 @@ namespace EasyLotteryDomain.Services
                     .ToList()
             };
 
-            return await CreateTemplateAsync(duplicate);
+            var created = await CreateTemplateAsync(duplicate);
+            await RecordAuditAsync(document, "複製轉盤模板", created.Name, $"來源模板 ID {source.Id}");
+            return created;
         }
 
         public async Task<List<RouletteTemplate>> ListTemplatesAsync()
@@ -124,6 +131,7 @@ namespace EasyLotteryDomain.Services
             template.PublicationStatus = status;
             template.UpdatedAt = DateTime.UtcNow;
             await _configStore.SaveAsync(document);
+            await RecordAuditAsync(document, status == TemplatePublicationStatus.Published ? "發布轉盤模板" : "轉為轉盤草稿", template.Name, $"模板 ID {template.Id}");
             return template;
         }
 
@@ -250,6 +258,7 @@ namespace EasyLotteryDomain.Services
             }
 
             await _configStore.SaveAsync(document);
+            await RecordAuditAsync(document, "建立內建轉盤模板", "預設模板", "初始化 3 組內建模板");
         }
 
         private async Task<EasyLotteryDomain.Models.Config.EasyLotteryConfigDocument> LoadDocumentAsync(bool ensureBuiltIns)
@@ -279,6 +288,14 @@ namespace EasyLotteryDomain.Services
             }
 
             return true;
+        }
+
+        private async Task RecordAuditAsync(EasyLotteryDomain.Models.Config.EasyLotteryConfigDocument document, string action, string targetName, string details)
+        {
+            if (_auditService != null)
+            {
+                await _auditService.RecordAsync("Template", action, targetName, details, changedBy: document.SystemSettings.Audit.ActorName);
+            }
         }
 
         private static void PrepareTemplateForSave(RouletteTemplate template, int nextSegmentId)

--- a/src/EasyLotteryDomain/Services/SystemSettingsService.cs
+++ b/src/EasyLotteryDomain/Services/SystemSettingsService.cs
@@ -5,10 +5,12 @@ namespace EasyLotteryDomain.Services
     public class SystemSettingsService
     {
         private readonly IEasyLotteryConfigStore _configStore;
+        private readonly EasyLotteryAuditService? _auditService;
 
-        public SystemSettingsService(IEasyLotteryConfigStore configStore)
+        public SystemSettingsService(IEasyLotteryConfigStore configStore, EasyLotteryAuditService? auditService = null)
         {
             _configStore = configStore;
+            _auditService = auditService;
         }
 
         public async Task<LotterySystemSettings> GetSettingsAsync(CancellationToken cancellationToken = default)
@@ -28,6 +30,10 @@ namespace EasyLotteryDomain.Services
             var document = await _configStore.LoadAsync(cancellationToken);
             document.SystemSettings = settings ?? new LotterySystemSettings();
             await _configStore.SaveAsync(document, cancellationToken);
+            if (_auditService != null)
+            {
+                await _auditService.RecordAsync("SystemSettings", "更新系統設定", "系統設定", changedBy: document.SystemSettings.Audit.ActorName, cancellationToken: cancellationToken);
+            }
         }
 
         public async Task UpdateYouTubeSettingsAsync(Action<YouTubeApiSettings> updateAction, CancellationToken cancellationToken = default)
@@ -35,6 +41,10 @@ namespace EasyLotteryDomain.Services
             var document = await _configStore.LoadAsync(cancellationToken);
             updateAction(document.SystemSettings.YouTube);
             await _configStore.SaveAsync(document, cancellationToken);
+            if (_auditService != null)
+            {
+                await _auditService.RecordAsync("SystemSettings", "更新 YouTube 設定", "YouTube", changedBy: document.SystemSettings.Audit.ActorName, cancellationToken: cancellationToken);
+            }
         }
     }
 }

--- a/src/EasyLotteryWasm/Layout/NavMenu.razor
+++ b/src/EasyLotteryWasm/Layout/NavMenu.razor
@@ -73,6 +73,11 @@
                     YouTube 登入
                 </NavLink>
             </div>
+            <div class="nav-item px-3 nav-sub-item">
+                <NavLink class="nav-link" href="system/audit">
+                    審計紀錄
+                </NavLink>
+            </div>
         }
 
     </nav>

--- a/src/EasyLotteryWasm/Pages/Config/AuditSettings.razor
+++ b/src/EasyLotteryWasm/Pages/Config/AuditSettings.razor
@@ -1,0 +1,104 @@
+@page "/system/audit"
+@using EasyLotteryDomain.Models.Config
+
+@inject SystemSettingsService SystemSettingsService
+@inject EasyLotteryAuditService AuditService
+@inject IMessageService MessageService
+
+<PageTitle>審計紀錄</PageTitle>
+
+<Card Margin="Margin.Is3.FromBottom">
+    <CardHeader>
+        <CardTitle>審計紀錄</CardTitle>
+    </CardHeader>
+    <CardBody>
+        <CardText>
+            <p>這裡會記錄模板與設定的變更，方便追蹤誰在什麼時間改了什麼。</p>
+        </CardText>
+
+        <Row>
+            <Column ColumnSize="ColumnSize.Is6">
+                <Field>
+                    <FieldLabel>操作名稱</FieldLabel>
+                    <InputText @bind-Value="auditActorName" />
+                </Field>
+                <Button Color="Color.Primary" Clicked="@SaveActorNameAsync">儲存操作名稱</Button>
+            </Column>
+            <Column ColumnSize="ColumnSize.Is6">
+                <Alert Color="Color.Info" Visible>
+                    <AlertMessage>說明</AlertMessage>
+                    <AlertDescription>
+                        變更設定或模板時，系統會使用這個名稱寫入審計紀錄。若留空，預設會使用「本機操作」。
+                    </AlertDescription>
+                </Alert>
+            </Column>
+        </Row>
+    </CardBody>
+</Card>
+
+<Card>
+    <CardHeader>
+        <CardTitle>最近變更</CardTitle>
+    </CardHeader>
+    <CardBody>
+        @if (!auditRecords.Any())
+        {
+            <p class="text-muted mb-0">目前還沒有審計紀錄。</p>
+        }
+        else
+        {
+            <Table Responsive Striped Hoverable>
+                <TableHeader>
+                    <TableRow>
+                        <TableHeaderCell>時間</TableHeaderCell>
+                        <TableHeaderCell>誰</TableHeaderCell>
+                        <TableHeaderCell>類別</TableHeaderCell>
+                        <TableHeaderCell>動作</TableHeaderCell>
+                        <TableHeaderCell>對象</TableHeaderCell>
+                        <TableHeaderCell>內容</TableHeaderCell>
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    @foreach (var record in auditRecords)
+                    {
+                        <TableRow>
+                            <TableRowCell>@FormatDate(record.ChangedAtUtc)</TableRowCell>
+                            <TableRowCell>@record.ChangedBy</TableRowCell>
+                            <TableRowCell>@record.Category</TableRowCell>
+                            <TableRowCell>@record.Action</TableRowCell>
+                            <TableRowCell>@record.TargetName</TableRowCell>
+                            <TableRowCell>@record.Details</TableRowCell>
+                        </TableRow>
+                    }
+                </TableBody>
+            </Table>
+        }
+    </CardBody>
+</Card>
+
+@code {
+    private string auditActorName = "";
+    private List<ChangeAuditRecord> auditRecords = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        var settings = await SystemSettingsService.GetSettingsAsync();
+        auditActorName = settings.Audit.ActorName;
+        auditRecords = await AuditService.ListAsync();
+    }
+
+    private async Task SaveActorNameAsync()
+    {
+        var settings = await SystemSettingsService.GetSettingsAsync();
+        settings.Audit.ActorName = string.IsNullOrWhiteSpace(auditActorName) ? "本機操作" : auditActorName.Trim();
+        await SystemSettingsService.SaveSettingsAsync(settings);
+        auditRecords = await AuditService.ListAsync();
+        await MessageService.Success("已儲存操作名稱。");
+    }
+
+    private static string FormatDate(DateTime dateTime)
+    {
+        var local = dateTime.Kind == DateTimeKind.Utc ? dateTime.ToLocalTime() : dateTime;
+        return local.ToString("yyyy/MM/dd HH:mm:ss");
+    }
+}

--- a/src/EasyLotteryWasm/Pages/Home.razor
+++ b/src/EasyLotteryWasm/Pages/Home.razor
@@ -19,6 +19,7 @@
 @inject YouTubeServiceHelper youTubeServiceHelper
 @inject OvertimeFeedClient OvertimeFeedClient
 @inject IEasyLotteryConfigStore ConfigStore
+@inject EasyLotteryAuditService AuditService
 @inject ILogger<YouTubeServiceHelper> Logger
 @implements IDisposable
 

--- a/src/EasyLotteryWasm/Pages/Home.razor.cs
+++ b/src/EasyLotteryWasm/Pages/Home.razor.cs
@@ -103,6 +103,7 @@ public partial class Home
         }
 
         await ConfigStore.SaveAsync(document);
+        await AuditService.RecordAsync("Template", "儲存規則模板", preset.Name, $"模板包含 {preset.LevelRates.Count} 個等級", changedBy: document.SystemSettings.Audit.ActorName);
         await LoadRulePresetsAsync();
         selectedRulePresetName = preset.Name;
         await MessageService.Success($"已儲存規則模板「{preset.Name}」。");
@@ -128,6 +129,7 @@ public partial class Home
 
         SetLevelRates(preset.LevelRates);
         await PersistLevelRatesAsync();
+        await AuditService.RecordAsync("Template", "套用規則模板", preset.Name, $"套用 {preset.LevelRates.Count} 個等級倍率", changedBy: document.SystemSettings.Audit.ActorName);
         await LoadDrawPrizeAsync();
         await MessageService.Success($"已套用規則模板「{preset.Name}」。");
     }
@@ -141,6 +143,7 @@ public partial class Home
         }
 
         await PersistLevelRatesAsync();
+        await AuditService.RecordAsync("Settings", "更新抽獎倍率", "倍率設定", $"共 {levelRate.Count} 個等級", changedBy: (await ConfigStore.LoadAsync()).SystemSettings.Audit.ActorName);
         await LoadDrawPrizeAsync();
         await MessageService.Success("已儲存倍率設定。");
     }
@@ -202,6 +205,7 @@ public partial class Home
 
         document.DrawingRulePresets.Remove(preset);
         await ConfigStore.SaveAsync(document);
+        await AuditService.RecordAsync("Template", "刪除規則模板", preset.Name, $"模板名稱 {preset.Name}", changedBy: document.SystemSettings.Audit.ActorName);
         await LoadRulePresetsAsync();
 
         if (string.Equals(selectedRulePresetName, presetName, StringComparison.OrdinalIgnoreCase))

--- a/src/EasyLotteryWasm/Program.cs
+++ b/src/EasyLotteryWasm/Program.cs
@@ -37,6 +37,7 @@ builder.Services.AddScoped<SystemSettingsService>();
 builder.Services.AddScoped<ActivityResultService>();
 builder.Services.AddScoped<VisualStyleService>();
 builder.Services.AddScoped<OvertimeFeedClient>();
+builder.Services.AddScoped<EasyLotteryAuditService>();
 
 // 添加服務
 builder.Services.AddScoped<YouTubeServiceHelper>();

--- a/src/EasyLotteryWasm/Services/YamlEasyLotteryConfigStore.cs
+++ b/src/EasyLotteryWasm/Services/YamlEasyLotteryConfigStore.cs
@@ -132,6 +132,7 @@ namespace EasyLotteryWasm.Services
             document ??= new EasyLotteryConfigDocument();
             document.SystemSettings ??= new LotterySystemSettings();
             document.SystemSettings.YouTube ??= new YouTubeApiSettings();
+            document.SystemSettings.Audit ??= new AuditSettings();
             document.IdSequence ??= new LotteryIdSequence();
             document.PokeTemplates ??= new List<PokeTemplate>();
             document.RouletteTemplates ??= new List<RouletteTemplate>();
@@ -147,6 +148,7 @@ namespace EasyLotteryWasm.Services
                 ? "festival-stage"
                 : document.OvertimeOverlay.ThemeKey.Trim();
             document.OvertimeOverlay.MaxVisibleItems = Math.Max(1, document.OvertimeOverlay.MaxVisibleItems);
+            document.AuditRecords ??= new List<ChangeAuditRecord>();
 
             foreach (var template in document.PokeTemplates)
             {
@@ -168,6 +170,11 @@ namespace EasyLotteryWasm.Services
                 NormalizeDrawingRulePreset(preset);
             }
 
+            foreach (var auditRecord in document.AuditRecords)
+            {
+                NormalizeAuditRecord(auditRecord);
+            }
+
             NormalizeDrawingRuleSettings(document.DrawingRules);
 
             document.IdSequence.NextPokeTemplateId = Math.Max(document.IdSequence.NextPokeTemplateId, document.PokeTemplates.Select(t => t.Id).DefaultIfEmpty(0).Max() + 1);
@@ -175,6 +182,8 @@ namespace EasyLotteryWasm.Services
             document.IdSequence.NextRouletteTemplateId = Math.Max(document.IdSequence.NextRouletteTemplateId, document.RouletteTemplates.Select(t => t.Id).DefaultIfEmpty(0).Max() + 1);
             document.IdSequence.NextRouletteSegmentId = Math.Max(document.IdSequence.NextRouletteSegmentId, document.RouletteTemplates.SelectMany(t => t.Segments).Select(s => s.Id).DefaultIfEmpty(0).Max() + 1);
             document.IdSequence.NextActivityResultId = Math.Max(document.IdSequence.NextActivityResultId, document.ActivityResults.Select(result => result.Id).DefaultIfEmpty(0).Max() + 1);
+            document.IdSequence.NextAuditRecordId = Math.Max(document.IdSequence.NextAuditRecordId, document.AuditRecords.Select(record => record.Id).DefaultIfEmpty(0).Max() + 1);
+            document.SystemSettings.Audit.ActorName = string.IsNullOrWhiteSpace(document.SystemSettings.Audit.ActorName) ? "本機操作" : document.SystemSettings.Audit.ActorName.Trim();
 
             return document;
         }
@@ -282,6 +291,15 @@ namespace EasyLotteryWasm.Services
             {
                 settings.LevelRates[key] = Math.Max(1, settings.LevelRates[key]);
             }
+        }
+
+        private static void NormalizeAuditRecord(ChangeAuditRecord auditRecord)
+        {
+            auditRecord.ChangedBy ??= "本機操作";
+            auditRecord.Category ??= "";
+            auditRecord.Action ??= "";
+            auditRecord.TargetName ??= "";
+            auditRecord.Details ??= "";
         }
     }
 }

--- a/tests/EasyLotteryDomainTests/Services/EasyLotteryAuditServiceTests.cs
+++ b/tests/EasyLotteryDomainTests/Services/EasyLotteryAuditServiceTests.cs
@@ -1,0 +1,55 @@
+using EasyLotteryDomain.Models.Config;
+using EasyLotteryDomain.Services;
+using EasyLotteryDomainTests.Helpers;
+
+namespace EasyLotteryDomainTests.Services
+{
+    [TestClass]
+    public class EasyLotteryAuditServiceTests
+    {
+        [TestMethod]
+        public async Task RecordAsync_AppendsAuditRecordWithConfiguredActor()
+        {
+            var store = new InMemoryEasyLotteryConfigStore();
+            await store.SaveAsync(new EasyLotteryConfigDocument
+            {
+                SystemSettings = new LotterySystemSettings
+                {
+                    Audit = new AuditSettings
+                    {
+                        ActorName = "主播 A"
+                    }
+                }
+            });
+
+            var service = new EasyLotteryAuditService(store);
+
+            await service.RecordAsync("Template", "更新模板", "經典模板", "測試內容");
+
+            var document = await store.LoadAsync();
+            Assert.AreEqual(1, document.AuditRecords.Count);
+            var record = document.AuditRecords[0];
+            Assert.AreEqual("主播 A", record.ChangedBy);
+            Assert.AreEqual("Template", record.Category);
+            Assert.AreEqual("更新模板", record.Action);
+            Assert.AreEqual("經典模板", record.TargetName);
+            Assert.AreEqual("測試內容", record.Details);
+        }
+
+        [TestMethod]
+        public async Task RecordAsync_TrimsAuditRecordsToRecentLimit()
+        {
+            var store = new InMemoryEasyLotteryConfigStore();
+            var service = new EasyLotteryAuditService(store);
+
+            for (var index = 0; index < 205; index++)
+            {
+                await service.RecordAsync("Settings", $"動作 {index}", "系統設定", $"內容 {index}", changedBy: "系統");
+            }
+
+            var document = await store.LoadAsync();
+            Assert.AreEqual(200, document.AuditRecords.Count);
+            Assert.AreEqual("動作 204", document.AuditRecords.Last().Action);
+        }
+    }
+}

--- a/tests/EasyLotteryDomainTests/Services/SystemSettingsServiceAuditTests.cs
+++ b/tests/EasyLotteryDomainTests/Services/SystemSettingsServiceAuditTests.cs
@@ -1,0 +1,32 @@
+using EasyLotteryDomain.Models.Config;
+using EasyLotteryDomain.Services;
+using EasyLotteryDomainTests.Helpers;
+
+namespace EasyLotteryDomainTests.Services
+{
+    [TestClass]
+    public class SystemSettingsServiceAuditTests
+    {
+        [TestMethod]
+        public async Task SaveSettingsAsync_WritesAuditRecord()
+        {
+            var store = new InMemoryEasyLotteryConfigStore();
+            var auditService = new EasyLotteryAuditService(store);
+            var service = new SystemSettingsService(store, auditService);
+
+            await service.SaveSettingsAsync(new LotterySystemSettings
+            {
+                Audit = new AuditSettings
+                {
+                    ActorName = "管理員"
+                },
+                OpenAIKey = "secret"
+            });
+
+            var document = await store.LoadAsync();
+            Assert.AreEqual(1, document.AuditRecords.Count);
+            Assert.AreEqual("SystemSettings", document.AuditRecords[0].Category);
+            Assert.AreEqual("管理員", document.AuditRecords[0].ChangedBy);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add an audit trail that records who changed templates and settings.
- Add a dedicated audit page so the operator name can be set and recent changes can be reviewed.
- Persist audit records in the shared EasyLottery config document so the history travels with the rest of the app state.

## What changed
- Added `ChangeAuditRecord` and `AuditSettings` to the shared config model.
- Added `EasyLotteryAuditService` to append and list audit entries.
- Added normalization support for audit records in the YAML config store.
- Wired audit recording into system settings updates, Poke Box template changes, Roulette template changes, and drawing rule preset changes.
- Added a new `/system/audit` page to set the operator name and inspect recent audit entries.
- Added tests for the audit service and system settings audit recording.

## Why
- Template and settings changes were previously invisible after the fact, which made it hard to answer who changed what.
- Keeping the audit trail inside the shared config document means it is saved and restored together with the rest of the app state.
- A dedicated operator name field is a practical way to record a meaningful author name in the current app, since there is no shared authenticated user identity yet.

## Verification
- `dotnet restore EasyLottery.generated.sln`
- `dotnet test EasyLottery.generated.sln --configuration Release --no-restore`
- Result: all API and domain tests passed.

## Notes
- This implements issue #30.
- The audit trail is capped to recent entries so the config document does not grow without bound.
- Existing template and settings flows continue to work normally; the audit entries are recorded as a side effect after successful saves.