### PR TITLE
Switch YouTube setup to API key

### DIFF
--- a/src/EasyLotteryDomain/Models/Config/EasyLotteryConfigDocument.cs
+++ b/src/EasyLotteryDomain/Models/Config/EasyLotteryConfigDocument.cs
@@ -52,10 +52,7 @@ namespace EasyLotteryDomain.Models.Config
         public string RefreshToken { get; set; } = "";
 
         public bool HasConfiguration =>
-            !string.IsNullOrWhiteSpace(ApiKey) ||
-            !string.IsNullOrWhiteSpace(CredentialsBase64) ||
-            !string.IsNullOrWhiteSpace(RedirectUri) ||
-            !string.IsNullOrWhiteSpace(RefreshToken);
+            !string.IsNullOrWhiteSpace(ApiKey);
     }
 
     public sealed class DonationIntegrationSettings

--- a/src/EasyLotteryDomain/Services/YouTubeServiceHelper.cs
+++ b/src/EasyLotteryDomain/Services/YouTubeServiceHelper.cs
@@ -60,7 +60,7 @@ namespace EasyLotteryDomain.Services
         public async Task<bool> HasConfiguredCredentialsAsync()
         {
             var settings = await GetEffectiveYouTubeSettingsAsync();
-            return !string.IsNullOrWhiteSpace(settings.CredentialsBase64);
+            return !string.IsNullOrWhiteSpace(settings.ApiKey);
         }
 
         public async Task<bool> HasRefreshTokenAsync()
@@ -289,53 +289,57 @@ namespace EasyLotteryDomain.Services
 
         public async Task<IEnumerable<Google.Apis.YouTube.v3.Data.LiveChatMessage>> ListLiveChatMessageAsync(string chatID)
         {
-              if (string.IsNullOrWhiteSpace(accessToken))
-                {
-                    throw new InvalidOperationException("OAuth access token is required. Please authorize via YouTube OAuth first.");
-                }
-              using var httpClient = new HttpClient();
-                httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
-               
-                var response = await httpClient.GetAsync($"https://www.googleapis.com/youtube/v3/liveChat/messages?liveChatId={chatID}&part=snippet,authorDetails");
+            var apiKey = await GetConfiguredApiKeyAsync();
+            if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                throw new InvalidOperationException("YouTube API key is required. Please configure the API key first.");
+            }
 
-                if (response.IsSuccessStatusCode)
+            using var httpClient = new HttpClient();
+
+            var response = await httpClient.GetAsync($"https://www.googleapis.com/youtube/v3/liveChat/messages?liveChatId={Uri.EscapeDataString(chatID)}&part=snippet,authorDetails&key={Uri.EscapeDataString(apiKey)}");
+
+            if (response.IsSuccessStatusCode)
+            {
+                var info = await response.Content.ReadFromJsonAsync<Google.Apis.YouTube.v3.Data.LiveChatMessageListResponse>();
+                if (info == null)
                 {
-                    var info = await response.Content.ReadFromJsonAsync<Google.Apis.YouTube.v3.Data.LiveChatMessageListResponse>();
-                    if (info == null)
-                    {
-                         return [];
-                    }
-                    return info.Items;
-                }
-                else
-                {
-                    logger.LogInformation($"Error: {response.StatusCode}");
                     return [];
                 }
+
+                return info.Items;
+            }
+
+            logger.LogInformation($"Error: {response.StatusCode}");
+            return [];
         }
 
 
         public async Task<Google.Apis.YouTube.v3.Data.VideoLiveStreamingDetails?> GetYoutubeLiveInfoAsync(string liveID)
         {
-                if (string.IsNullOrWhiteSpace(accessToken))
-                {
-                    throw new InvalidOperationException("OAuth access token is required. Please authorize via YouTube OAuth first.");
-                }
-                using var httpClient = new HttpClient();
-                httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
-                var response = await httpClient.GetAsync($"https://www.googleapis.com/youtube/v3/videos?part=liveStreamingDetails&id={liveID}");
+            var apiKey = await GetConfiguredApiKeyAsync();
+            if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                throw new InvalidOperationException("YouTube API key is required. Please configure the API key first.");
+            }
 
-                if (response.IsSuccessStatusCode)
-                {
-                    var info = await response.Content.ReadFromJsonAsync<Google.Apis.YouTube.v3.Data.VideoListResponse>();
-                    return info?.Items.FirstOrDefault(o=>o.LiveStreamingDetails != null)?.LiveStreamingDetails;
-                    
-                }
-                else
-                {
-                    logger.LogInformation($"Error: {response.StatusCode}");
-                    return null;
-                }
+            using var httpClient = new HttpClient();
+            var response = await httpClient.GetAsync($"https://www.googleapis.com/youtube/v3/videos?part=liveStreamingDetails&id={Uri.EscapeDataString(liveID)}&key={Uri.EscapeDataString(apiKey)}");
+
+            if (response.IsSuccessStatusCode)
+            {
+                var info = await response.Content.ReadFromJsonAsync<Google.Apis.YouTube.v3.Data.VideoListResponse>();
+                return info?.Items.FirstOrDefault(o => o.LiveStreamingDetails != null)?.LiveStreamingDetails;
+            }
+
+            logger.LogInformation($"Error: {response.StatusCode}");
+            return null;
+        }
+
+        private async Task<string> GetConfiguredApiKeyAsync()
+        {
+            var settings = await GetEffectiveYouTubeSettingsAsync();
+            return settings.ApiKey ?? string.Empty;
         }
 
         public static string GetYouTubeLiveID(string url)

--- a/src/EasyLotteryWasm/App.razor
+++ b/src/EasyLotteryWasm/App.razor
@@ -1,5 +1,4 @@
-﻿@using System.Web
-@inject NavigationManager NavigationManager
+﻿@inject NavigationManager NavigationManager
 @inject EasyLotteryWasm.Services.VisualStyleService VisualStyleService
 
 <Router AppAssembly="@typeof(App).Assembly">
@@ -24,24 +23,5 @@
         }
 
         await VisualStyleService.InitializeAsync();
-        TryForwardYoutubeOAuthCallback();
-    }
-
-    private void TryForwardYoutubeOAuthCallback()
-    {
-        var currentUri = NavigationManager.ToAbsoluteUri(NavigationManager.Uri);
-        var queryParams = HttpUtility.ParseQueryString(currentUri.Query);
-        if (string.IsNullOrWhiteSpace(queryParams["code"]) && string.IsNullOrWhiteSpace(queryParams["error"]))
-        {
-            return;
-        }
-
-        var currentPath = currentUri.AbsolutePath.TrimEnd('/');
-        if (string.Equals(currentPath, "/system/youtube-login", StringComparison.OrdinalIgnoreCase))
-        {
-            return;
-        }
-
-        NavigationManager.NavigateTo($"/system/youtube-login{currentUri.Query}", replace: true);
     }
 }

--- a/src/EasyLotteryWasm/Layout/NavMenu.razor
+++ b/src/EasyLotteryWasm/Layout/NavMenu.razor
@@ -65,7 +65,7 @@
             </div>
             <div class="nav-item px-3 nav-sub-item">
                 <NavLink class="nav-link" href="system/youtube-login">
-                    YouTube 登入
+                    YouTube API Key
                 </NavLink>
             </div>
             <div class="nav-item px-3 nav-sub-item">
@@ -80,15 +80,15 @@
 
 <div class="nav-login-status px-3">
     <div class="status-indicator">
-        @if(youTubeServiceHelper.IsAuthorized)
+        @if(hasYoutubeApiKey)
         {
             <span class="status-dot status-online"></span>
-            <span class="status-text">YT 已登入</span>
+            <span class="status-text">YT API Key 已設定</span>
         }
         else
         {
             <span class="status-dot status-offline"></span>
-            <span class="status-text">YT 未登入</span>
+            <span class="status-text">YT API Key 未設定</span>
         }
     </div>
 </div>
@@ -97,12 +97,14 @@
     private bool collapseNavMenu = false;
     private bool activityGroupExpanded = false;
     private bool systemGroupExpanded = false;
+    private bool hasYoutubeApiKey = false;
 
     private string? NavMenuCssClass => collapseNavMenu ? "collapse" : null;
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
         youTubeServiceHelper.AuthStateChanged += OnAuthStateChanged;
+        hasYoutubeApiKey = await youTubeServiceHelper.HasConfiguredCredentialsAsync();
     }
 
     private void OnAuthStateChanged()

--- a/src/EasyLotteryWasm/Pages/Config/PaymentSettings.razor
+++ b/src/EasyLotteryWasm/Pages/Config/PaymentSettings.razor
@@ -191,7 +191,7 @@
                         <CardBody>
                             <Alert Color="@(settings.YouTube.HasConfiguration ? Color.Success : Color.Warning)" Visible>
                                 <AlertMessage>@(settings.YouTube.HasConfiguration ? "已具備 YouTube 配置" : "尚未完成 YouTube 配置")</AlertMessage>
-                                <AlertDescription>SuperChat 是否可啟用，會依照 YouTube OAuth / API 設定判斷。若沒有可用配置，這個來源會被自動停用。</AlertDescription>
+                                <AlertDescription>SuperChat 是否可啟用，會依照 YouTube API Key 設定判斷。若沒有可用配置，這個來源會被自動停用。</AlertDescription>
                             </Alert>
                             <Field>
                                 <FieldLabel>啟用</FieldLabel>

--- a/src/EasyLotteryWasm/Pages/Config/YoutubeLogin.razor
+++ b/src/EasyLotteryWasm/Pages/Config/YoutubeLogin.razor
@@ -1,165 +1,73 @@
 @page "/system/youtube-login"
-@using EasyLotteryDomain.Models.Youtube
-@using Google.Apis.Auth.OAuth2
-@using Google.Apis.Auth.OAuth2.Flows
-@using Google.Apis.Auth.OAuth2.Responses
-@using Google.Apis.YouTube.v3
-@using System.Web
-@using Serilog
+@using EasyLotteryDomain.Models.Config
 
-@inject NavigationManager NavigationManager
-@implements IDisposable
-@inject YouTubeServiceHelper youTubeServiceHelper
-@inject ILogger<YouTubeServiceHelper> Logger
+@inject SystemSettingsService SystemSettingsService
+@inject IMessageService MessageService
 
-<PageTitle>YouTube 登入</PageTitle>
+<PageTitle>YouTube API Key</PageTitle>
 
 <Card>
     <CardHeader>
-        <CardTitle>YouTube OAuth 授權</CardTitle>
+        <CardTitle>YouTube API Key 設定與說明</CardTitle>
     </CardHeader>
     <CardBody>
         <CardText>
-            @if(!showYoutube)
+            <Alert Color="@(settings?.YouTube.HasConfiguration == true ? Color.Success : Color.Warning)" Visible>
+                <AlertMessage>@(settings?.YouTube.HasConfiguration == true ? "已設定 YouTube API Key" : "尚未設定 YouTube API Key")</AlertMessage>
+                <AlertDescription>系統現在以 API Key 讀取公開的 YouTube 資料，不再要求使用者先走 OAuth 登入流程。</AlertDescription>
+            </Alert>
+
+            @if (settings == null)
             {
-                <Alert Color="Color.Warning" Visible>
-                    <AlertMessage>尚未設定 YouTube API 憑證</AlertMessage>
-                    <AlertDescription>目前未載入應用程式內建的 YouTube OAuth 設定。這組 client 憑證不應由使用者在 YAML 中手動填寫，請檢查 appsettings 的 <code>YouTubeApi:CredentialsBase64</code> 與 <code>YouTubeApi:RedirectUri</code> 是否已隨應用程式發布。</AlertDescription>
-                </Alert>
+                <p class="text-muted mb-0">載入中…</p>
             }
             else
             {
-                <Row>
-                    <Column ColumnSize="ColumnSize.Is12">
-                        <Field>
-                            <FieldLabel>授權狀態</FieldLabel>
-                            <FieldBody>
-                                @if(isAuthorized)
-                                {
-                                    <Alert Color="Color.Success" Visible>
-                                        <AlertMessage>已授權</AlertMessage>
-                                        <AlertDescription>YouTube OAuth 授權成功，可以使用 YouTube 相關功能。</AlertDescription>
-                                    </Alert>
-                                }
-                                else
-                                {
-                                    <Alert Color="Color.Info" Visible>
-                                        <AlertMessage>未授權</AlertMessage>
-                                        <AlertDescription>請點擊下方按鈕進行 YouTube OAuth 授權登入。</AlertDescription>
-                                    </Alert>
-                                }
-                            </FieldBody>
-                        </Field>
-                    </Column>
-                </Row>
+                <Field>
+                    <FieldLabel>YouTube API Key</FieldLabel>
+                    <TextInput @bind-Value="settings.YouTube.ApiKey" Placeholder="AIza..." />
+                </Field>
 
-                <Divider />
-
-                <Row>
-                    <Column ColumnSize="ColumnSize.IsAuto">
-                        @if(isAuthorized)
-                        {
-                            <Button Color="Color.Danger" @onclick="Logout" Size="Size.Large">
-                                <Icon Name="IconName.TimesCircle" /> 登出 YouTube 授權
-                            </Button>
-                        }
-                        else
-                        {
-                            <Button Color="Color.Primary" @onclick="Authorize" Size="Size.Large">
-                                <Icon Name="IconName.Link" /> YouTube OAuth 授權登入
-                            </Button>
-                        }
-                    </Column>
-                </Row>
+                <div class="d-flex gap-2 flex-wrap mt-3">
+                    <Button Color="Color.Primary" Clicked="SaveAsync">儲存 API Key</Button>
+                </div>
             }
         </CardText>
     </CardBody>
 </Card>
 
-<Toaster>
-    <Toast @bind-Visible="@toastVisible">
-        <ToastBody>
-           @toastMessage
-        </ToastBody>
-    </Toast>
-</Toaster>
+<Card class="mt-3">
+    <CardHeader>
+        <CardTitle>取得方式與必要設定</CardTitle>
+    </CardHeader>
+    <CardBody>
+        <ol class="mb-0">
+            <li>前往 Google Cloud Console 建立或選擇專案。</li>
+            <li>啟用 <strong>YouTube Data API v3</strong>。</li>
+            <li>建立一組 API Key，並依實際部署環境限制來源。</li>
+            <li>將 API Key 貼到上方欄位並儲存。</li>
+            <li>若要讀取公開直播聊天室與直播狀態，API Key 就足夠；不需要再做 OAuth 登入。</li>
+        </ol>
+    </CardBody>
+</Card>
 
 @code {
-    private bool showYoutube = false;
-    private bool isAuthorized = false;
-    private string toastMessage = "";
-    private bool toastVisible = false;
+    private LotterySystemSettings? settings;
 
     protected override async Task OnInitializedAsync()
     {
-        youTubeServiceHelper.AuthStateChanged += OnAuthStateChanged;
+        settings = await SystemSettingsService.GetSettingsAsync();
+    }
 
-        if (await youTubeServiceHelper.HasConfiguredCredentialsAsync())
+    private async Task SaveAsync()
+    {
+        if (settings == null)
         {
-            showYoutube = true;
-        }
-
-        if (await youTubeServiceHelper.HasRefreshTokenAsync())
-        {
-            await youTubeServiceHelper.RefreshTokenAsync();
-            isAuthorized = youTubeServiceHelper.IsAuthorized;
-        }
-
-        var uri = NavigationManager.ToAbsoluteUri(NavigationManager.Uri);
-        var queryParams = HttpUtility.ParseQueryString(uri.Query);
-        if (!string.IsNullOrWhiteSpace(queryParams["error"]))
-        {
-            toastMessage = $"授權失敗：{queryParams["error"]}";
-            toastVisible = true;
-            NavigationManager.NavigateTo("/system/youtube-login", replace: true);
             return;
         }
 
-        if (queryParams["code"] != null)
-        {
-            await ExchangeCodeForTokensAsync(queryParams["code"]!);
-        }
-
-        // 也同步一下現有的授權狀態
-        isAuthorized = youTubeServiceHelper.IsAuthorized;
-    }
-
-    private async Task Authorize()
-    {
-        var authorizationUrl = await youTubeServiceHelper.GetAuthorizeUrlAsync();
-        NavigationManager.NavigateTo(authorizationUrl, forceLoad: true);
-    }
-
-    private async Task ExchangeCodeForTokensAsync(string code)
-    {
-        var token = await youTubeServiceHelper.ExchangeCodeAsync(code);
-        if (token != null)
-        {
-            isAuthorized = true;
-            toastMessage = "授權成功";
-            toastVisible = true;
-            NavigationManager.NavigateTo("/system/youtube-login", forceLoad: false);
-            StateHasChanged();
-        }
-    }
-
-    private void Logout()
-    {
-        youTubeServiceHelper.Logout();
-        isAuthorized = false;
-        toastMessage = "已登出 YouTube 授權";
-        toastVisible = true;
-        StateHasChanged();
-    }
-
-    private async void OnAuthStateChanged()
-    {
-        isAuthorized = youTubeServiceHelper.IsAuthorized;
-        await InvokeAsync(StateHasChanged);
-    }
-
-    public void Dispose()
-    {
-        youTubeServiceHelper.AuthStateChanged -= OnAuthStateChanged;
+        await SystemSettingsService.SaveSettingsAsync(settings);
+        settings = await SystemSettingsService.GetSettingsAsync();
+        await MessageService.Success("已儲存 YouTube API Key。");
     }
 }

--- a/src/EasyLotteryWasm/Pages/Home.razor
+++ b/src/EasyLotteryWasm/Pages/Home.razor
@@ -40,13 +40,13 @@
                 </Field>
             </Column>
             <Column ColumnSize="ColumnSize.IsAuto">
-                @if(youTubeServiceHelper.IsAuthorized)
+                @if(hasYoutubeApiKey)
                 {
-                    <Badge Color="Color.Success"><Icon Name="IconName.CheckCircle" /> YT 已授權</Badge>
+                    <Badge Color="Color.Success"><Icon Name="IconName.CheckCircle" /> YT API Key 已設定</Badge>
                 }
                 else
                 {
-                    <Badge Color="Color.Secondary">YT 未授權</Badge>
+                    <Badge Color="Color.Secondary">YT API Key 未設定</Badge>
                 }
             </Column>
         </Row>
@@ -326,7 +326,7 @@
 
 <Toaster>
     <Toast @bind-Visible="@toastVisible">
-        
+
         <ToastBody>
            @toastMessage
         </ToastBody>
@@ -338,6 +338,7 @@
     private ChatRoomCatch chatRoomCatch = new ChatRoomCatch();
     private bool catchChat = false;
     private Dictionary<string, DateTimeOffset> lastAcceptedMessageTimes = new(StringComparer.OrdinalIgnoreCase);
+    private bool hasYoutubeApiKey = false;
 
     private string toastMessage = "";
 
@@ -350,9 +351,7 @@
     {
         youTubeServiceHelper.AuthStateChanged += OnAuthStateChanged;
 
-        if (await youTubeServiceHelper.HasRefreshTokenAsync()) {
-            await youTubeServiceHelper.RefreshTokenAsync();
-        }
+        hasYoutubeApiKey = await youTubeServiceHelper.HasConfiguredCredentialsAsync();
 
         await LoadDrawingRuleStateAsync();
     }

--- a/tests/EasyLotteryDomainTests/Services/YouTubeServiceHelperTest.cs
+++ b/tests/EasyLotteryDomainTests/Services/YouTubeServiceHelperTest.cs
@@ -65,7 +65,7 @@ namespace EasyLotteryDomainTests.Services
             var exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
                 () => svc.GetYoutubeLiveInfoAsync("zrSJ7p5m0Bk"));
 
-            Assert.AreEqual("OAuth access token is required. Please authorize via YouTube OAuth first.", exception.Message);
+            Assert.AreEqual("YouTube API key is required. Please configure the API key first.", exception.Message);
         }
 
         [TestMethod]
@@ -84,7 +84,7 @@ namespace EasyLotteryDomainTests.Services
             var exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
                 () => svc.ListLiveChatMessageAsync("Cg0KCy1MOWNCZjNvQU8wKicKGFVDa0VMTU1CZHk0Z1BqNm9vUXdZSi15ZxILLUw5Y0JmM29BTzA"));
 
-            Assert.AreEqual("OAuth access token is required. Please authorize via YouTube OAuth first.", exception.Message);
+            Assert.AreEqual("YouTube API key is required. Please configure the API key first.", exception.Message);
         }
 
         [TestMethod]

--- a/tests/EasyLotteryDomainTests/Services/YouTubeServiceHelperUnitTest.cs
+++ b/tests/EasyLotteryDomainTests/Services/YouTubeServiceHelperUnitTest.cs
@@ -295,6 +295,20 @@ namespace EasyLotteryDomainTests.Services
             Assert.IsTrue(configured);
         }
 
+        [TestMethod]
+        public async Task HasConfiguredCredentialsAsync_RequiresApiKey()
+        {
+            var svc = CreateService(extraConfig: new Dictionary<string, string>
+            {
+                { "YouTubeApi:ApiKey", "" },
+                { "YouTubeApi:CredentialsBase64", TestCredentialsBase64 }
+            });
+
+            var configured = await svc.HasConfiguredCredentialsAsync();
+
+            Assert.IsFalse(configured);
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
## Summary
- replace the YouTube setup/login flow with API key configuration and guidance
- switch YouTube availability checks and public live chat/video lookups to API key usage
- update the home page, nav menu, and payment settings wording to match the new model
- add a regression test that API key availability no longer depends on legacy OAuth fields

## Validation
- `git diff --check`
- `dotnet test tests/EasyLotteryDomainTests/EasyLotteryDomainTests.csproj --filter YouTubeServiceHelperUnitTest --nologo` (blocked in this container because `Grpc.Tools` `protoc` exits 139)
