### PR TITLE
feat: move overtime to activity

### DIFF
--- a/src/EasyLottery/src-tauri/tauri.conf.json
+++ b/src/EasyLottery/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "build": {
-    "beforeDevCommand": "ASPNETCORE_URLS=http://0.0.0.0:22399 dotnet watch run --project ../../EasyLotteryWasm/EasyLotteryWasm.csproj --non-interactive",
+    "beforeDevCommand": "ASPNETCORE_URLS=http://0.0.0.0:18930 dotnet watch run --project ../../EasyLotteryWasm/EasyLotteryWasm.csproj --non-interactive",
     "beforeBuildCommand": "dotnet publish --self-contained -c release ../../EasyLotteryWasm/EasyLotteryWasm.csproj -o ../dist",
-    "devPath": "http://localhost:22399/",
+    "devPath": "http://localhost:18930/",
     "distDir": "../dist/wwwroot",
     "withGlobalTauri": true
   },

--- a/src/EasyLotteryWasm/Layout/NavMenu.razor
+++ b/src/EasyLotteryWasm/Layout/NavMenu.razor
@@ -43,6 +43,11 @@
                     活動結果
                 </NavLink>
             </div>
+            <div class="nav-item px-3 nav-sub-item">
+                <NavLink class="nav-link" href="activity/overtime">
+                    加班台
+                </NavLink>
+            </div>
         }
 
         @* === 3. 系統配置 === *@
@@ -56,16 +61,6 @@
             <div class="nav-item px-3 nav-sub-item">
                 <NavLink class="nav-link" href="system/payment">
                     支付配置
-                </NavLink>
-            </div>
-            <div class="nav-item px-3 nav-sub-item">
-                <NavLink class="nav-link" href="system/visual-styles">
-                    視覺風格
-                </NavLink>
-            </div>
-            <div class="nav-item px-3 nav-sub-item">
-                <NavLink class="nav-link" href="system/overtime">
-                    加班台
                 </NavLink>
             </div>
             <div class="nav-item px-3 nav-sub-item">

--- a/src/EasyLotteryWasm/Pages/Config/OvertimeOverlay.razor
+++ b/src/EasyLotteryWasm/Pages/Config/OvertimeOverlay.razor
@@ -1,4 +1,4 @@
-@page "/system/overtime"
+@page "/activity/overtime"
 @using EasyLotteryDomain.Models.Config
 @using EasyLotteryDomain.Models.Overtime
 @using EasyLotteryWasm.Models
@@ -27,7 +27,7 @@ else
                 <div>
                     <div class="overtime-eyebrow">LIVE SUPPORT OVERLAY</div>
                     <h2 class="overtime-title">加班台設定</h2>
-                    <div class="overtime-subtitle">設定直播加班台樣式、啟用狀態與事件來源。</div>
+                    <div class="overtime-subtitle">設定直播加班台的啟用狀態、事件來源與畫面樣式。</div>
                 </div>
                 <div class="overtime-actions">
                     <Button Color="Color.Secondary" Clicked="@CopyOverlayUrlAsync">複製 OBS 網址</Button>

--- a/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
+++ b/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
@@ -6,8 +6,6 @@
 @using EasyLotteryWasm.Models
 @inject IEasyLotteryConfigStore ConfigStore
 @inject OvertimeFeedClient OvertimeFeedClient
-@inject NavigationManager NavigationManager
-@inject IJSRuntime JSRuntime
 
 <PageTitle>加班台 - OBS</PageTitle>
 
@@ -21,31 +19,11 @@ else
 {
     <div class="overtime-overlay" style="@ThemeStyle">
         <div class="overtime-shell">
-            <div class="overtime-topbar">
-                <div>
-                    <div class="overtime-eyebrow">SUPPORT OVERLAY</div>
-                    <div class="overtime-title">@settings.Title</div>
-                    <div class="overtime-subtitle">@settings.Subtitle</div>
-                </div>
-                <div class="overtime-topbar-actions">
-                    <button class="overtime-secondary-btn" @onclick="@CopyOverlayUrlAsync">複製來源網址</button>
-                    <button class="overtime-secondary-btn" @onclick="@ReloadAsync">重新載入</button>
-                </div>
-            </div>
-
-            <div class="overtime-status-panel">
-                <span class="overtime-status-pill">風格：@CurrentTheme.Name</span>
-                <span class="overtime-status-pill">最大顯示：@settings.MaxVisibleItems 筆</span>
-                <span class="overtime-status-pill">金額：@(settings.ShowAmounts ? "顯示" : "隱藏")</span>
-                <span class="overtime-status-pill">頭像：@(settings.ShowAvatars ? "顯示" : "隱藏")</span>
-                <span class="overtime-status-pill">來源：@OverlayUrl</span>
-            </div>
-
             @if (!settings.IsEnabled)
             {
                 <div class="overtime-disabled-panel">
                     <div class="overtime-disabled-title">加班台尚未啟用</div>
-                    <div class="overtime-disabled-subtitle">請到「系統配置 / 加班台」開啟後，這個畫面才會開始顯示 SuperChat 與綠界 Donate。</div>
+                    <div class="overtime-disabled-subtitle">請到「活動配置 / 加班台」開啟後，這個畫面才會開始顯示 SuperChat 與綠界 Donate。</div>
                 </div>
             }
             else if (!events.Any())
@@ -158,81 +136,6 @@ else
         z-index: 1;
     }
 
-    .overtime-topbar {
-        display: flex;
-        justify-content: space-between;
-        gap: 16px;
-        flex-wrap: wrap;
-        padding: 18px 20px;
-        border-radius: 24px;
-        background: color-mix(in srgb, var(--overtime-surface) 88%, transparent);
-        border: 1px solid var(--overtime-surface-border);
-    }
-
-    .overtime-eyebrow {
-        font-size: 0.72rem;
-        font-weight: 800;
-        letter-spacing: 0.24em;
-        opacity: 0.7;
-        text-transform: uppercase;
-    }
-
-    .overtime-title {
-        margin-top: 4px;
-        font-size: 2.1rem;
-        font-weight: 900;
-        line-height: 1.1;
-    }
-
-    .overtime-subtitle {
-        margin-top: 4px;
-        font-size: 0.98rem;
-        opacity: 0.86;
-    }
-
-    .overtime-topbar-actions {
-        display: flex;
-        gap: 8px;
-        flex-wrap: wrap;
-        align-items: flex-start;
-        justify-content: flex-end;
-    }
-
-    .overtime-secondary-btn {
-        appearance: none;
-        border: 1px solid rgba(255, 255, 255, 0.18);
-        background: rgba(255, 255, 255, 0.12);
-        color: white;
-        border-radius: 12px;
-        padding: 10px 14px;
-        font-weight: 800;
-        cursor: pointer;
-        transition: transform 0.18s ease, background 0.18s ease;
-    }
-
-    .overtime-secondary-btn:hover {
-        transform: translateY(-1px);
-        background: rgba(255, 255, 255, 0.18);
-    }
-
-    .overtime-status-panel {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 8px;
-    }
-
-    .overtime-status-pill {
-        display: inline-flex;
-        align-items: center;
-        gap: 6px;
-        padding: 7px 12px;
-        border-radius: 999px;
-        background: rgba(255, 255, 255, 0.12);
-        border: 1px solid rgba(255, 255, 255, 0.14);
-        font-size: 0.84rem;
-        font-weight: 800;
-    }
-
     .overtime-feed {
         display: grid;
         grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -254,6 +157,30 @@ else
         display: flex;
         gap: 14px;
         align-items: flex-start;
+        animation: overtime-card-pop 0.45s ease-out;
+        position: relative;
+        overflow: hidden;
+    }
+
+    .overtime-card::before {
+        content: "";
+        position: absolute;
+        inset: 0 auto 0 0;
+        width: 6px;
+        border-radius: 24px 0 0 24px;
+        background: linear-gradient(180deg, var(--overtime-accent), var(--overtime-accent-soft));
+        opacity: 0.9;
+    }
+
+    .overtime-card::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background:
+            linear-gradient(120deg, rgba(255, 255, 255, 0.06), transparent 26%),
+            radial-gradient(circle at 100% 0%, rgba(255, 255, 255, 0.08), transparent 28%);
+        pointer-events: none;
+        opacity: 0.6;
     }
 
     .overtime-avatar {
@@ -278,6 +205,8 @@ else
     .overtime-card-main {
         flex: 1;
         min-width: 0;
+        position: relative;
+        z-index: 1;
     }
 
     .overtime-card-head {
@@ -288,14 +217,17 @@ else
     }
 
     .overtime-card-name {
-        font-size: 1.06rem;
+        font-size: 1.08rem;
         font-weight: 900;
+        letter-spacing: 0.01em;
     }
 
     .overtime-card-source {
         margin-top: 2px;
         font-size: 0.82rem;
         opacity: 0.78;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
     }
 
     .overtime-card-time {
@@ -329,6 +261,7 @@ else
         font-weight: 800;
         background: rgba(255, 255, 255, 0.12);
         border: 1px solid rgba(255, 255, 255, 0.12);
+        backdrop-filter: blur(8px);
     }
 
     .overtime-card-amount {
@@ -337,6 +270,11 @@ else
 
     .overtime-card-amount.muted {
         color: rgba(255, 255, 255, 0.72);
+    }
+
+    .overtime-card:hover {
+        transform: translateY(-3px) scale(1.005);
+        transition: transform 0.18s ease;
     }
 
     .overtime-state {
@@ -354,6 +292,11 @@ else
     .overtime-state-title {
         font-size: 1.2rem;
         font-weight: 700;
+    }
+
+    @@keyframes overtime-card-pop {
+        0% { transform: translateY(8px); opacity: 0; }
+        100% { transform: translateY(0); opacity: 1; }
     }
 
     .overtime-disabled-panel,
@@ -390,11 +333,9 @@ else
     private bool isLoading = true;
     private System.Timers.Timer? refreshTimer;
     private bool isRefreshing;
-    private EasyLotteryConfigDocument document = new();
     private OvertimeOverlaySettings settings = new();
     private IReadOnlyList<OvertimeSupportEvent> events = [];
     private OvertimeThemePreset CurrentTheme => OvertimeThemePreset.GetByKey(settings.ThemeKey);
-    private string OverlayUrl => NavigationManager.ToAbsoluteUri("/obs/overtime").ToString();
     private string ThemeStyle => CurrentTheme.BuildCssVariables();
 
     protected override async Task OnInitializedAsync()
@@ -432,7 +373,7 @@ else
     private async Task ReloadAsync()
     {
         isLoading = true;
-        document = await ConfigStore.LoadAsync();
+        var document = await ConfigStore.LoadAsync();
         settings = document.OvertimeOverlay ?? new OvertimeOverlaySettings();
         settings.ThemeKey = string.IsNullOrWhiteSpace(settings.ThemeKey) ? OvertimeThemePreset.Catalog[0].Key : settings.ThemeKey;
         await ReloadEventsAsync();
@@ -449,11 +390,6 @@ else
         {
             events = [];
         }
-    }
-
-    private async Task CopyOverlayUrlAsync()
-    {
-        await JSRuntime.InvokeVoidAsync("easyLotteryClipboard.copyText", OverlayUrl);
     }
 
     private static string GetAvatarFallback(string? displayName)

--- a/src/EasyLotteryWasm/Pages/PokeBox/PokeBoxObs.razor
+++ b/src/EasyLotteryWasm/Pages/PokeBox/PokeBoxObs.razor
@@ -6,8 +6,6 @@
 
 @inject ActivityResultService ActivityResultService
 @inject PokeService PokeService
-@inject NavigationManager NavigationManager
-@inject IJSRuntime JSRuntime
 
 <PageTitle>戳戳樂 - OBS</PageTitle>
 
@@ -27,84 +25,56 @@ else if (template == null)
 else
 {
     <div class="obs-poke-wrapper" style="@WrapperStyle">
-        <div class="obs-topbar">
-            <div class="obs-topbar-copy">
-                <div class="obs-topbar-eyebrow">OBS CONTROL</div>
-                <div class="obs-topbar-title">戳戳樂控制台</div>
-                <div class="obs-topbar-subtitle">@template.Name</div>
-            </div>
-            <div class="obs-topbar-actions">
-                <button class="obs-secondary-btn" @onclick="@CopyObsUrlAsync">複製來源網址</button>
-                <button class="obs-secondary-btn" @onclick="@LoadTemplate">重新載入模板</button>
-            </div>
-        </div>
-
-        <div class="obs-status-panel">
-            <div class="obs-status-pill">模式：@(template.Mode == PokeMode.Random ? "隨機" : "手動")</div>
-            <div class="obs-status-pill">已戳：@RevealedCount / @template.Cells.Count</div>
-            @if (template.MaxPokeCount > 0)
-            {
-                <div class="obs-status-pill">上限：@template.MaxPokeCount</div>
-            }
-            <div class="obs-status-pill">來源：@ObsUrl</div>
-        </div>
-
-        <div class="poke-grid" style="@GridStyle">
-            @foreach (var cell in template.Cells.OrderBy(c => c.Index))
-            {
-                <div class="poke-cell @(cell.IsRevealed ? "revealed " + AnimationClass : "") @(lastPokedIndex == cell.Index ? "just-poked" : "")"
-                     style="@CellStyle(cell)"
-                     @onclick="@(() => OnCellClick(cell))">
-                    @if (cell.IsRevealed)
-                    {
-                        @if (!string.IsNullOrEmpty(cell.RevealedImageUrl))
+        <div class="obs-stage">
+            <div class="poke-grid" style="@GridStyle">
+                @foreach (var cell in template.Cells.OrderBy(c => c.Index))
+                {
+                    <div class="poke-cell @(cell.IsRevealed ? "revealed " + AnimationClass : "") @(lastPokedIndex == cell.Index ? "just-poked" : "")"
+                         style="@CellStyle(cell)"
+                         @onclick="@(() => OnCellClick(cell))">
+                        @if (cell.IsRevealed)
                         {
-                            <img src="@cell.RevealedImageUrl" alt="@cell.Title" style="max-width:100%;max-height:80%;" />
-                        }
-                        <div class="cell-title">@cell.Title</div>
-                        @if (!string.IsNullOrEmpty(cell.SubTitle))
-                        {
-                            <div class="cell-subtitle">@cell.SubTitle</div>
-                        }
-                    }
-                    else
-                    {
-                        @if (!string.IsNullOrEmpty(cell.ImageUrl))
-                        {
-                            <img src="@cell.ImageUrl" alt="@cell.Title" style="max-width:100%;max-height:80%;" />
+                            @if (!string.IsNullOrEmpty(cell.RevealedImageUrl))
+                            {
+                                <img src="@cell.RevealedImageUrl" alt="@cell.Title" style="max-width:100%;max-height:80%;" />
+                            }
+                            <div class="cell-title">@cell.Title</div>
+                            @if (!string.IsNullOrEmpty(cell.SubTitle))
+                            {
+                                <div class="cell-subtitle">@cell.SubTitle</div>
+                            }
                         }
                         else
                         {
-                            <span class="poke-icon">👆</span>
+                            @if (!string.IsNullOrEmpty(cell.ImageUrl))
+                            {
+                                <img src="@cell.ImageUrl" alt="@cell.Title" style="max-width:100%;max-height:80%;" />
+                            }
+                            else
+                            {
+                                <span class="poke-icon">👆</span>
+                            }
                         }
-                    }
-                </div>
-            }
-        </div>
+                    </div>
+                }
+            </div>
 
-        <div class="obs-controls">
-            @if (template.Mode == PokeMode.Random)
+            <div class="obs-controls">
+                @if (template.Mode == PokeMode.Random)
+                {
+                    <button class="obs-poke-btn" @onclick="@PokeRandom">隨機戳一格</button>
+                }
+                <button class="obs-record-btn" @onclick="@EndActivityAndRecord" disabled="@(!CanRecordCurrentActivity || isRecording)">
+                    @(isRecording ? "記錄中…" : "結束本次活動並記錄")
+                </button>
+                <button class="obs-reset-btn" @onclick="@ResetTemplate">重設</button>
+            </div>
+
+            @if (!string.IsNullOrWhiteSpace(statusMessage))
             {
-                <button class="obs-poke-btn" @onclick="@PokeRandom">隨機戳一格</button>
-            }
-            <button class="obs-record-btn" @onclick="@EndActivityAndRecord" disabled="@(!CanRecordCurrentActivity || isRecording)">
-                @(isRecording ? "記錄中…" : "結束本次活動並記錄")
-            </button>
-            <button class="obs-reset-btn" @onclick="@ResetTemplate">重設</button>
-        </div>
-
-        <div class="obs-status">
-            已戳：@RevealedCount / @template.Cells.Count
-            @if (template.MaxPokeCount > 0)
-            {
-                <span>（上限：@template.MaxPokeCount）</span>
+                <div class="obs-feedback @(statusIsError ? "obs-feedback-error" : "obs-feedback-success")">@statusMessage</div>
             }
         </div>
-
-        @if (!string.IsNullOrWhiteSpace(statusMessage))
-        {
-            <div class="obs-feedback @(statusIsError ? "obs-feedback-error" : "obs-feedback-success")">@statusMessage</div>
-        }
     </div>
 }
 
@@ -121,83 +91,25 @@ else
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        padding: 16px;
+        min-height: 100vh;
+        padding: 24px;
         gap: 12px;
     }
 
-    .obs-topbar,
-    .obs-status-panel {
-        width: min(100%, 960px);
+    .obs-stage {
+        width: min(100%, 980px);
         display: flex;
+        flex-direction: column;
         align-items: center;
-        justify-content: space-between;
-        gap: 12px;
-        flex-wrap: wrap;
-        padding: 12px 16px;
-        border-radius: 16px;
-        background: var(--el-surface-strong);
-        color: var(--el-text);
-        box-shadow: 0 18px 48px rgba(0, 0, 0, 0.22);
-        border: 1px solid var(--el-border);
-    }
-
-    .obs-topbar-eyebrow {
-        font-size: 0.72rem;
-        font-weight: 700;
-        letter-spacing: 0.18em;
-        opacity: 0.7;
-    }
-
-    .obs-topbar-title {
-        margin-top: 2px;
-        font-size: 1.08rem;
-        font-weight: 800;
-    }
-
-    .obs-topbar-subtitle {
-        margin-top: 2px;
-        font-size: 0.92rem;
-        opacity: 0.82;
-    }
-
-    .obs-topbar-actions {
-        display: flex;
-        gap: 8px;
-        flex-wrap: wrap;
-        justify-content: flex-end;
-    }
-
-    .obs-secondary-btn {
-        background: rgba(255, 255, 255, 0.08);
-        color: var(--el-text);
-        border: 1px solid var(--el-border);
-        border-radius: 8px;
-        padding: 10px 16px;
-        font-size: 0.95rem;
-        font-weight: 700;
-        cursor: pointer;
-        transition: background 0.2s, transform 0.2s;
-    }
-
-    .obs-secondary-btn:hover {
-        background: rgba(255, 255, 255, 0.16);
-        transform: translateY(-1px);
-    }
-
-    .obs-status-panel {
-        justify-content: flex-start;
-    }
-
-    .obs-status-pill {
-        display: inline-flex;
-        align-items: center;
-        padding: 6px 12px;
-        border-radius: 999px;
-        background: rgba(255, 255, 255, 0.08);
-        border: 1px solid var(--el-border);
-        font-size: 0.88rem;
-        font-weight: 700;
-        word-break: break-all;
+        gap: 16px;
+        padding: 24px;
+        border-radius: 32px;
+        background:
+            radial-gradient(circle at 50% 0%, rgba(255, 255, 255, 0.12), transparent 28%),
+            linear-gradient(180deg, rgba(12, 18, 34, 0.78), rgba(12, 18, 34, 0.52));
+        border: 1px solid rgba(255, 255, 255, 0.14);
+        box-shadow: 0 28px 72px rgba(0, 0, 0, 0.35);
+        backdrop-filter: blur(10px);
     }
 
     .obs-state {
@@ -232,10 +144,11 @@ else
     .poke-grid {
         gap: 8px;
         width: 100%;
-        max-width: 600px;
+        max-width: 760px;
     }
 
     .poke-cell {
+        position: relative;
         display: flex;
         flex-direction: column;
         align-items: center;
@@ -251,6 +164,7 @@ else
         color: var(--el-text);
         border: 2px solid var(--el-border-strong);
         user-select: none;
+        overflow: hidden;
     }
 
     .poke-cell:hover:not(.revealed) {
@@ -260,6 +174,29 @@ else
 
     .poke-cell.revealed {
         cursor: default;
+    }
+
+    .poke-cell.revealed::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        background: linear-gradient(135deg, rgba(255, 255, 255, 0.24), transparent 38%, rgba(255, 255, 255, 0.08));
+        pointer-events: none;
+        animation: reveal-sheen 1.1s ease-out infinite;
+        mix-blend-mode: screen;
+    }
+
+    .poke-cell.revealed::after {
+        content: "✦";
+        position: absolute;
+        top: 8px;
+        right: 10px;
+        font-size: 0.9rem;
+        color: rgba(255, 255, 255, 0.9);
+        text-shadow: 0 0 10px var(--el-glow);
+        animation: reveal-star 1s ease-in-out infinite;
+        pointer-events: none;
     }
 
     .poke-cell .poke-icon {
@@ -297,6 +234,13 @@ else
         animation: flip 0.5s ease-out;
     }
 
+    .poke-cell.revealed {
+        box-shadow:
+            0 0 0 2px rgba(255, 255, 255, 0.08) inset,
+            0 12px 26px rgba(0, 0, 0, 0.18);
+        animation: reveal-glow 0.7s ease-out;
+    }
+
     @@keyframes burst {
         0% { transform: scale(1); }
         30% { transform: scale(1.4); }
@@ -328,19 +272,24 @@ else
     }
 
     .obs-controls {
-        margin-top: 12px;
         display: flex;
-        gap: 8px;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 10px;
+        padding: 14px 16px;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.06);
+        border: 1px solid rgba(255, 255, 255, 0.14);
     }
 
     .obs-poke-btn {
-        background: var(--bs-warning);
-        color: var(--el-accent-contrast);
+        background: linear-gradient(135deg, #ffcb47, #ff9f1a);
+        color: #18121a;
         border: none;
-        border-radius: 8px;
-        padding: 10px 24px;
-        font-size: 1rem;
-        font-weight: bold;
+        border-radius: 999px;
+        padding: 12px 22px;
+        font-size: 0.98rem;
+        font-weight: 900;
         cursor: pointer;
         box-shadow: 0 2px 8px rgba(0,0,0,0.3);
     }
@@ -350,13 +299,13 @@ else
     }
 
     .obs-reset-btn {
-        background: var(--bs-danger);
-        color: var(--el-text);
+        background: linear-gradient(135deg, #ef6b6b, #c53e3e);
+        color: white;
         border: none;
-        border-radius: 8px;
-        padding: 10px 24px;
-        font-size: 1rem;
-        font-weight: bold;
+        border-radius: 999px;
+        padding: 12px 22px;
+        font-size: 0.98rem;
+        font-weight: 900;
         cursor: pointer;
         box-shadow: 0 2px 8px rgba(0,0,0,0.3);
     }
@@ -366,13 +315,13 @@ else
     }
 
     .obs-record-btn {
-        background: var(--bs-success);
-        color: var(--el-text);
+        background: linear-gradient(135deg, #41c97d, #20935d);
+        color: white;
         border: none;
-        border-radius: 8px;
-        padding: 10px 24px;
-        font-size: 1rem;
-        font-weight: bold;
+        border-radius: 999px;
+        padding: 12px 22px;
+        font-size: 0.98rem;
+        font-weight: 900;
         cursor: pointer;
         box-shadow: 0 2px 8px rgba(0,0,0,0.3);
     }
@@ -386,13 +335,6 @@ else
     .obs-reset-btn:disabled {
         opacity: 0.6;
         cursor: not-allowed;
-    }
-
-    .obs-status {
-        margin-top: 8px;
-        color: var(--el-text);
-        font-size: 0.9rem;
-        opacity: 0.8;
     }
 
     .obs-feedback {
@@ -411,6 +353,23 @@ else
 
     .obs-feedback-error {
         border: 1px solid rgba(248, 113, 113, 0.5);
+    }
+
+    @@keyframes reveal-glow {
+        0% { transform: scale(0.96); filter: brightness(0.9); }
+        50% { transform: scale(1.02); filter: brightness(1.18); }
+        100% { transform: scale(1); filter: brightness(1); }
+    }
+
+    @@keyframes reveal-sheen {
+        0% { opacity: 0.1; transform: translateX(-6px); }
+        50% { opacity: 0.8; transform: translateX(6px); }
+        100% { opacity: 0.12; transform: translateX(-6px); }
+    }
+
+    @@keyframes reveal-star {
+        0%, 100% { transform: scale(0.85) rotate(0deg); opacity: 0.5; }
+        50% { transform: scale(1.15) rotate(12deg); opacity: 1; }
     }
 </style>
 
@@ -473,14 +432,6 @@ else
         }
 
         isLoading = false;
-    }
-
-    private string ObsUrl => NavigationManager.ToAbsoluteUri($"/obs/pokebox/{Id}").ToString();
-
-    private async Task CopyObsUrlAsync()
-    {
-        await JSRuntime.InvokeVoidAsync("easyLotteryClipboard.copyText", ObsUrl);
-        SetStatus("已複製 OBS 來源網址。", false);
     }
 
     private async Task OnCellClick(PokeCell cell)

--- a/src/EasyLotteryWasm/Pages/PokeBox/PokeBoxPreview.razor
+++ b/src/EasyLotteryWasm/Pages/PokeBox/PokeBoxPreview.razor
@@ -75,13 +75,16 @@ else
         <!-- OBS Browser Source -->
         <div class="mt-3">
             <details>
-                <summary style="color:var(--el-text-muted);cursor:pointer;">📺 OBS 瀏覽器來源</summary>
-                <div class="mt-2 p-2" style="background:var(--el-surface-soft);border-radius:6px;">
-                    <p style="color:var(--el-text-muted);font-size:0.85rem;margin-bottom:4px;">在 OBS 加入「瀏覽器」來源，將以下網址貼入：</p>
-                    <code style="color:var(--el-accent);word-break:break-all;">@ObsUrl</code>
-                    <p style="color:var(--el-text-muted);font-size:0.75rem;margin-top:8px;margin-bottom:0;">
-                        💡 建議寬高依格數調整（如 3×3 建議 500×550），勾選「關閉時使場景不活躍」。背景會自動透明。
-                    </p>
+                <summary style="color:var(--el-text-muted);cursor:pointer;">📺 OBS 瀏覽器來源（固定網址）</summary>
+                <div class="mt-2 p-3 obs-source-guide">
+                    <p class="obs-source-guide-title">這是固定的 OBS 來源網址，設定一次後就可以長期使用。</p>
+                    <p class="obs-source-guide-body">在 OBS 新增「瀏覽器」來源，直接貼上下面網址：</p>
+                    <code class="obs-source-code">@ObsUrl</code>
+                    <ul class="obs-source-list">
+                        <li>建議依格數調整大小，例如 <strong>3 × 3 建議 500 × 550</strong></li>
+                        <li>勾選「關閉時使場景不活躍」</li>
+                        <li>背景已預設透明，可直接疊加在直播場景上</li>
+                    </ul>
                 </div>
             </details>
         </div>
@@ -139,6 +142,42 @@ else
     .poke-cell .cell-subtitle {
         font-size: 0.75rem;
         opacity: 0.8;
+    }
+
+    .obs-source-guide {
+        background: var(--el-surface-soft);
+        border-radius: 10px;
+        border: 1px solid var(--el-border);
+    }
+
+    .obs-source-guide-title {
+        color: var(--el-text);
+        font-weight: 700;
+        margin-bottom: 8px;
+    }
+
+    .obs-source-guide-body {
+        color: var(--el-text-muted);
+        font-size: 0.9rem;
+        margin-bottom: 8px;
+    }
+
+    .obs-source-code {
+        display: block;
+        color: var(--el-accent);
+        word-break: break-all;
+        padding: 10px 12px;
+        border-radius: 8px;
+        background: color-mix(in srgb, var(--el-surface-strong) 82%, transparent);
+        border: 1px solid var(--el-border);
+    }
+
+    .obs-source-list {
+        margin: 10px 0 0;
+        padding-left: 20px;
+        color: var(--el-text-muted);
+        font-size: 0.85rem;
+        line-height: 1.6;
     }
 
     /* Animation classes */

--- a/src/EasyLotteryWasm/Pages/Roulette/RouletteObs.razor
+++ b/src/EasyLotteryWasm/Pages/Roulette/RouletteObs.razor
@@ -6,8 +6,6 @@
 
 @inject ActivityResultService ActivityResultService
 @inject RouletteService RouletteService
-@inject NavigationManager NavigationManager
-@inject IJSRuntime JSRuntime
 
 <PageTitle>轉盤 - OBS</PageTitle>
 
@@ -27,118 +25,94 @@ else if (template == null)
 else
 {
     <div class="obs-roulette-wrapper" style="@WrapperStyle">
-        <div class="obs-topbar">
-            <div class="obs-topbar-copy">
-                <div class="obs-topbar-eyebrow">OBS CONTROL</div>
-                <div class="obs-topbar-title">轉盤控制台</div>
-                <div class="obs-topbar-subtitle">@template.Name</div>
-            </div>
-            <div class="obs-topbar-actions">
-                <button class="obs-secondary-btn" @onclick="@CopyObsUrlAsync">複製來源網址</button>
-                <button class="obs-secondary-btn" @onclick="@ReloadTemplateAsync">重新載入模板</button>
-            </div>
-        </div>
-
-        <div class="obs-status-panel">
-            <div class="obs-status-pill">段數：@template.SegmentCount</div>
-            <div class="obs-status-pill">狀態：@(isSpinning ? "轉動中" : "待轉動")</div>
-            <div class="obs-status-pill">目前角度：@currentRotation.ToString("F1")°</div>
-            @if (lastResult != null)
-            {
-                <div class="obs-status-pill">最近結果：@lastResult.SegmentTitle</div>
-            }
-            <div class="obs-status-pill">來源：@ObsUrl</div>
-        </div>
-
-        <LiveDrawFlowGuide Title="OBS 直播流程"
-                           Subtitle="@template.Name"
-                           Phase="@flowPhase"
-                           CountdownRemaining="@countdownRemaining"
-                           DetailText="@FlowDetailText" />
-
-        <div class="roulette-container">
-            <!-- Pointer -->
-            <div class="roulette-pointer">
-                @if (!string.IsNullOrEmpty(template.PointerImageUrl))
+        <div class="obs-stage">
+            <div class="roulette-container">
+                @if (isSpinning)
                 {
-                    <img src="@template.PointerImageUrl" alt="指針" style="width:40px;" />
+                    <div class="roulette-spinning-aura"></div>
                 }
-                else
-                {
-                    <div class="default-pointer">▼</div>
-                }
-            </div>
 
-            <!-- Wheel -->
-            <div class="roulette-wheel-wrapper">
-                <svg class="roulette-wheel @(isSpinning ? "spinning" : "")"
-                     viewBox="0 0 400 400"
-                     style="@WheelStyle">
-                    @{
-                        var segments = template.Segments.OrderBy(s => s.Index).ToList();
-                        int count = segments.Count;
-                        double segAngle = 360.0 / count;
-                    }
-                    @for (int i = 0; i < count; i++)
+                <div class="roulette-pointer">
+                    @if (!string.IsNullOrEmpty(template.PointerImageUrl))
                     {
-                        var seg = segments[i];
-                        var startAngle = i * segAngle - 90;
-                        var endAngle = startAngle + segAngle;
-                        var midAngle = startAngle + segAngle / 2.0;
-                        var path = DescribeSector(200, 200, 180, startAngle, endAngle);
-                        var textX = 200 + 120 * Math.Cos(midAngle * Math.PI / 180);
-                        var textY = 200 + 120 * Math.Sin(midAngle * Math.PI / 180);
-                        var isWinner = lastResult != null && lastResult.SegmentIndex == i && !isSpinning;
-
-                        <g>
-                            <path d="@path" fill="@seg.Color"
-                                  stroke="var(--el-border-strong)" stroke-width="2"
-                                  class="@(isWinner ? "winner-segment" : "")" />
-                            <text x="@textX.ToString("F1")" y="@textY.ToString("F1")"
-                                  text-anchor="middle" dominant-baseline="middle"
-                                  font-size="14" fill="var(--el-text)" font-weight="bold"
-                                  transform="rotate(@midAngle.ToString("F1"), @textX.ToString("F1"), @textY.ToString("F1"))">
-                                @seg.Title
-                            </text>
-                        </g>
-                    }
-                    <!-- Center image or circle -->
-                    @if (!string.IsNullOrEmpty(template.CenterImageUrl))
-                    {
-                        <image href="@template.CenterImageUrl" x="160" y="160" width="80" height="80" />
+                        <img src="@template.PointerImageUrl" alt="指針" style="width:40px;" />
                     }
                     else
                     {
-                        <circle cx="200" cy="200" r="30" fill="var(--el-surface-strong)" />
+                        <div class="default-pointer">▼</div>
                     }
-                </svg>
+                </div>
+
+                <div class="roulette-wheel-wrapper">
+                    <svg class="roulette-wheel @(isSpinning ? "spinning" : "")"
+                         viewBox="0 0 400 400"
+                         style="@WheelStyle">
+                        @{
+                            var segments = template.Segments.OrderBy(s => s.Index).ToList();
+                            int count = segments.Count;
+                            double segAngle = 360.0 / count;
+                        }
+                        @for (int i = 0; i < count; i++)
+                        {
+                            var seg = segments[i];
+                            var startAngle = i * segAngle - 90;
+                            var endAngle = startAngle + segAngle;
+                            var midAngle = startAngle + segAngle / 2.0;
+                            var path = DescribeSector(200, 200, 180, startAngle, endAngle);
+                            var textX = 200 + 120 * Math.Cos(midAngle * Math.PI / 180);
+                            var textY = 200 + 120 * Math.Sin(midAngle * Math.PI / 180);
+                            var isWinner = lastResult != null && lastResult.SegmentIndex == i && !isSpinning;
+
+                            <g>
+                                <path d="@path" fill="@seg.Color"
+                                      stroke="var(--el-border-strong)" stroke-width="2"
+                                      class="@(isWinner ? "winner-segment" : "")" />
+                                <text x="@textX.ToString("F1")" y="@textY.ToString("F1")"
+                                      text-anchor="middle" dominant-baseline="middle"
+                                      font-size="14" fill="var(--el-text)" font-weight="bold"
+                                      transform="rotate(@midAngle.ToString("F1"), @textX.ToString("F1"), @textY.ToString("F1"))">
+                                    @seg.Title
+                                </text>
+                            </g>
+                        }
+                        @if (!string.IsNullOrEmpty(template.CenterImageUrl))
+                        {
+                            <image href="@template.CenterImageUrl" x="160" y="160" width="80" height="80" />
+                        }
+                        else
+                        {
+                            <circle cx="200" cy="200" r="30" fill="var(--el-surface-strong)" />
+                        }
+                    </svg>
+                </div>
+
+                @if (lastResult != null && !IsBusy)
+                {
+                    <div class="roulette-result-flare"></div>
+                    <div class="obs-win-result">
+                        <span class="win-label">🎉 中獎：</span>
+                        <span class="win-title">@lastResult.SegmentTitle</span>
+                    </div>
+                }
             </div>
-        </div>
 
-        <div class="obs-controls">
-            <button class="obs-spin-btn" @onclick="@SpinWheelWithCountdown" disabled="@IsBusy">
-                @((IsBusy && flowPhase == LiveDrawPhase.CountingDown) ? $"倒數中… {countdownRemaining}" : "⏳ 倒數 3 秒後轉動")
-            </button>
-            <button class="obs-spin-btn" @onclick="@SpinWheel" disabled="@IsBusy">
-                @(IsBusy && flowPhase == LiveDrawPhase.Spinning ? "轉動中…" : "🎰 立即轉動")
-            </button>
-            <button class="obs-record-btn" @onclick="@EndActivityAndRecord" disabled="@(!CanRecordCurrentActivity || isRecording)">
-                @(isRecording ? "記錄中…" : "結束本次活動並記錄")
-            </button>
-        </div>
-
-        @if (lastResult != null && !IsBusy)
-        {
-            <div class="obs-win-result">
-                <span class="win-label">🎉 中獎：</span>
-                <span class="win-title">@lastResult.SegmentTitle</span>
+            <div class="obs-controls">
+                <button class="obs-spin-btn" @onclick="@SpinWheelWithCountdown" disabled="@IsBusy">
+                    @((IsBusy && flowPhase == LiveDrawPhase.CountingDown) ? $"倒數中… {countdownRemaining}" : "⏳ 倒數 3 秒後轉動")
+                </button>
+                <button class="obs-spin-btn" @onclick="@SpinWheel" disabled="@IsBusy">
+                    @(IsBusy && flowPhase == LiveDrawPhase.Spinning ? "轉動中…" : "🎰 立即轉動")
+                </button>
+                <button class="obs-record-btn" @onclick="@EndActivityAndRecord" disabled="@(!CanRecordCurrentActivity || isRecording)">
+                    @(isRecording ? "記錄中…" : "結束本次活動並記錄")
+                </button>
             </div>
-        }
 
-        @if (!string.IsNullOrWhiteSpace(statusMessage))
-        {
-            <div class="obs-feedback @(statusIsError ? "obs-feedback-error" : "obs-feedback-success")">@statusMessage</div>
-        }
+            @if (!string.IsNullOrWhiteSpace(statusMessage))
+            {
+                <div class="obs-feedback @(statusIsError ? "obs-feedback-error" : "obs-feedback-success")">@statusMessage</div>
+            }
+        </div>
     </div>
 }
 
@@ -155,83 +129,25 @@ else
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        padding: 16px;
+        min-height: 100vh;
+        padding: 24px;
         gap: 12px;
     }
 
-    .obs-topbar,
-    .obs-status-panel {
-        width: min(100%, 980px);
+    .obs-stage {
+        width: min(100%, 1040px);
         display: flex;
+        flex-direction: column;
         align-items: center;
-        justify-content: space-between;
-        gap: 12px;
-        flex-wrap: wrap;
-        padding: 12px 16px;
-        border-radius: 16px;
-        background: var(--el-surface-strong);
-        color: var(--el-text);
-        box-shadow: 0 18px 48px rgba(0, 0, 0, 0.22);
-        border: 1px solid var(--el-border);
-    }
-
-    .obs-topbar-eyebrow {
-        font-size: 0.72rem;
-        font-weight: 700;
-        letter-spacing: 0.18em;
-        opacity: 0.7;
-    }
-
-    .obs-topbar-title {
-        margin-top: 2px;
-        font-size: 1.08rem;
-        font-weight: 800;
-    }
-
-    .obs-topbar-subtitle {
-        margin-top: 2px;
-        font-size: 0.92rem;
-        opacity: 0.82;
-    }
-
-    .obs-topbar-actions {
-        display: flex;
-        gap: 8px;
-        flex-wrap: wrap;
-        justify-content: flex-end;
-    }
-
-    .obs-secondary-btn {
-        background: rgba(255, 255, 255, 0.08);
-        color: var(--el-text);
-        border: 1px solid var(--el-border);
-        border-radius: 8px;
-        padding: 10px 16px;
-        font-size: 0.95rem;
-        font-weight: 700;
-        cursor: pointer;
-        transition: background 0.2s, transform 0.2s;
-    }
-
-    .obs-secondary-btn:hover {
-        background: rgba(255, 255, 255, 0.16);
-        transform: translateY(-1px);
-    }
-
-    .obs-status-panel {
-        justify-content: flex-start;
-    }
-
-    .obs-status-pill {
-        display: inline-flex;
-        align-items: center;
-        padding: 6px 12px;
-        border-radius: 999px;
-        background: rgba(255, 255, 255, 0.08);
-        border: 1px solid var(--el-border);
-        font-size: 0.88rem;
-        font-weight: 700;
-        word-break: break-all;
+        gap: 16px;
+        padding: 24px;
+        border-radius: 32px;
+        background:
+            radial-gradient(circle at 50% 0%, rgba(255, 255, 255, 0.12), transparent 28%),
+            linear-gradient(180deg, rgba(12, 18, 34, 0.78), rgba(12, 18, 34, 0.52));
+        border: 1px solid rgba(255, 255, 255, 0.14);
+        box-shadow: 0 28px 72px rgba(0, 0, 0, 0.35);
+        backdrop-filter: blur(10px);
     }
 
     .obs-state {
@@ -268,6 +184,28 @@ else
         flex-direction: column;
         align-items: center;
         position: relative;
+        gap: 10px;
+    }
+
+    .roulette-spinning-aura,
+    .roulette-result-flare {
+        position: absolute;
+        inset: -24px;
+        border-radius: 50%;
+        pointer-events: none;
+        z-index: 0;
+    }
+
+    .roulette-spinning-aura {
+        background:
+            radial-gradient(circle, rgba(255, 192, 66, 0.24) 0%, rgba(255, 192, 66, 0.06) 34%, transparent 66%);
+        animation: spin-aura 1s ease-in-out infinite;
+    }
+
+    .roulette-result-flare {
+        background:
+            radial-gradient(circle, rgba(255, 211, 104, 0.36) 0%, rgba(255, 211, 104, 0.1) 30%, transparent 70%);
+        animation: result-flare 1.1s ease-out infinite;
     }
 
     .roulette-pointer {
@@ -285,16 +223,20 @@ else
     }
 
     .roulette-wheel-wrapper {
-        width: 400px;
-        height: 400px;
+        width: min(64vw, 520px);
+        height: min(64vw, 520px);
         border-radius: 50%;
-        box-shadow: 0 0 30px rgba(0,0,0,0.35);
+        box-shadow:
+            0 0 0 10px rgba(255, 255, 255, 0.06),
+            0 24px 54px rgba(0, 0, 0, 0.36);
         overflow: hidden;
+        position: relative;
+        z-index: 1;
     }
 
     .roulette-wheel {
-        width: 400px;
-        height: 400px;
+        width: min(64vw, 520px);
+        height: min(64vw, 520px);
         transition-property: transform;
         transition-timing-function: cubic-bezier(0.17, 0.67, 0.12, 0.99);
     }
@@ -303,28 +245,36 @@ else
         filter: brightness(1.4);
         stroke: var(--el-accent) !important;
         stroke-width: 4 !important;
+        animation: winner-pulse 0.9s ease-in-out infinite;
     }
 
     .obs-controls {
-        margin-top: 16px;
-        text-align: center;
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 10px;
+        padding: 14px 16px;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.06);
+        border: 1px solid rgba(255, 255, 255, 0.14);
     }
 
     .obs-spin-btn {
-        background: var(--bs-warning);
-        color: var(--el-accent-contrast);
+        background: linear-gradient(135deg, #ffcb47, #ff9f1a);
+        color: #18121a;
         border: none;
-        border-radius: 8px;
-        padding: 12px 32px;
-        font-size: 1.2rem;
-        font-weight: bold;
+        border-radius: 999px;
+        padding: 14px 26px;
+        font-size: 1rem;
+        font-weight: 900;
         cursor: pointer;
         box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-        transition: background 0.2s;
+        transition: transform 0.18s ease, filter 0.18s ease;
     }
 
     .obs-spin-btn:hover:not(:disabled) {
-        filter: brightness(0.92);
+        transform: translateY(-1px);
+        filter: brightness(1.03);
     }
 
     .obs-spin-btn:disabled {
@@ -333,20 +283,21 @@ else
     }
 
     .obs-record-btn {
-        background: var(--bs-success);
-        color: var(--el-text);
+        background: linear-gradient(135deg, #41c97d, #20935d);
+        color: white;
         border: none;
-        border-radius: 8px;
-        padding: 12px 32px;
-        font-size: 1.2rem;
-        font-weight: bold;
+        border-radius: 999px;
+        padding: 14px 26px;
+        font-size: 1rem;
+        font-weight: 900;
         cursor: pointer;
         box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-        transition: background 0.2s;
+        transition: transform 0.18s ease, filter 0.18s ease;
     }
 
     .obs-record-btn:hover:not(:disabled) {
-        filter: brightness(0.92);
+        transform: translateY(-1px);
+        filter: brightness(1.03);
     }
 
     .obs-record-btn:disabled {
@@ -355,10 +306,19 @@ else
     }
 
     .obs-win-result {
-        margin-top: 12px;
-        font-size: 1.4rem;
+        display: inline-flex;
+        align-items: baseline;
+        gap: 10px;
+        padding: 12px 18px;
+        border-radius: 999px;
+        font-size: 1.2rem;
         color: var(--el-text);
         text-align: center;
+        background: rgba(255, 255, 255, 0.08);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        box-shadow: 0 14px 34px rgba(0, 0, 0, 0.2);
+        position: relative;
+        z-index: 1;
     }
 
     .obs-win-result .win-label {
@@ -370,6 +330,7 @@ else
         color: var(--el-accent);
         font-size: 1.6rem;
         text-shadow: 0 0 12px var(--el-glow);
+        animation: result-pop 0.35s ease-out;
     }
 
     .obs-feedback {
@@ -388,6 +349,27 @@ else
 
     .obs-feedback-error {
         border: 1px solid rgba(248, 113, 113, 0.5);
+    }
+
+    @@keyframes winner-pulse {
+        0%, 100% { filter: brightness(1.3); }
+        50% { filter: brightness(1.7); }
+    }
+
+    @@keyframes result-pop {
+        0% { transform: scale(0.96); opacity: 0.4; }
+        100% { transform: scale(1); opacity: 1; }
+    }
+
+    @@keyframes spin-aura {
+        0%, 100% { transform: scale(0.98); opacity: 0.7; }
+        50% { transform: scale(1.04); opacity: 1; }
+    }
+
+    @@keyframes result-flare {
+        0% { transform: scale(0.92); opacity: 0.3; }
+        40% { transform: scale(1.02); opacity: 0.9; }
+        100% { transform: scale(1.08); opacity: 0.0; }
     }
 </style>
 
@@ -411,16 +393,6 @@ else
     private bool IsBusy => isSpinning || countdownRemaining.HasValue;
     private bool CanRecordCurrentActivity => template != null && lastResult != null && !IsBusy && BuildRecordSignature() != lastRecordedSignature;
 
-    private string FlowDetailText =>
-        flowPhase switch
-        {
-            LiveDrawPhase.Ready => "先確認畫面與來源，再開始倒數或立即轉動。",
-            LiveDrawPhase.CountingDown => "請確認 OBS 已切好場景，倒數結束就會開始轉動。",
-            LiveDrawPhase.Spinning => "轉盤正在轉動，等待最終結果。",
-            LiveDrawPhase.ShowingResult when lastResult != null => $"本次結果已產生：「{lastResult.SegmentTitle}」。",
-            _ => "抽獎流程已就緒。"
-        };
-
     private string WrapperStyle =>
         string.IsNullOrEmpty(template?.BackgroundImageUrl)
             ? ""
@@ -440,31 +412,6 @@ else
         }
 
         isLoading = false;
-    }
-
-    private string ObsUrl => NavigationManager.ToAbsoluteUri($"/obs/roulette/{Id}").ToString();
-
-    private async Task CopyObsUrlAsync()
-    {
-        await JSRuntime.InvokeVoidAsync("easyLotteryClipboard.copyText", ObsUrl);
-        SetStatus("已複製 OBS 來源網址。", false);
-    }
-
-    private async Task ReloadTemplateAsync()
-    {
-        if (template == null) return;
-
-        template = await RouletteService.LoadTemplateAsync(Id);
-        if (template == null)
-        {
-            await RouletteService.SeedDefaultTemplatesAsync();
-            template = await RouletteService.LoadTemplateAsync(Id);
-        }
-
-        flowPhase = LiveDrawPhase.Ready;
-        countdownRemaining = null;
-        SetStatus("已重新載入模板。", false);
-        StateHasChanged();
     }
 
     private async Task SpinWheel()

--- a/src/EasyLotteryWasm/Pages/Roulette/RoulettePreview.razor
+++ b/src/EasyLotteryWasm/Pages/Roulette/RoulettePreview.razor
@@ -114,13 +114,16 @@ else
         <!-- OBS Browser Source -->
         <div class="mt-3">
             <details>
-                <summary style="color:var(--el-text-muted);cursor:pointer;">📺 OBS 瀏覽器來源</summary>
-                <div class="mt-2 p-2" style="background:var(--el-surface-soft);border-radius:6px;">
-                    <p style="color:var(--el-text-muted);font-size:0.85rem;margin-bottom:4px;">在 OBS 加入「瀏覽器」來源，將以下網址貼入：</p>
-                    <code style="color:var(--el-accent);word-break:break-all;">@ObsUrl</code>
-                    <p style="color:var(--el-text-muted);font-size:0.75rem;margin-top:8px;margin-bottom:0;">
-                        💡 建議寬高設為 480 × 600，勾選「關閉時使場景不活躍」。背景會自動透明。
-                    </p>
+                <summary style="color:var(--el-text-muted);cursor:pointer;">📺 OBS 瀏覽器來源（固定網址）</summary>
+                <div class="mt-2 p-3 obs-source-guide">
+                    <p class="obs-source-guide-title">這是固定的 OBS 來源網址，設定一次後就可以長期使用。</p>
+                    <p class="obs-source-guide-body">在 OBS 新增「瀏覽器」來源，直接貼上下面網址：</p>
+                    <code class="obs-source-code">@ObsUrl</code>
+                    <ul class="obs-source-list">
+                        <li>建議寬高設為 <strong>480 × 600</strong></li>
+                        <li>勾選「關閉時使場景不活躍」</li>
+                        <li>背景已預設透明，可直接疊加在直播場景上</li>
+                    </ul>
                 </div>
             </details>
         </div>
@@ -205,6 +208,42 @@ else
         color: var(--el-accent);
         font-size: 1.6rem;
         text-shadow: 0 0 12px var(--el-glow);
+    }
+
+    .obs-source-guide {
+        background: var(--el-surface-soft);
+        border-radius: 10px;
+        border: 1px solid var(--el-border);
+    }
+
+    .obs-source-guide-title {
+        color: var(--el-text);
+        font-weight: 700;
+        margin-bottom: 8px;
+    }
+
+    .obs-source-guide-body {
+        color: var(--el-text-muted);
+        font-size: 0.9rem;
+        margin-bottom: 8px;
+    }
+
+    .obs-source-code {
+        display: block;
+        color: var(--el-accent);
+        word-break: break-all;
+        padding: 10px 12px;
+        border-radius: 8px;
+        background: color-mix(in srgb, var(--el-surface-strong) 82%, transparent);
+        border: 1px solid var(--el-border);
+    }
+
+    .obs-source-list {
+        margin: 10px 0 0;
+        padding-left: 20px;
+        color: var(--el-text-muted);
+        font-size: 0.85rem;
+        line-height: 1.6;
     }
 </style>
 

--- a/src/EasyLotteryWasm/Properties/launchSettings.json
+++ b/src/EasyLotteryWasm/Properties/launchSettings.json
@@ -6,15 +6,15 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:22399"
+      "applicationUrl": "http://localhost:18930"
     },
     "WSL": {
       "commandName": "WSL2",
       "launchBrowser": true,
-      "launchUrl": "http://localhost:22399",
+      "launchUrl": "http://localhost:18930",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_URLS": "http://0.0.0.0:22399"
+        "ASPNETCORE_URLS": "http://0.0.0.0:18930"
       },
       "distributionName": ""
     }


### PR DESCRIPTION
## Summary
- Restore the previous visual style experience so the app no longer removes the existing styling system.
- Move the overtime configuration entry from System to Activity, while keeping the OBS overlay route intact.

## What changed
- Restored the visual style files and runtime wiring.
- Kept the overtime overlay page available, but moved its navigation entry under Activity.
- Updated the overtime settings text to reference Activity instead of System.
- Kept the OBS overlay URL stable.

## Why
- The visual styling changes were too disruptive for the current UX.
- Overtime belongs with activity-driven workflows rather than system settings.

## Verification
- `dotnet restore EasyLottery.generated.sln`
- `dotnet test EasyLottery.generated.sln --configuration Release --no-restore`

## Notes
- Main branch is kept clean through a dedicated worktree for this change.