### PR TITLE
建立斗內抽拍立得特效與結果寄信功能

### DIFF
--- a/src/EasyLottery/src-tauri/Cargo.toml
+++ b/src/EasyLottery/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "rustls-tls"] }
 tiny_http = "0.12"
+lettre = { version = "0.11", default-features = false, features = ["builder", "smtp-transport", "rustls-tls"] }
 
 [features]
 # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!

--- a/src/EasyLottery/src-tauri/src/main.rs
+++ b/src/EasyLottery/src-tauri/src/main.rs
@@ -2,6 +2,9 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use reqwest::blocking::Client;
+use lettre::{Message, SmtpTransport, Transport};
+use lettre::message::Mailbox;
+use lettre::transport::smtp::authentication::Credentials;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -29,6 +32,81 @@ fn write_config_yaml(app_handle: tauri::AppHandle, content: String) -> Result<()
     }
 
     fs::write(path, content).map_err(|error| error.to_string())
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EmailRequest {
+    recipient: String,
+    subject: String,
+    body: String,
+    smtp: SmtpRequest,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SmtpRequest {
+    host: String,
+    port: u16,
+    username: String,
+    password: String,
+    from_address: String,
+    from_name: String,
+    enable_ssl: bool,
+}
+
+#[tauri::command]
+fn send_result_notification_email(request: EmailRequest) -> Result<(), String> {
+    if request.recipient.trim().is_empty() {
+        return Ok(());
+    }
+
+    if request.smtp.host.trim().is_empty() || request.smtp.from_address.trim().is_empty() || request.smtp.port == 0 {
+        return Ok(());
+    }
+
+    let from_mailbox: Mailbox = if request.smtp.from_name.trim().is_empty() {
+        request
+            .smtp
+            .from_address
+            .parse()
+            .map_err(|error| error.to_string())?
+    } else {
+        format!("{} <{}>", request.smtp.from_name.trim(), request.smtp.from_address.trim())
+            .parse()
+            .map_err(|error| error.to_string())?
+    };
+
+    let recipient_mailbox: Mailbox = request
+        .recipient
+        .parse()
+        .map_err(|error| error.to_string())?;
+
+    let email = Message::builder()
+        .from(from_mailbox)
+        .to(recipient_mailbox)
+        .subject(request.subject)
+        .body(request.body)
+        .map_err(|error| error.to_string())?;
+
+    let credentials = Credentials::new(request.smtp.username, request.smtp.password);
+    let mailer = if request.smtp.enable_ssl {
+        SmtpTransport::relay(&request.smtp.host)
+            .map_err(|error| error.to_string())?
+            .port(request.smtp.port)
+            .credentials(credentials)
+            .build()
+    } else {
+        SmtpTransport::builder_dangerous(&request.smtp.host)
+            .port(request.smtp.port)
+            .credentials(credentials)
+            .build()
+    };
+
+    mailer
+        .send(&email)
+        .map(|_| ())
+        .map_err(|error| error.to_string())
 }
 
 fn resolve_config_yaml_path(app_handle: &tauri::AppHandle) -> Result<PathBuf, String> {

--- a/src/EasyLotteryDomain/Models/Config/EasyLotteryConfigDocument.cs
+++ b/src/EasyLotteryDomain/Models/Config/EasyLotteryConfigDocument.cs
@@ -28,6 +28,14 @@ namespace EasyLotteryDomain.Models.Config
     {
         public YouTubeApiSettings YouTube { get; set; } = new();
 
+        public DonationIntegrationSettings DonationIntegration { get; set; } = new();
+
+        public MailDeliverySettings MailDelivery { get; set; } = new();
+
+        public bool EnableYouTubeSuperChat { get; set; }
+
+        public string ResultNotificationEmail { get; set; } = "";
+
         public string OpenAIKey { get; set; } = "";
 
         public AuditSettings Audit { get; set; } = new();
@@ -42,6 +50,84 @@ namespace EasyLotteryDomain.Models.Config
         public string RedirectUri { get; set; } = "";
 
         public string RefreshToken { get; set; } = "";
+
+        public bool HasConfiguration =>
+            !string.IsNullOrWhiteSpace(ApiKey) ||
+            !string.IsNullOrWhiteSpace(CredentialsBase64) ||
+            !string.IsNullOrWhiteSpace(RedirectUri) ||
+            !string.IsNullOrWhiteSpace(RefreshToken);
+    }
+
+    public sealed class DonationIntegrationSettings
+    {
+        public DonationProviderSettings Ecpay { get; set; } = new()
+        {
+            Name = "綠界"
+        };
+
+        public DonationProviderSettings NewebPay { get; set; } = new()
+        {
+            Name = "藍新"
+        };
+
+        public DonationProviderSettings OenTw { get; set; } = new()
+        {
+            Name = "oen.tw"
+        };
+
+        public DonationProviderSettings TwitchBits { get; set; } = new()
+        {
+            Name = "Twitch 小奇點"
+        };
+    }
+
+    public sealed class DonationProviderSettings
+    {
+        public string Name { get; set; } = "";
+
+        public bool IsEnabled { get; set; }
+
+        public string MerchantId { get; set; } = "";
+
+        public string ApiKey { get; set; } = "";
+
+        public string SecretKey { get; set; } = "";
+
+        public string ChannelId { get; set; } = "";
+
+        public string AccessToken { get; set; } = "";
+
+        public string CreatorId { get; set; } = "";
+
+        public bool HasConfiguration =>
+            !string.IsNullOrWhiteSpace(MerchantId) ||
+            !string.IsNullOrWhiteSpace(ApiKey) ||
+            !string.IsNullOrWhiteSpace(SecretKey) ||
+            !string.IsNullOrWhiteSpace(ChannelId) ||
+            !string.IsNullOrWhiteSpace(AccessToken) ||
+            !string.IsNullOrWhiteSpace(CreatorId);
+    }
+
+    public sealed class MailDeliverySettings
+    {
+        public string SmtpHost { get; set; } = "";
+
+        public int SmtpPort { get; set; } = 587;
+
+        public string SmtpUsername { get; set; } = "";
+
+        public string SmtpPassword { get; set; } = "";
+
+        public string FromAddress { get; set; } = "";
+
+        public string FromName { get; set; } = "EasyLottery";
+
+        public bool EnableSsl { get; set; } = true;
+
+        public bool HasConfiguration =>
+            !string.IsNullOrWhiteSpace(SmtpHost) &&
+            SmtpPort > 0 &&
+            !string.IsNullOrWhiteSpace(FromAddress);
     }
 
     public sealed class LotteryIdSequence

--- a/src/EasyLotteryDomain/Models/Entities/PokeBox.cs
+++ b/src/EasyLotteryDomain/Models/Entities/PokeBox.cs
@@ -45,6 +45,8 @@ namespace EasyLotteryDomain.Models.Entities
 
         public string FontFamily { get; set; } = "";
 
+        public string CongratulationMessage { get; set; } = "";
+
         public int OverlayWidth { get; set; } = 1920;
 
         public int OverlayHeight { get; set; } = 1080;

--- a/src/EasyLotteryDomain/Services/ActivityResultNotificationFormatter.cs
+++ b/src/EasyLotteryDomain/Services/ActivityResultNotificationFormatter.cs
@@ -1,0 +1,35 @@
+using System.Text;
+using EasyLotteryDomain.Models.Config;
+
+namespace EasyLotteryDomain.Services
+{
+    public static class ActivityResultNotificationFormatter
+    {
+        public static string BuildSubject(ActivityResultRecord record)
+        {
+            return $"EasyLottery 結果通知 - {record.ActivityName}";
+        }
+
+        public static string BuildBody(ActivityResultRecord record)
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine("EasyLottery 結果通知");
+            builder.AppendLine($"活動名稱：{record.ActivityName}");
+            builder.AppendLine($"活動時間：{record.ActivityDateUtc.ToLocalTime():yyyy/MM/dd HH:mm:ss}");
+            builder.AppendLine($"摘要：{record.Summary}");
+
+            if (record.Items.Count > 0)
+            {
+                builder.AppendLine();
+                builder.AppendLine("結果明細：");
+
+                foreach (var item in record.Items.OrderBy(item => item.Order))
+                {
+                    builder.AppendLine($"{item.Order}. {item.Name} - {item.Description}");
+                }
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/src/EasyLotteryDomain/Services/PokeService.cs
+++ b/src/EasyLotteryDomain/Services/PokeService.cs
@@ -82,6 +82,7 @@ namespace EasyLotteryDomain.Services
                 MaxPokeCount = source.MaxPokeCount,
                 BackgroundImageUrl = source.BackgroundImageUrl,
                 FontFamily = source.FontFamily,
+                CongratulationMessage = source.CongratulationMessage,
                 OverlayWidth = source.OverlayWidth,
                 OverlayHeight = source.OverlayHeight,
                 Animation = source.Animation,

--- a/src/EasyLotteryWasm/Pages/Config/PaymentSettings.razor
+++ b/src/EasyLotteryWasm/Pages/Config/PaymentSettings.razor
@@ -1,4 +1,8 @@
 @page "/system/payment"
+@using EasyLotteryDomain.Models.Config
+
+@inject SystemSettingsService SystemSettingsService
+@inject IMessageService MessageService
 
 <PageTitle>支付配置</PageTitle>
 
@@ -8,8 +12,218 @@
     </CardHeader>
     <CardBody>
         <CardText>
-            <p>此功能開發中，敬請期待。</p>
-            <p>未來將可設定支付方式、金流串接等相關配置。</p>
+            <p>在這裡設定斗內來源是否可用，以及結果通知要寄送到哪個信箱。</p>
         </CardText>
+
+        @if (settings == null)
+        {
+            <p class="text-muted mb-0">載入中…</p>
+        }
+        else
+        {
+            <Row>
+                <Column ColumnSize="ColumnSize.Is12">
+                    <Field>
+                        <FieldLabel>結果通知信箱</FieldLabel>
+                        <TextInput @bind-Value="settings.ResultNotificationEmail" Placeholder="result@example.com" />
+                    </Field>
+                </Column>
+            </Row>
+
+            <Row Margin="Margin.Is3.FromTop">
+                <Column ColumnSize="ColumnSize.Is12">
+                    <Card>
+                        <CardHeader><CardTitle>SMTP 寄信設定</CardTitle></CardHeader>
+                        <CardBody>
+                            <Alert Color="@(settings.MailDelivery.HasConfiguration ? Color.Success : Color.Warning)" Visible>
+                                <AlertMessage>@(settings.MailDelivery.HasConfiguration ? "已具備寄信配置" : "尚未完成寄信配置")</AlertMessage>
+                                <AlertDescription>結果通知會透過此 SMTP 設定寄出，若沒有完成設定，通知流程會自動略過。</AlertDescription>
+                            </Alert>
+                            <Row>
+                                <Column ColumnSize="ColumnSize.Is6">
+                                    <Field>
+                                        <FieldLabel>SMTP Host</FieldLabel>
+                                        <TextInput @bind-Value="settings.MailDelivery.SmtpHost" Placeholder="smtp.example.com" />
+                                    </Field>
+                                </Column>
+                                <Column ColumnSize="ColumnSize.Is3">
+                                    <Field>
+                                        <FieldLabel>Port</FieldLabel>
+                                        <NumericInput TValue="int" @bind-Value="settings.MailDelivery.SmtpPort" Min="1" Max="65535" />
+                                    </Field>
+                                </Column>
+                                <Column ColumnSize="ColumnSize.Is3">
+                                    <Field>
+                                        <FieldLabel>啟用 SSL</FieldLabel>
+                                        <Switch TValue="bool" @bind-Value="settings.MailDelivery.EnableSsl" />
+                                    </Field>
+                                </Column>
+                            </Row>
+                            <Row>
+                                <Column ColumnSize="ColumnSize.Is6">
+                                    <Field>
+                                        <FieldLabel>SMTP 帳號</FieldLabel>
+                                        <TextInput @bind-Value="settings.MailDelivery.SmtpUsername" />
+                                    </Field>
+                                </Column>
+                                <Column ColumnSize="ColumnSize.Is6">
+                                    <Field>
+                                        <FieldLabel>SMTP 密碼</FieldLabel>
+                                        <TextInput @bind-Value="settings.MailDelivery.SmtpPassword" />
+                                    </Field>
+                                </Column>
+                            </Row>
+                            <Row>
+                                <Column ColumnSize="ColumnSize.Is6">
+                                    <Field>
+                                        <FieldLabel>寄件地址</FieldLabel>
+                                        <TextInput @bind-Value="settings.MailDelivery.FromAddress" Placeholder="noreply@example.com" />
+                                    </Field>
+                                </Column>
+                                <Column ColumnSize="ColumnSize.Is6">
+                                    <Field>
+                                        <FieldLabel>寄件名稱</FieldLabel>
+                                        <TextInput @bind-Value="settings.MailDelivery.FromName" Placeholder="EasyLottery" />
+                                    </Field>
+                                </Column>
+                            </Row>
+                        </CardBody>
+                    </Card>
+                </Column>
+            </Row>
+
+            <Divider />
+
+            <Row>
+                <Column ColumnSize="ColumnSize.Is6">
+                    <Card>
+                        <CardHeader><CardTitle>綠界</CardTitle></CardHeader>
+                        <CardBody>
+                            <Field>
+                                <FieldLabel>Merchant ID</FieldLabel>
+                                <TextInput @bind-Value="settings.DonationIntegration.Ecpay.MerchantId" />
+                            </Field>
+                            <Field>
+                                <FieldLabel>API Key</FieldLabel>
+                                <TextInput @bind-Value="settings.DonationIntegration.Ecpay.ApiKey" />
+                            </Field>
+                            <Field>
+                                <FieldLabel>Secret Key</FieldLabel>
+                                <TextInput @bind-Value="settings.DonationIntegration.Ecpay.SecretKey" />
+                            </Field>
+                            <Field>
+                                <FieldLabel>啟用</FieldLabel>
+                                <Switch TValue="bool" @bind-Value="settings.DonationIntegration.Ecpay.IsEnabled" Disabled="@(!settings.DonationIntegration.Ecpay.HasConfiguration)" />
+                            </Field>
+                        </CardBody>
+                    </Card>
+                </Column>
+                <Column ColumnSize="ColumnSize.Is6">
+                    <Card>
+                        <CardHeader><CardTitle>藍新</CardTitle></CardHeader>
+                        <CardBody>
+                            <Field>
+                                <FieldLabel>Merchant ID</FieldLabel>
+                                <TextInput @bind-Value="settings.DonationIntegration.NewebPay.MerchantId" />
+                            </Field>
+                            <Field>
+                                <FieldLabel>API Key</FieldLabel>
+                                <TextInput @bind-Value="settings.DonationIntegration.NewebPay.ApiKey" />
+                            </Field>
+                            <Field>
+                                <FieldLabel>Secret Key</FieldLabel>
+                                <TextInput @bind-Value="settings.DonationIntegration.NewebPay.SecretKey" />
+                            </Field>
+                            <Field>
+                                <FieldLabel>啟用</FieldLabel>
+                                <Switch TValue="bool" @bind-Value="settings.DonationIntegration.NewebPay.IsEnabled" Disabled="@(!settings.DonationIntegration.NewebPay.HasConfiguration)" />
+                            </Field>
+                        </CardBody>
+                    </Card>
+                </Column>
+            </Row>
+
+            <Row Margin="Margin.Is3.FromTop">
+                <Column ColumnSize="ColumnSize.Is6">
+                    <Card>
+                        <CardHeader><CardTitle>oen.tw</CardTitle></CardHeader>
+                        <CardBody>
+                            <Field>
+                                <FieldLabel>Creator ID</FieldLabel>
+                                <TextInput @bind-Value="settings.DonationIntegration.OenTw.CreatorId" />
+                            </Field>
+                            <Field>
+                                <FieldLabel>Access Token</FieldLabel>
+                                <TextInput @bind-Value="settings.DonationIntegration.OenTw.AccessToken" />
+                            </Field>
+                            <Field>
+                                <FieldLabel>啟用</FieldLabel>
+                                <Switch TValue="bool" @bind-Value="settings.DonationIntegration.OenTw.IsEnabled" Disabled="@(!settings.DonationIntegration.OenTw.HasConfiguration)" />
+                            </Field>
+                        </CardBody>
+                    </Card>
+                </Column>
+                <Column ColumnSize="ColumnSize.Is6">
+                    <Card>
+                        <CardHeader><CardTitle>Twitch 小奇點</CardTitle></CardHeader>
+                        <CardBody>
+                            <Field>
+                                <FieldLabel>Channel ID</FieldLabel>
+                                <TextInput @bind-Value="settings.DonationIntegration.TwitchBits.ChannelId" />
+                            </Field>
+                            <Field>
+                                <FieldLabel>Access Token</FieldLabel>
+                                <TextInput @bind-Value="settings.DonationIntegration.TwitchBits.AccessToken" />
+                            </Field>
+                            <Field>
+                                <FieldLabel>啟用</FieldLabel>
+                                <Switch TValue="bool" @bind-Value="settings.DonationIntegration.TwitchBits.IsEnabled" Disabled="@(!settings.DonationIntegration.TwitchBits.HasConfiguration)" />
+                            </Field>
+                        </CardBody>
+                    </Card>
+                </Column>
+            </Row>
+
+            <Row Margin="Margin.Is3.FromTop">
+                <Column ColumnSize="ColumnSize.Is12">
+                    <Card>
+                        <CardHeader><CardTitle>YouTube SuperChat</CardTitle></CardHeader>
+                        <CardBody>
+                            <Alert Color="@(settings.YouTube.HasConfiguration ? Color.Success : Color.Warning)" Visible>
+                                <AlertMessage>@(settings.YouTube.HasConfiguration ? "已具備 YouTube 配置" : "尚未完成 YouTube 配置")</AlertMessage>
+                                <AlertDescription>SuperChat 是否可啟用，會依照 YouTube OAuth / API 設定判斷。若沒有可用配置，這個來源會被自動停用。</AlertDescription>
+                            </Alert>
+                            <Field>
+                                <FieldLabel>啟用</FieldLabel>
+                                <Switch TValue="bool" @bind-Value="settings.EnableYouTubeSuperChat" Disabled="@(!settings.YouTube.HasConfiguration)" />
+                            </Field>
+                        </CardBody>
+                    </Card>
+                </Column>
+            </Row>
+
+            <Button Color="Color.Primary" Clicked="@SaveAsync" class="mt-3">儲存設定</Button>
+        }
     </CardBody>
 </Card>
+
+@code {
+    private LotterySystemSettings? settings;
+
+    protected override async Task OnInitializedAsync()
+    {
+        settings = await SystemSettingsService.GetSettingsAsync();
+    }
+
+    private async Task SaveAsync()
+    {
+        if (settings == null)
+        {
+            return;
+        }
+
+        await SystemSettingsService.SaveSettingsAsync(settings);
+        settings = await SystemSettingsService.GetSettingsAsync();
+        await MessageService.Success("已儲存支付配置。");
+    }
+}

--- a/src/EasyLotteryWasm/Pages/PokeBox/PokeBoxEditor.razor
+++ b/src/EasyLotteryWasm/Pages/PokeBox/PokeBoxEditor.razor
@@ -72,6 +72,10 @@ else
                         <TextInput @bind-Value="@template.BackgroundImageUrl" Placeholder="https://…" />
                     </Field>
                     <Field>
+                        <FieldLabel>恭喜語句</FieldLabel>
+                        <TextInput @bind-Value="@template.CongratulationMessage" Placeholder="例如：恭喜中獎，請保持聯絡！" />
+                    </Field>
+                    <Field>
                         <FieldLabel>Overlay 寬度</FieldLabel>
                         <NumericInput TValue="int" @bind-Value="@template.OverlayWidth" Min="320" Max="3840" />
                     </Field>

--- a/src/EasyLotteryWasm/Pages/PokeBox/PokeBoxObs.razor
+++ b/src/EasyLotteryWasm/Pages/PokeBox/PokeBoxObs.razor
@@ -5,6 +5,7 @@
 @using EasyLotteryWasm.Layout
 
 @inject ActivityResultService ActivityResultService
+@inject ResultNotificationService ResultNotificationService
 @inject PokeService PokeService
 
 <PageTitle>戳戳樂 - OBS</PageTitle>
@@ -487,6 +488,7 @@ else
         {
             var record = await ActivityResultService.RecordPokeActivityAsync(template.Id);
             lastRecordedSignature = BuildRecordSignature();
+            await ResultNotificationService.NotifyActivityResultAsync(record);
             SetStatus($"已記錄活動「{record.ActivityName}」結果。", false);
         }
         catch (Exception ex)

--- a/src/EasyLotteryWasm/Pages/PokeBox/PokeBoxPreview.razor
+++ b/src/EasyLotteryWasm/Pages/PokeBox/PokeBoxPreview.razor
@@ -3,6 +3,7 @@
 @using EasyLotteryDomain.Services
 
 @inject ActivityResultService ActivityResultService
+@inject ResultNotificationService ResultNotificationService
 @inject PokeService PokeService
 @inject NavigationManager NavigationManager
 @inject IMessageService MessageService
@@ -30,6 +31,13 @@ else
                 <Button Color="Color.Light" Clicked="@GoBack">返回</Button>
             </div>
         </div>
+
+        @if (!string.IsNullOrWhiteSpace(template.CongratulationMessage))
+        {
+            <div class="poke-congrats-banner mb-3">
+                @template.CongratulationMessage
+            </div>
+        }
 
         <div class="poke-grid" style="@GridStyle">
             @foreach (var cell in template.Cells.OrderBy(c => c.Index))
@@ -101,6 +109,19 @@ else
 
     .poke-grid {
         gap: 8px;
+    }
+
+    .poke-congrats-banner {
+        display: inline-flex;
+        align-items: center;
+        max-width: 100%;
+        padding: 12px 16px;
+        border-radius: 999px;
+        background: color-mix(in srgb, var(--el-accent) 24%, var(--el-surface-strong));
+        color: var(--el-text);
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        box-shadow: 0 10px 24px rgba(0, 0, 0, 0.18);
     }
 
     .poke-cell {
@@ -344,6 +365,7 @@ else
         {
             var record = await ActivityResultService.RecordPokeActivityAsync(template.Id);
             lastRecordedSignature = BuildRecordSignature();
+            await ResultNotificationService.NotifyActivityResultAsync(record);
             await MessageService.Success($"已記錄活動「{record.ActivityName}」結果。");
         }
         catch (Exception ex)

--- a/src/EasyLotteryWasm/Pages/Roulette/RouletteObs.razor
+++ b/src/EasyLotteryWasm/Pages/Roulette/RouletteObs.razor
@@ -5,6 +5,7 @@
 @using EasyLotteryWasm.Layout
 
 @inject ActivityResultService ActivityResultService
+@inject ResultNotificationService ResultNotificationService
 @inject RouletteService RouletteService
 
 <PageTitle>轉盤 - OBS</PageTitle>
@@ -470,6 +471,7 @@ else
         {
             var record = await ActivityResultService.RecordRouletteActivityAsync(template.Id, lastResult);
             lastRecordedSignature = BuildRecordSignature();
+            await ResultNotificationService.NotifyActivityResultAsync(record);
             SetStatus($"已記錄活動「{record.ActivityName}」結果。", false);
         }
         catch (Exception ex)

--- a/src/EasyLotteryWasm/Pages/Roulette/RoulettePreview.razor
+++ b/src/EasyLotteryWasm/Pages/Roulette/RoulettePreview.razor
@@ -3,6 +3,7 @@
 @using EasyLotteryDomain.Services
 
 @inject ActivityResultService ActivityResultService
+@inject ResultNotificationService ResultNotificationService
 @inject RouletteService RouletteService
 @inject NavigationManager NavigationManager
 @inject IMessageService MessageService
@@ -355,6 +356,7 @@ else
         {
             var record = await ActivityResultService.RecordRouletteActivityAsync(template.Id, lastResult);
             lastRecordedSignature = BuildRecordSignature();
+            await ResultNotificationService.NotifyActivityResultAsync(record);
             await MessageService.Success($"已記錄活動「{record.ActivityName}」結果。");
         }
         catch (Exception ex)

--- a/src/EasyLotteryWasm/Program.cs
+++ b/src/EasyLotteryWasm/Program.cs
@@ -35,6 +35,7 @@ builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(apiBaseU
 builder.Services.AddScoped<IEasyLotteryConfigStore, YamlEasyLotteryConfigStore>();
 builder.Services.AddScoped<SystemSettingsService>();
 builder.Services.AddScoped<ActivityResultService>();
+builder.Services.AddScoped<ResultNotificationService>();
 builder.Services.AddScoped<VisualStyleService>();
 builder.Services.AddScoped<OvertimeFeedClient>();
 builder.Services.AddScoped<EasyLotteryAuditService>();

--- a/src/EasyLotteryWasm/Services/ResultNotificationService.cs
+++ b/src/EasyLotteryWasm/Services/ResultNotificationService.cs
@@ -1,0 +1,95 @@
+using EasyLotteryDomain.Models.Config;
+using EasyLotteryDomain.Services;
+using Microsoft.JSInterop;
+
+namespace EasyLotteryWasm.Services
+{
+    public sealed class ResultNotificationService
+    {
+        private readonly SystemSettingsService _systemSettingsService;
+        private readonly IJSRuntime _jsRuntime;
+        private readonly ILogger<ResultNotificationService> _logger;
+
+        public ResultNotificationService(
+            SystemSettingsService systemSettingsService,
+            IJSRuntime jsRuntime,
+            ILogger<ResultNotificationService> logger)
+        {
+            _systemSettingsService = systemSettingsService;
+            _jsRuntime = jsRuntime;
+            _logger = logger;
+        }
+
+        public async Task NotifyActivityResultAsync(ActivityResultRecord record, CancellationToken cancellationToken = default)
+        {
+            if (record == null)
+            {
+                return;
+            }
+
+            try
+            {
+                var settings = await _systemSettingsService.GetSettingsAsync(cancellationToken);
+                if (string.IsNullOrWhiteSpace(settings.ResultNotificationEmail) || !settings.MailDelivery.HasConfiguration)
+                {
+                    return;
+                }
+
+                var request = new EmailRequest
+                {
+                    Recipient = settings.ResultNotificationEmail.Trim(),
+                    Subject = ActivityResultNotificationFormatter.BuildSubject(record),
+                    Body = ActivityResultNotificationFormatter.BuildBody(record),
+                    Smtp = new SmtpRequest
+                    {
+                        Host = settings.MailDelivery.SmtpHost,
+                        Port = settings.MailDelivery.SmtpPort,
+                        Username = settings.MailDelivery.SmtpUsername,
+                        Password = settings.MailDelivery.SmtpPassword,
+                        FromAddress = settings.MailDelivery.FromAddress,
+                        FromName = settings.MailDelivery.FromName,
+                        EnableSsl = settings.MailDelivery.EnableSsl
+                    }
+                };
+
+                await _jsRuntime.InvokeVoidAsync("easyLotteryMail.send", cancellationToken, request);
+            }
+            catch (JSException ex)
+            {
+                _logger.LogWarning(ex, "Failed to send result notification mail through the browser bridge.");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to send result notification mail.");
+            }
+        }
+
+        public sealed class EmailRequest
+        {
+            public string Recipient { get; set; } = "";
+
+            public string Subject { get; set; } = "";
+
+            public string Body { get; set; } = "";
+
+            public SmtpRequest Smtp { get; set; } = new();
+        }
+
+        public sealed class SmtpRequest
+        {
+            public string Host { get; set; } = "";
+
+            public int Port { get; set; }
+
+            public string Username { get; set; } = "";
+
+            public string Password { get; set; } = "";
+
+            public string FromAddress { get; set; } = "";
+
+            public string FromName { get; set; } = "";
+
+            public bool EnableSsl { get; set; }
+        }
+    }
+}

--- a/src/EasyLotteryWasm/Services/YamlEasyLotteryConfigStore.cs
+++ b/src/EasyLotteryWasm/Services/YamlEasyLotteryConfigStore.cs
@@ -132,6 +132,12 @@ namespace EasyLotteryWasm.Services
             document ??= new EasyLotteryConfigDocument();
             document.SystemSettings ??= new LotterySystemSettings();
             document.SystemSettings.YouTube ??= new YouTubeApiSettings();
+            document.SystemSettings.DonationIntegration ??= new DonationIntegrationSettings();
+            document.SystemSettings.MailDelivery ??= new MailDeliverySettings();
+            document.SystemSettings.DonationIntegration.Ecpay ??= new DonationProviderSettings { Name = "綠界" };
+            document.SystemSettings.DonationIntegration.NewebPay ??= new DonationProviderSettings { Name = "藍新" };
+            document.SystemSettings.DonationIntegration.OenTw ??= new DonationProviderSettings { Name = "oen.tw" };
+            document.SystemSettings.DonationIntegration.TwitchBits ??= new DonationProviderSettings { Name = "Twitch 小奇點" };
             document.SystemSettings.Audit ??= new AuditSettings();
             document.IdSequence ??= new LotteryIdSequence();
             document.PokeTemplates ??= new List<PokeTemplate>();
@@ -148,6 +154,22 @@ namespace EasyLotteryWasm.Services
                 ? "festival-stage"
                 : document.OvertimeOverlay.ThemeKey.Trim();
             document.OvertimeOverlay.MaxVisibleItems = Math.Max(1, document.OvertimeOverlay.MaxVisibleItems);
+            document.SystemSettings.ResultNotificationEmail = document.SystemSettings.ResultNotificationEmail.Trim();
+            document.SystemSettings.DonationIntegration.Ecpay.Name = string.IsNullOrWhiteSpace(document.SystemSettings.DonationIntegration.Ecpay.Name) ? "綠界" : document.SystemSettings.DonationIntegration.Ecpay.Name.Trim();
+            document.SystemSettings.DonationIntegration.NewebPay.Name = string.IsNullOrWhiteSpace(document.SystemSettings.DonationIntegration.NewebPay.Name) ? "藍新" : document.SystemSettings.DonationIntegration.NewebPay.Name.Trim();
+            document.SystemSettings.DonationIntegration.OenTw.Name = string.IsNullOrWhiteSpace(document.SystemSettings.DonationIntegration.OenTw.Name) ? "oen.tw" : document.SystemSettings.DonationIntegration.OenTw.Name.Trim();
+            document.SystemSettings.DonationIntegration.TwitchBits.Name = string.IsNullOrWhiteSpace(document.SystemSettings.DonationIntegration.TwitchBits.Name) ? "Twitch 小奇點" : document.SystemSettings.DonationIntegration.TwitchBits.Name.Trim();
+            document.SystemSettings.MailDelivery.SmtpHost = document.SystemSettings.MailDelivery.SmtpHost.Trim();
+            document.SystemSettings.MailDelivery.SmtpPort = Math.Max(0, document.SystemSettings.MailDelivery.SmtpPort);
+            document.SystemSettings.MailDelivery.SmtpUsername = document.SystemSettings.MailDelivery.SmtpUsername.Trim();
+            document.SystemSettings.MailDelivery.SmtpPassword = document.SystemSettings.MailDelivery.SmtpPassword.Trim();
+            document.SystemSettings.MailDelivery.FromAddress = document.SystemSettings.MailDelivery.FromAddress.Trim();
+            document.SystemSettings.MailDelivery.FromName = string.IsNullOrWhiteSpace(document.SystemSettings.MailDelivery.FromName) ? "EasyLottery" : document.SystemSettings.MailDelivery.FromName.Trim();
+            document.SystemSettings.EnableYouTubeSuperChat &= document.SystemSettings.YouTube.HasConfiguration;
+            document.SystemSettings.DonationIntegration.Ecpay.IsEnabled &= document.SystemSettings.DonationIntegration.Ecpay.HasConfiguration;
+            document.SystemSettings.DonationIntegration.NewebPay.IsEnabled &= document.SystemSettings.DonationIntegration.NewebPay.HasConfiguration;
+            document.SystemSettings.DonationIntegration.OenTw.IsEnabled &= document.SystemSettings.DonationIntegration.OenTw.HasConfiguration;
+            document.SystemSettings.DonationIntegration.TwitchBits.IsEnabled &= document.SystemSettings.DonationIntegration.TwitchBits.HasConfiguration;
             document.AuditRecords ??= new List<ChangeAuditRecord>();
 
             foreach (var template in document.PokeTemplates)
@@ -184,6 +206,7 @@ namespace EasyLotteryWasm.Services
             document.IdSequence.NextActivityResultId = Math.Max(document.IdSequence.NextActivityResultId, document.ActivityResults.Select(result => result.Id).DefaultIfEmpty(0).Max() + 1);
             document.IdSequence.NextAuditRecordId = Math.Max(document.IdSequence.NextAuditRecordId, document.AuditRecords.Select(record => record.Id).DefaultIfEmpty(0).Max() + 1);
             document.SystemSettings.Audit.ActorName = string.IsNullOrWhiteSpace(document.SystemSettings.Audit.ActorName) ? "本機操作" : document.SystemSettings.Audit.ActorName.Trim();
+            document.SystemSettings.ResultNotificationEmail = document.SystemSettings.ResultNotificationEmail.Trim();
 
             return document;
         }
@@ -203,6 +226,7 @@ namespace EasyLotteryWasm.Services
             template.Description ??= "";
             template.BackgroundImageUrl ??= "";
             template.FontFamily ??= "";
+            template.CongratulationMessage ??= "";
             template.PokeSoundUrl ??= "";
             template.OpenSoundUrl ??= "";
             template.Cells ??= new List<PokeCell>();

--- a/src/EasyLotteryWasm/wwwroot/index.html
+++ b/src/EasyLotteryWasm/wwwroot/index.html
@@ -85,6 +85,32 @@
             };
         })();
     </script>
+    <script>
+        (() => {
+            if (window.easyLotteryMail) {
+                return;
+            }
+
+            function getTauriInvoker() {
+                if (window.__TAURI__ && typeof window.__TAURI__.invoke === "function") {
+                    return window.__TAURI__.invoke.bind(window.__TAURI__);
+                }
+
+                return null;
+            }
+
+            window.easyLotteryMail = {
+                send: async (request) => {
+                    const tauriInvoke = getTauriInvoker();
+                    if (!tauriInvoke) {
+                        return;
+                    }
+
+                    await tauriInvoke("send_result_notification_email", { request });
+                }
+            };
+        })();
+    </script>
     <script src="js/configStorage.js"></script>
     <script>
         window.easyLotteryDownload = {

--- a/tests/EasyLotteryDomainTests/Services/ActivityResultNotificationFormatterTests.cs
+++ b/tests/EasyLotteryDomainTests/Services/ActivityResultNotificationFormatterTests.cs
@@ -1,0 +1,33 @@
+using EasyLotteryDomain.Models.Config;
+using EasyLotteryDomain.Services;
+
+namespace EasyLotteryDomainTests.Services
+{
+    [TestClass]
+    public class ActivityResultNotificationFormatterTests
+    {
+        [TestMethod]
+        public void BuildBody_IncludesActivitySummaryAndItems()
+        {
+            var record = new ActivityResultRecord
+            {
+                ActivityName = "拍立得抽獎",
+                ActivityDateUtc = new DateTime(2026, 7, 16, 12, 30, 0, DateTimeKind.Utc),
+                Summary = "中獎項目：A 獎",
+                Items =
+                [
+                    new ActivityResultItem { Order = 2, Name = "B 獎", Description = "第二項" },
+                    new ActivityResultItem { Order = 1, Name = "A 獎", Description = "第一項" }
+                ]
+            };
+
+            var body = ActivityResultNotificationFormatter.BuildBody(record);
+
+            Assert.IsTrue(body.Contains("EasyLottery 結果通知"));
+            Assert.IsTrue(body.Contains("活動名稱：拍立得抽獎"));
+            Assert.IsTrue(body.Contains("摘要：中獎項目：A 獎"));
+            Assert.IsTrue(body.Contains("1. A 獎 - 第一項"));
+            Assert.IsTrue(body.Contains("2. B 獎 - 第二項"));
+        }
+    }
+}

--- a/tests/EasyLotteryDomainTests/Services/PokeServiceTests.cs
+++ b/tests/EasyLotteryDomainTests/Services/PokeServiceTests.cs
@@ -99,6 +99,7 @@ namespace EasyLotteryDomainTests.Services
                 MaxPokeCount = 4,
                 BackgroundImageUrl = "/bg.png",
                 FontFamily = "Noto Sans TC",
+                CongratulationMessage = "恭喜中獎",
                 OverlayWidth = 1280,
                 OverlayHeight = 720,
                 Animation = PokeAnimation.Flash,
@@ -128,6 +129,7 @@ namespace EasyLotteryDomainTests.Services
             Assert.AreEqual(template.MaxPokeCount, duplicate.MaxPokeCount);
             Assert.AreEqual(template.BackgroundImageUrl, duplicate.BackgroundImageUrl);
             Assert.AreEqual(template.FontFamily, duplicate.FontFamily);
+            Assert.AreEqual(template.CongratulationMessage, duplicate.CongratulationMessage);
             Assert.AreEqual(template.OverlayWidth, duplicate.OverlayWidth);
             Assert.AreEqual(template.OverlayHeight, duplicate.OverlayHeight);
             Assert.AreEqual(template.Animation, duplicate.Animation);


### PR DESCRIPTION
## Summary
- 新增斗內來源設定中的 YouTube SuperChat 獨立開關，以及結果通知信箱與 SMTP 寄信設定。
- 擴充戳戳樂模板，加入恭喜語句欄位，並在預覽頁顯示該文案。
- 結果記錄後會嘗試透過 Tauri 後端寄出通知信。

## What changed
- `PaymentSettings` 新增 SMTP 設定區塊，並讓來源可用性依配置自動停用。
- `PokeTemplate` 新增恭喜語句欄位，編輯器與預覽頁同步支援。
- `ActivityResultService` 的結果輸出格式抽成可測試 formatter，通知服務可重用。
- `PokeBox` / `Roulette` 的 preview 與 OBS 入口在記錄結果後會呼叫通知服務。
- Tauri 後端新增 `send_result_notification_email` command，使用 SMTP 寄出結果信。

## Verification
- `dotnet build src/EasyLotteryWasm/EasyLotteryWasm.csproj -nologo`
- `dotnet test tests/EasyLotteryDomainTests/EasyLotteryDomainTests.csproj --filter PokeServiceTests -nologo`
- `dotnet test tests/EasyLotteryDomainTests/EasyLotteryDomainTests.csproj --filter ActivityResultNotificationFormatterTests -nologo`

## Risk / follow-up
- Rust / Tauri 端在目前容器沒有 `cargo`，所以無法做本機編譯驗證；`main.rs` 已做來源檢查，但仍建議在有 Rust toolchain 的環境再跑一次 `cargo check`。
- SMTP 設定目前是最小可用落點，後續若要支援 provider-specific auth 或更完整的郵件樣板，可能需要再擴充。
