### PR TITLE
feat: add overtime chat template presets

### DIFF
--- a/src/EasyLotteryDomain/Models/Config/OvertimeOverlaySettings.cs
+++ b/src/EasyLotteryDomain/Models/Config/OvertimeOverlaySettings.cs
@@ -20,6 +20,10 @@ namespace EasyLotteryDomain.Models.Config
 
         public decimal DemoEcpayAmount { get; set; } = 2000m;
 
+        public string MessageTemplateKey { get; set; } = "default";
+
+        public string TextAnimationKey { get; set; } = "slide-in";
+
         public DateTimeOffset? StreamStartedAtUtc { get; set; }
 
         public DateTimeOffset? PlannedEndAtUtc { get; set; }

--- a/src/EasyLotteryWasm/Models/OvertimeMessageTemplatePreset.cs
+++ b/src/EasyLotteryWasm/Models/OvertimeMessageTemplatePreset.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EasyLotteryWasm.Models
+{
+    public sealed class OvertimeMessageTemplatePreset
+    {
+        public string Key { get; init; } = "";
+
+        public string Name { get; init; } = "";
+
+        public string Description { get; init; } = "";
+
+        public static IReadOnlyList<OvertimeMessageTemplatePreset> Catalog { get; } = new[]
+        {
+            new OvertimeMessageTemplatePreset
+            {
+                Key = "default",
+                Name = "標準單行",
+                Description = "維持現在的簡潔單行資訊列。"
+            },
+            new OvertimeMessageTemplatePreset
+            {
+                Key = "pixel-hud",
+                Name = "點陣 Q 版",
+                Description = "使用像遊戲 HUD 的卡片布局，頭像與訊息更接近點陣圖 Q 版風格。"
+            }
+        };
+
+        public static OvertimeMessageTemplatePreset GetByKey(string? key)
+        {
+            var normalizedKey = NormalizeKey(key);
+            return Catalog.FirstOrDefault(item => string.Equals(item.Key, normalizedKey, System.StringComparison.OrdinalIgnoreCase)) ?? Catalog[0];
+        }
+
+        public static string NormalizeKey(string? key)
+        {
+            return Catalog.Any(item => string.Equals(item.Key, key, System.StringComparison.OrdinalIgnoreCase))
+                ? key!.Trim()
+                : Catalog[0].Key;
+        }
+    }
+}

--- a/src/EasyLotteryWasm/Models/OvertimeTextAnimationPreset.cs
+++ b/src/EasyLotteryWasm/Models/OvertimeTextAnimationPreset.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EasyLotteryWasm.Models
+{
+    public sealed class OvertimeTextAnimationPreset
+    {
+        public string Key { get; init; } = "";
+
+        public string Name { get; init; } = "";
+
+        public string Description { get; init; } = "";
+
+        public static IReadOnlyList<OvertimeTextAnimationPreset> Catalog { get; } = new[]
+        {
+            new OvertimeTextAnimationPreset
+            {
+                Key = "slide-in",
+                Name = "滑入",
+                Description = "文字從左側滑入並落位。"
+            },
+            new OvertimeTextAnimationPreset
+            {
+                Key = "fade-in",
+                Name = "淡入",
+                Description = "文字淡入顯示，節奏較柔和。"
+            },
+            new OvertimeTextAnimationPreset
+            {
+                Key = "pop-in",
+                Name = "彈出",
+                Description = "文字快速彈出，適合強調新 donate。"
+            },
+            new OvertimeTextAnimationPreset
+            {
+                Key = "none",
+                Name = "無動畫",
+                Description = "直接顯示，不套用進場動作。"
+            }
+        };
+
+        public static OvertimeTextAnimationPreset GetByKey(string? key)
+        {
+            var normalizedKey = NormalizeKey(key);
+            return Catalog.FirstOrDefault(item => string.Equals(item.Key, normalizedKey, System.StringComparison.OrdinalIgnoreCase)) ?? Catalog[0];
+        }
+
+        public static string NormalizeKey(string? key)
+        {
+            return Catalog.Any(item => string.Equals(item.Key, key, System.StringComparison.OrdinalIgnoreCase))
+                ? key!.Trim()
+                : Catalog[0].Key;
+        }
+    }
+}

--- a/src/EasyLotteryWasm/Pages/Config/OvertimeOverlay.razor
+++ b/src/EasyLotteryWasm/Pages/Config/OvertimeOverlay.razor
@@ -87,10 +87,10 @@ else
                                     <Column ColumnSize="ColumnSize.Is12">
                                         <Field>
                                             <FieldLabel>預計結束時間</FieldLabel>
-                                            <input class="overtime-datetime-input"
-                                                   type="datetime-local"
-                                                   value="@PlannedEndAtInput"
-                                                   @onchange="OnPlannedEndAtInputChanged" />
+                                              <input class="overtime-datetime-input"
+                                                  type="datetime-local"
+                                                  value="@PlannedEndAtInput"
+                                                  @oninput="OnPlannedEndAtInputChanged" />
                                         </Field>
                                     </Column>
                                 </Row>
@@ -176,6 +176,28 @@ else
                                         <SelectItem Value="@preset.Key">@preset.Name</SelectItem>
                                     }
                                 </Select>
+                            </Field>
+
+                            <Field>
+                                <FieldLabel>單行文字動畫</FieldLabel>
+                                <select class="overtime-animation-select" value="@selectedTextAnimationKey" @onchange="OnTextAnimationChanged">
+                                    @foreach (var preset in textAnimationPresets)
+                                    {
+                                        <option value="@preset.Key">@preset.Name</option>
+                                    }
+                                </select>
+                                <div class="text-muted mt-1">@SelectedTextAnimation.Description</div>
+                            </Field>
+
+                            <Field>
+                                <FieldLabel>聊天室樣板配置</FieldLabel>
+                                <select class="overtime-template-select" value="@selectedMessageTemplateKey" @onchange="OnMessageTemplateChanged">
+                                    @foreach (var preset in messageTemplatePresets)
+                                    {
+                                        <option value="@preset.Key">@preset.Name</option>
+                                    }
+                                </select>
+                                <div class="text-muted mt-1">@SelectedMessageTemplate.Description</div>
                             </Field>
 
                             <Row>
@@ -736,11 +758,17 @@ else
     private EasyLotteryConfigDocument document = new();
     private OvertimeOverlaySettings settings = new();
     private IReadOnlyList<OvertimeThemePreset> presets = OvertimeThemePreset.Catalog;
+    private IReadOnlyList<OvertimeTextAnimationPreset> textAnimationPresets = OvertimeTextAnimationPreset.Catalog;
+    private IReadOnlyList<OvertimeMessageTemplatePreset> messageTemplatePresets = OvertimeMessageTemplatePreset.Catalog;
     private string selectedThemeKey = OvertimeThemePreset.Catalog[0].Key;
+    private string selectedTextAnimationKey = OvertimeTextAnimationPreset.Catalog[0].Key;
+    private string selectedMessageTemplateKey = OvertimeMessageTemplatePreset.Catalog[0].Key;
     private string OverlayUrl => NavigationManager.ToAbsoluteUri("/obs/overtime").ToString();
     private string PlannedEndAtInput { get; set; } = "";
 
     private OvertimeThemePreset CurrentTheme => OvertimeThemePreset.GetByKey(selectedThemeKey);
+    private OvertimeTextAnimationPreset SelectedTextAnimation => OvertimeTextAnimationPreset.GetByKey(selectedTextAnimationKey);
+    private OvertimeMessageTemplatePreset SelectedMessageTemplate => OvertimeMessageTemplatePreset.GetByKey(selectedMessageTemplateKey);
 
     protected override async Task OnInitializedAsync()
     {
@@ -750,6 +778,8 @@ else
         settings.DemoSuperChatAmount = Math.Max(0, settings.DemoSuperChatAmount);
         settings.DemoEcpayAmount = Math.Max(0, settings.DemoEcpayAmount);
         selectedThemeKey = string.IsNullOrWhiteSpace(settings.ThemeKey) ? OvertimeThemePreset.Catalog[0].Key : settings.ThemeKey;
+        selectedTextAnimationKey = string.IsNullOrWhiteSpace(settings.TextAnimationKey) ? OvertimeTextAnimationPreset.Catalog[0].Key : settings.TextAnimationKey;
+        selectedMessageTemplateKey = string.IsNullOrWhiteSpace(settings.MessageTemplateKey) ? OvertimeMessageTemplatePreset.Catalog[0].Key : settings.MessageTemplateKey;
         PlannedEndAtInput = FormatDateTimeLocal(settings.PlannedEndAtUtc);
         isLoading = false;
     }
@@ -758,6 +788,16 @@ else
     {
         PlannedEndAtInput = args.Value?.ToString() ?? "";
         settings.PlannedEndAtUtc = ParseDateTimeLocal(PlannedEndAtInput);
+    }
+
+    private void OnTextAnimationChanged(ChangeEventArgs args)
+    {
+        selectedTextAnimationKey = args.Value?.ToString() ?? OvertimeTextAnimationPreset.Catalog[0].Key;
+    }
+
+    private void OnMessageTemplateChanged(ChangeEventArgs args)
+    {
+        selectedMessageTemplateKey = args.Value?.ToString() ?? OvertimeMessageTemplatePreset.Catalog[0].Key;
     }
 
     private void SelectTheme(string key)
@@ -801,9 +841,13 @@ else
 
     private async Task SaveAsync()
     {
+        PlannedEndAtInput = await JSRuntime.InvokeAsync<string>("easyLotteryDom.getValue", ".overtime-datetime-input");
+        selectedTextAnimationKey = await JSRuntime.InvokeAsync<string>("easyLotteryDom.getValue", ".overtime-animation-select");
         settings.PlannedEndAtUtc = ParseDateTimeLocal(PlannedEndAtInput);
         document.OvertimeOverlay = settings;
         document.OvertimeOverlay.ThemeKey = selectedThemeKey;
+        document.OvertimeOverlay.MessageTemplateKey = selectedMessageTemplateKey;
+        document.OvertimeOverlay.TextAnimationKey = selectedTextAnimationKey;
         await ConfigStore.SaveAsync(document);
 
         if (!await IsSessionStartedAsync())

--- a/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
+++ b/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
@@ -42,26 +42,65 @@ else
 
                     @if (VisibleEvent is not null)
                     {
-                        <div class="overtime-live-line">
-                            <span class="overtime-live-source">@VisibleEvent.SourceLabel</span>
-                            <span class="overtime-live-divider">·</span>
-                            <span class="overtime-live-name">@VisibleEvent.DisplayName</span>
-                            @if (settings.ShowAmounts && !string.IsNullOrWhiteSpace(VisibleEvent.AmountDisplay))
-                            {
+                        @if (IsPixelHudTemplate)
+                        {
+                            <div class="overtime-pixel-card @LiveEventAnimationClass" @key="VisibleEvent.Id">
+                                <div class="overtime-pixel-avatar-wrap">
+                                    @if (!string.IsNullOrWhiteSpace(VisibleEvent.AvatarUrl))
+                                    {
+                                        <img class="overtime-pixel-avatar" src="@VisibleEvent.AvatarUrl" alt="@VisibleEvent.DisplayName" />
+                                    }
+                                    else
+                                    {
+                                        <div class="overtime-pixel-avatar fallback">@GetAvatarFallback(VisibleEvent.DisplayName)</div>
+                                    }
+                                </div>
+
+                                <div class="overtime-pixel-body">
+                                    <div class="overtime-pixel-name">@VisibleEvent.DisplayName</div>
+                                    <div class="overtime-pixel-source">@VisibleEvent.SourceLabel</div>
+                                    <div class="overtime-pixel-message">@BuildMessageText(VisibleEvent)</div>
+                                    <div class="overtime-pixel-tags">
+                                        @if (settings.ShowAmounts && !string.IsNullOrWhiteSpace(VisibleEvent.AmountDisplay))
+                                        {
+                                            <span class="overtime-pixel-tag amount">@VisibleEvent.AmountDisplay</span>
+                                        }
+                                        else if (settings.ShowAmounts && VisibleEvent.Amount.HasValue)
+                                        {
+                                            <span class="overtime-pixel-tag amount">@VisibleEvent.Amount.Value.ToString("0.##") @VisibleEvent.Currency</span>
+                                        }
+
+                                        @if (TryGetRewardSummary(VisibleEvent, out var visibleRewardSummary))
+                                        {
+                                            <span class="overtime-pixel-tag reward">@visibleRewardSummary</span>
+                                        }
+                                    </div>
+                                </div>
+                            </div>
+                        }
+                        else
+                        {
+                            <div class="overtime-live-line @LiveEventAnimationClass" @key="VisibleEvent.Id">
+                                <span class="overtime-live-source">@VisibleEvent.SourceLabel</span>
                                 <span class="overtime-live-divider">·</span>
-                                <span class="overtime-live-amount">@VisibleEvent.AmountDisplay</span>
-                            }
-                            @if (TryGetRewardSummary(VisibleEvent, out var visibleRewardSummary))
-                            {
-                                <span class="overtime-live-divider">·</span>
-                                <span class="overtime-live-reward">@visibleRewardSummary</span>
-                            }
-                            else if (settings.ShowAmounts && VisibleEvent.Amount.HasValue && string.IsNullOrWhiteSpace(VisibleEvent.AmountDisplay))
-                            {
-                                <span class="overtime-live-divider">·</span>
-                                <span class="overtime-live-amount">@VisibleEvent.Amount.Value.ToString("0.##") @VisibleEvent.Currency</span>
-                            }
-                        </div>
+                                <span class="overtime-live-name">@VisibleEvent.DisplayName</span>
+                                @if (settings.ShowAmounts && !string.IsNullOrWhiteSpace(VisibleEvent.AmountDisplay))
+                                {
+                                    <span class="overtime-live-divider">·</span>
+                                    <span class="overtime-live-amount">@VisibleEvent.AmountDisplay</span>
+                                }
+                                @if (TryGetRewardSummary(VisibleEvent, out var visibleRewardSummary))
+                                {
+                                    <span class="overtime-live-divider">·</span>
+                                    <span class="overtime-live-reward">@visibleRewardSummary</span>
+                                }
+                                else if (settings.ShowAmounts && VisibleEvent.Amount.HasValue && string.IsNullOrWhiteSpace(VisibleEvent.AmountDisplay))
+                                {
+                                    <span class="overtime-live-divider">·</span>
+                                    <span class="overtime-live-amount">@VisibleEvent.Amount.Value.ToString("0.##") @VisibleEvent.Currency</span>
+                                }
+                            </div>
+                        }
                     }
                 </div>
             }
@@ -186,6 +225,116 @@ else
         text-overflow: ellipsis;
     }
 
+    .overtime-live-line.animation-slide-in {
+        animation: overtime-live-slide-in 0.42s cubic-bezier(0.2, 0.85, 0.25, 1);
+    }
+
+    .overtime-live-line.animation-fade-in {
+        animation: overtime-live-fade-in 0.32s ease-out;
+    }
+
+    .overtime-live-line.animation-pop-in {
+        animation: overtime-live-pop-in 0.38s cubic-bezier(0.2, 0.85, 0.25, 1);
+    }
+
+    .overtime-pixel-card {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        width: 100%;
+        padding: 16px 18px;
+        border-radius: 18px;
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(241, 245, 249, 0.95));
+        border: 4px solid #111827;
+        box-shadow: 0 12px 0 rgba(17, 24, 39, 0.75);
+        color: #111827;
+        image-rendering: pixelated;
+    }
+
+    .overtime-pixel-avatar-wrap {
+        flex: 0 0 auto;
+    }
+
+    .overtime-pixel-avatar {
+        width: 76px;
+        height: 76px;
+        border-radius: 14px;
+        object-fit: cover;
+        border: 4px solid #111827;
+        box-shadow: 0 6px 0 rgba(17, 24, 39, 0.72);
+        background: #ffffff;
+    }
+
+    .overtime-pixel-avatar.fallback {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.6rem;
+        font-weight: 900;
+        color: #111827;
+        background: linear-gradient(180deg, #fff7ed, #ffe4e6);
+    }
+
+    .overtime-pixel-body {
+        flex: 1;
+        min-width: 0;
+    }
+
+    .overtime-pixel-name {
+        font-size: 1.35rem;
+        font-weight: 950;
+        line-height: 1.15;
+        letter-spacing: 0.01em;
+    }
+
+    .overtime-pixel-source {
+        margin-top: 3px;
+        font-size: 0.78rem;
+        font-weight: 800;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        color: #4b5563;
+    }
+
+    .overtime-pixel-message {
+        margin-top: 8px;
+        padding: 10px 12px;
+        border-radius: 12px;
+        background: #f8fafc;
+        border: 2px solid #111827;
+        font-size: 1rem;
+        font-weight: 700;
+        line-height: 1.45;
+        word-break: break-word;
+        box-shadow: inset 0 -3px 0 rgba(17, 24, 39, 0.08);
+    }
+
+    .overtime-pixel-tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-top: 10px;
+    }
+
+    .overtime-pixel-tag {
+        display: inline-flex;
+        align-items: center;
+        padding: 6px 10px;
+        border-radius: 999px;
+        border: 2px solid #111827;
+        font-size: 0.8rem;
+        font-weight: 900;
+        background: #ffffff;
+    }
+
+    .overtime-pixel-tag.amount {
+        color: #0f766e;
+    }
+
+    .overtime-pixel-tag.reward {
+        color: #7c3aed;
+    }
+
     .overtime-live-source,
     .overtime-live-name,
     .overtime-live-amount,
@@ -218,6 +367,41 @@ else
     .overtime-live-divider {
         opacity: 0.58;
         flex: 0 0 auto;
+    }
+
+    @@keyframes overtime-live-slide-in {
+        0% {
+            transform: translateX(-28px);
+            opacity: 0;
+        }
+        100% {
+            transform: translateX(0);
+            opacity: 1;
+        }
+    }
+
+    @@keyframes overtime-live-fade-in {
+        0% {
+            opacity: 0;
+        }
+        100% {
+            opacity: 1;
+        }
+    }
+
+    @@keyframes overtime-live-pop-in {
+        0% {
+            transform: scale(0.96);
+            opacity: 0;
+        }
+        70% {
+            transform: scale(1.015);
+            opacity: 1;
+        }
+        100% {
+            transform: scale(1);
+            opacity: 1;
+        }
     }
 
     .overtime-session-panel {
@@ -636,6 +820,8 @@ else
     private IReadOnlyList<OvertimeSupportEvent> events = [];
     private OvertimeThemePreset CurrentTheme => OvertimeThemePreset.GetByKey(settings.ThemeKey);
     private string ThemeStyle => CurrentTheme.BuildCssVariables();
+    private OvertimeMessageTemplatePreset MessageTemplate => OvertimeMessageTemplatePreset.GetByKey(settings.MessageTemplateKey);
+    private bool IsPixelHudTemplate => string.Equals(MessageTemplate.Key, "pixel-hud", StringComparison.OrdinalIgnoreCase);
     private OvertimeSupportEvent? PlannedEndMarker => events.FirstOrDefault(item =>
         item.Source == OvertimeSupportSource.Manual &&
         string.Equals(item.SourceLabel, PlannedEndMarkerLabel, StringComparison.OrdinalIgnoreCase));
@@ -648,6 +834,13 @@ else
     private DateTimeOffset? SessionEndAtUtc => events.FirstOrDefault(item => item.SessionEndAtUtc.HasValue)?.SessionEndAtUtc ?? PlannedEndMarker?.SessionEndAtUtc ?? settings.PlannedEndAtUtc;
     private string PlannedCloseText => BuildPlannedCloseText(PlannedEndMarker?.SessionEndAtUtc ?? settings.PlannedEndAtUtc);
     private string CountdownText => BuildCountdownText(SessionEndAtUtc);
+    private string LiveEventAnimationClass => OvertimeTextAnimationPreset.NormalizeKey(settings.TextAnimationKey) switch
+    {
+        "fade-in" => "animation-fade-in",
+        "pop-in" => "animation-pop-in",
+        "none" => "",
+        _ => "animation-slide-in"
+    };
 
     protected override async Task OnInitializedAsync()
     {
@@ -693,6 +886,7 @@ else
         document = await ConfigStore.LoadAsync();
         settings = document.OvertimeOverlay ?? new OvertimeOverlaySettings();
         settings.ThemeKey = string.IsNullOrWhiteSpace(settings.ThemeKey) ? OvertimeThemePreset.Catalog[0].Key : settings.ThemeKey;
+        settings.TextAnimationKey = OvertimeTextAnimationPreset.NormalizeKey(settings.TextAnimationKey);
         await ReloadEventsAsync();
     }
 
@@ -770,6 +964,32 @@ else
 
         summary = $"加班 +{OvertimeRewardRuleCalculator.DescribeDuration(matchedRule.AddHours, matchedRule.AddMinutes)}";
         return true;
+    }
+
+    private static string GetAvatarFallback(string? displayName)
+    {
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            return "?";
+        }
+
+        var trimmed = displayName.Trim();
+        return trimmed.Length <= 2 ? trimmed : trimmed.Substring(0, 2);
+    }
+
+    private static string BuildMessageText(OvertimeSupportEvent item)
+    {
+        if (!string.IsNullOrWhiteSpace(item.Message))
+        {
+            return item.Message;
+        }
+
+        return item.Source switch
+        {
+            OvertimeSupportSource.SuperChat => "送出 SuperChat 支援。",
+            OvertimeSupportSource.EcpayDonate => "送出綠界 Donate 支援。",
+            _ => "加班訊息"
+        };
     }
 
     private static string BuildCountdownText(DateTimeOffset? plannedEndAtUtc)

--- a/src/EasyLotteryWasm/Services/YamlEasyLotteryConfigStore.cs
+++ b/src/EasyLotteryWasm/Services/YamlEasyLotteryConfigStore.cs
@@ -150,6 +150,8 @@ namespace EasyLotteryWasm.Services
             document.OvertimeOverlay.ThemeKey = string.IsNullOrWhiteSpace(document.OvertimeOverlay.ThemeKey)
                 ? "festival-stage"
                 : document.OvertimeOverlay.ThemeKey.Trim();
+            document.OvertimeOverlay.MessageTemplateKey = OvertimeMessageTemplatePreset.NormalizeKey(document.OvertimeOverlay.MessageTemplateKey);
+            document.OvertimeOverlay.TextAnimationKey = OvertimeTextAnimationPreset.NormalizeKey(document.OvertimeOverlay.TextAnimationKey);
             document.OvertimeOverlay.MaxVisibleItems = Math.Max(1, document.OvertimeOverlay.MaxVisibleItems);
             document.SystemSettings.ResultNotificationEmail = document.SystemSettings.ResultNotificationEmail.Trim();
             document.SystemSettings.DonationIntegration.Ecpay.Name = string.IsNullOrWhiteSpace(document.SystemSettings.DonationIntegration.Ecpay.Name) ? "綠界" : document.SystemSettings.DonationIntegration.Ecpay.Name.Trim();

--- a/src/EasyLotteryWasm/wwwroot/index.html
+++ b/src/EasyLotteryWasm/wwwroot/index.html
@@ -25,116 +25,55 @@
     </div>
 
     <div id="blazor-error-ui">
-        <script>
-            (() => {
-                if (window.easyLotteryConfig) {
-                    return;
+        An unhandled error has occurred.
+        <a href="" class="reload">Reload</a>
+        <a class="dismiss">🗙</a>
+    </div>
+
+    <script>
+        (() => {
+            if (window.easyLotteryConfig) {
+                return;
+            }
+
+            const storageKey = "easy-lottery.config.yaml";
+            const remoteConfigUrl = "http://localhost:18930/easy-lottery-config.yaml";
+            let memoryFallback = "";
+
+            function getSafeContent(content) {
+                return content == null ? "" : content;
+            }
+
+            function getTauriInvoker() {
+                if (window.__TAURI__ && typeof window.__TAURI__.invoke === "function") {
+                    return window.__TAURI__.invoke.bind(window.__TAURI__);
                 }
 
-                const storageKey = "easy-lottery.config.yaml";
-                const remoteConfigUrl = "http://localhost:18930/easy-lottery-config.yaml";
-                let memoryFallback = "";
+                return null;
+            }
 
-                function getSafeContent(content) {
-                    return content == null ? "" : content;
-                }
-
-                function getTauriInvoker() {
-                    if (window.__TAURI__ && typeof window.__TAURI__.invoke === "function") {
-                        return window.__TAURI__.invoke.bind(window.__TAURI__);
-                    }
-
-                    return null;
-                }
-
-                window.easyLotteryConfig = {
-                    read: async () => {
-                        const tauriInvoke = getTauriInvoker();
-                        if (tauriInvoke) {
-                            const content = await tauriInvoke("read_config_yaml");
-                            memoryFallback = getSafeContent(content);
-                            return memoryFallback;
-                        }
-
-                        try {
-                            const content = window.localStorage.getItem(storageKey);
-                            memoryFallback = getSafeContent(content);
-                        } catch {
-                        }
-
-                        if (memoryFallback) {
-                            return memoryFallback;
-                        }
-
-                        try {
-                            const response = await fetch(remoteConfigUrl, { cache: "no-store", mode: "cors" });
-                            if (response.ok) {
-                                const content = await response.text();
-                                memoryFallback = getSafeContent(content);
-                                return memoryFallback;
-                            }
-                        } catch {
-                        }
-
+            window.easyLotteryConfig = {
+                read: async () => {
+                    const tauriInvoke = getTauriInvoker();
+                    if (tauriInvoke) {
+                        const content = await tauriInvoke("read_config_yaml");
+                        memoryFallback = getSafeContent(content);
                         return memoryFallback;
-                    },
-                    write: async (content) => {
-                        const safeContent = getSafeContent(content);
-                        memoryFallback = safeContent;
-
-                        try {
-                            window.localStorage.setItem(storageKey, safeContent);
-                        } catch {
-                        }
-
-                        const tauriInvoke = getTauriInvoker();
-                        if (tauriInvoke) {
-                            await tauriInvoke("write_config_yaml", { content: safeContent });
-                            return;
-                        }
-
-                        try {
-                            await fetch(remoteConfigUrl, {
-                                method: "PUT",
-                                cache: "no-store",
-                                mode: "cors",
-                                headers: {
-                                    "Content-Type": "text/yaml; charset=utf-8"
-                                },
-                                body: safeContent
-                            });
-                        } catch {
-                        }
-                    }
-                };
-            })();
-        </script>
-        <script>
-            (() => {
-                if (window.easyLotteryMail) {
-                    return;
-                }
-
-                function getTauriInvoker() {
-                    if (window.__TAURI__ && typeof window.__TAURI__.invoke === "function") {
-                        return window.__TAURI__.invoke.bind(window.__TAURI__);
                     }
 
-                    return null;
-                }
-
-                window.easyLotteryMail = {
-                    send: async (request) => {
-                        const tauriInvoke = getTauriInvoker();
-                        if (!tauriInvoke) {
-                            return;
-                        }
-
-                        await tauriInvoke("send_result_notification_email", { request });
+                    try {
+                        const content = window.localStorage.getItem(storageKey);
+                        memoryFallback = getSafeContent(content);
+                    } catch {
                     }
-                };
-            })();
-        </script>
+
+                    if (memoryFallback) {
+                        return memoryFallback;
+                    }
+
+                    try {
+                        const response = await fetch(remoteConfigUrl, { cache: "no-store", mode: "cors" });
+                        if (response.ok) {
                             const content = await response.text();
                             memoryFallback = getSafeContent(content);
                             return memoryFallback;
@@ -143,227 +82,286 @@
                     }
 
                     return memoryFallback;
-                        return;
-                    }
+                },
+                write: async (content) => {
+                    const safeContent = getSafeContent(content);
+                    memoryFallback = safeContent;
 
-                    await tauriInvoke("send_result_notification_email", { request });
-                }
                     try {
                         window.localStorage.setItem(storageKey, safeContent);
                     } catch {
                     }
 
-            };
-        })();
-    </script>
-        <script>
-            (() => {
-                if (window.easyLotteryOvertimeFeed) {
-                    return;
-                }
-
-                const storageKey = "easy-lottery.overtime-feed";
-                const remoteFeedUrl = "http://localhost:18930/easy-lottery-overtime-feed.json";
-
-                function getSafeContent(content) {
-                    return content == null ? "[]" : String(content);
-                }
-
-                function getTauriInvoker() {
-                    if (window.__TAURI__ && typeof window.__TAURI__.invoke === "function") {
-                        return window.__TAURI__.invoke.bind(window.__TAURI__);
+                    const tauriInvoke = getTauriInvoker();
+                    if (tauriInvoke) {
+                        await tauriInvoke("write_config_yaml", { content: safeContent });
+                        return;
                     }
 
-                    return null;
-                }
-
-                async function readRemoteFeed() {
                     try {
-                        const response = await fetch(remoteFeedUrl, { cache: "no-store", mode: "cors" });
-                        if (response.ok) {
-                            return getSafeContent(await response.text());
-                        }
-                    } catch {
-                    }
-
-                    return "";
-                }
-
-                function readLocalStorage() {
-                    try {
-                        return getSafeContent(window.localStorage.getItem(storageKey));
-                    } catch {
-                        return "[]";
-                    }
-                }
-
-                async function writeRemoteFeed(content) {
-                    try {
-                        await fetch(remoteFeedUrl, {
+                        await fetch(remoteConfigUrl, {
                             method: "PUT",
                             cache: "no-store",
                             mode: "cors",
                             headers: {
-                                "Content-Type": "application/json; charset=utf-8"
+                                "Content-Type": "text/yaml; charset=utf-8"
                             },
-                            body: getSafeContent(content)
+                            body: safeContent
                         });
                     } catch {
                     }
                 }
-
-                function writeLocalStorage(content) {
-                    try {
-                        window.localStorage.setItem(storageKey, getSafeContent(content));
-                    } catch {
-                    }
-                }
-
-                window.easyLotteryOvertimeFeed = {
-                    read: async () => {
-                        const tauriInvoke = getTauriInvoker();
-                        if (tauriInvoke) {
-                            try {
-                                const content = await tauriInvoke("read_overtime_feed_json");
-                                return getSafeContent(content);
-                            } catch {
-                            }
-                        }
-
-                        const local = readLocalStorage();
-                        if (local && local !== "[]") {
-                            return local;
-                        }
-
-                        const remote = await readRemoteFeed();
-                        if (remote) {
-                            writeLocalStorage(remote);
-                            return remote;
-                        }
-
-                        return local;
-                    },
-                    write: async (content) => {
-                        const safeContent = getSafeContent(content);
-                        writeLocalStorage(safeContent);
-
-                        const tauriInvoke = getTauriInvoker();
-                        if (tauriInvoke) {
-                            try {
-                                await tauriInvoke("write_overtime_feed_json", { content: safeContent });
-                                return;
-                            } catch {
-                            }
-                        }
-
-                        await writeRemoteFeed(safeContent);
-                    },
-                    clear: async () => {
-                        writeLocalStorage("[]");
-
-                        const tauriInvoke = getTauriInvoker();
-                        if (tauriInvoke) {
-                            try {
-                                await tauriInvoke("clear_overtime_feed_json");
-                                return;
-                            } catch {
-                            }
-                        }
-
-                        try {
-                            await fetch(remoteFeedUrl, {
-                                method: "DELETE",
-                                cache: "no-store",
-                                mode: "cors"
-                            });
-                        } catch {
-                        }
-                    }
-                };
-            })();
-        </script>
-        <script>
-            window.easyLotteryDownload = {
-                downloadText: (fileName, content, mimeType) => {
-                    const safeFileName = fileName || "download.txt";
-                    const safeContent = content == null ? "" : content;
-                    const blob = new Blob([safeContent], { type: mimeType || "text/plain;charset=utf-8" });
-                    const url = URL.createObjectURL(blob);
-
-                    const anchor = document.createElement("a");
-                    anchor.href = url;
-                    anchor.download = safeFileName;
-                    anchor.rel = "noopener";
-                    document.body.appendChild(anchor);
-                    anchor.click();
-                    anchor.remove();
-                    URL.revokeObjectURL(url);
-                }
             };
-        </script>
-        <script>
-            (() => {
-                const storageKey = "easy-lottery.visual-style";
-                const root = document.documentElement;
+        })();
+    </script>
+    <script>
+        (() => {
+            if (window.easyLotteryMail) {
+                return;
+            }
 
-                function applyThemeKey(key) {
-                    const safeKey = key === "arcade-neon" ? "dashboard-console" : (key || "dashboard-console");
-                    root.dataset.visualStyle = safeKey;
-
-                    if (document.body) {
-                        document.body.dataset.visualStyle = safeKey;
-                    }
-
-                    try {
-                        window.localStorage.setItem(storageKey, safeKey);
-                    } catch {
-                    }
+            function getTauriInvoker() {
+                if (window.__TAURI__ && typeof window.__TAURI__.invoke === "function") {
+                    return window.__TAURI__.invoke.bind(window.__TAURI__);
                 }
 
-                let storedKey = "dashboard-console";
-                try {
-                    storedKey = window.localStorage.getItem(storageKey) || storedKey;
-                } catch {
-                }
+                return null;
+            }
 
-                if (storedKey === "arcade-neon") {
-                    storedKey = "dashboard-console";
-                }
-
-                applyThemeKey(storedKey);
-
-                window.easyLotteryTheme = {
-                    apply: (key) => applyThemeKey(key),
-                    getStoredKey: () => {
-                        try {
-                            return window.localStorage.getItem(storageKey) || "";
-                        } catch {
-                            return "";
-                        }
-                    }
-                };
-            })();
-        </script>
-        <script>
-            window.easyLotteryClipboard = {
-                copyText: async (text) => {
-                    const safeText = text == null ? "" : String(text);
-
-                    if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
-                        await navigator.clipboard.writeText(safeText);
+            window.easyLotteryMail = {
+                send: async (request) => {
+                    const tauriInvoke = getTauriInvoker();
+                    if (!tauriInvoke) {
                         return;
                     }
 
-                    const textarea = document.createElement("textarea");
-                    textarea.value = safeText;
-                    textarea.setAttribute("readonly", "true");
-                    textarea.style.position = "fixed";
-                    textarea.style.opacity = "0";
-                    document.body.appendChild(textarea);
-                    textarea.select();
-                    document.execCommand("copy");
-                    textarea.remove();
+                    await tauriInvoke("send_result_notification_email", { request });
                 }
             };
-        </script>
+        })();
+    </script>
+    <script>
+        (() => {
+            if (window.easyLotteryDom) {
+                return;
+            }
+
+            window.easyLotteryDom = {
+                getValue: (selector) => {
+                    const element = document.querySelector(selector);
+                    return element && typeof element.value === "string" ? element.value : "";
+                }
+            };
+        })();
+    </script>
+    <script>
+        (() => {
+            if (window.easyLotteryOvertimeFeed) {
+                return;
+            }
+
+            const storageKey = "easy-lottery.overtime-feed";
+            const remoteFeedUrl = "http://localhost:18930/easy-lottery-overtime-feed.json";
+
+            function getSafeContent(content) {
+                return content == null ? "[]" : String(content);
+            }
+
+            function getTauriInvoker() {
+                if (window.__TAURI__ && typeof window.__TAURI__.invoke === "function") {
+                    return window.__TAURI__.invoke.bind(window.__TAURI__);
+                }
+
+                return null;
+            }
+
+            async function readRemoteFeed() {
+                try {
+                    const response = await fetch(remoteFeedUrl, { cache: "no-store", mode: "cors" });
+                    if (response.ok) {
+                        return getSafeContent(await response.text());
+                    }
+                } catch {
+                }
+
+                return "";
+            }
+
+            function readLocalStorage() {
+                try {
+                    return getSafeContent(window.localStorage.getItem(storageKey));
+                } catch {
+                    return "[]";
+                }
+            }
+
+            async function writeRemoteFeed(content) {
+                try {
+                    await fetch(remoteFeedUrl, {
+                        method: "PUT",
+                        cache: "no-store",
+                        mode: "cors",
+                        headers: {
+                            "Content-Type": "application/json; charset=utf-8"
+                        },
+                        body: getSafeContent(content)
+                    });
+                } catch {
+                }
+            }
+
+            function writeLocalStorage(content) {
+                try {
+                    window.localStorage.setItem(storageKey, getSafeContent(content));
+                } catch {
+                }
+            }
+
+            window.easyLotteryOvertimeFeed = {
+                read: async () => {
+                    const tauriInvoke = getTauriInvoker();
+                    if (tauriInvoke) {
+                        try {
+                            const content = await tauriInvoke("read_overtime_feed_json");
+                            return getSafeContent(content);
+                        } catch {
+                        }
+                    }
+
+                    const local = readLocalStorage();
+                    if (local && local !== "[]") {
+                        return local;
+                    }
+
+                    const remote = await readRemoteFeed();
+                    if (remote) {
+                        writeLocalStorage(remote);
+                        return remote;
+                    }
+
+                    return local;
+                },
+                write: async (content) => {
+                    const safeContent = getSafeContent(content);
+                    writeLocalStorage(safeContent);
+
+                    const tauriInvoke = getTauriInvoker();
+                    if (tauriInvoke) {
+                        try {
+                            await tauriInvoke("write_overtime_feed_json", { content: safeContent });
+                            return;
+                        } catch {
+                        }
+                    }
+
+                    await writeRemoteFeed(safeContent);
+                },
+                clear: async () => {
+                    writeLocalStorage("[]");
+
+                    const tauriInvoke = getTauriInvoker();
+                    if (tauriInvoke) {
+                        try {
+                            await tauriInvoke("clear_overtime_feed_json");
+                            return;
+                        } catch {
+                        }
+                    }
+
+                    try {
+                        await fetch(remoteFeedUrl, {
+                            method: "DELETE",
+                            cache: "no-store",
+                            mode: "cors"
+                        });
+                    } catch {
+                    }
+                }
+            };
+        })();
+    </script>
+    <script>
+        window.easyLotteryDownload = {
+            downloadText: (fileName, content, mimeType) => {
+                const safeFileName = fileName || "download.txt";
+                const safeContent = content == null ? "" : content;
+                const blob = new Blob([safeContent], { type: mimeType || "text/plain;charset=utf-8" });
+                const url = URL.createObjectURL(blob);
+
+                const anchor = document.createElement("a");
+                anchor.href = url;
+                anchor.download = safeFileName;
+                anchor.rel = "noopener";
+                document.body.appendChild(anchor);
+                anchor.click();
+                anchor.remove();
+                URL.revokeObjectURL(url);
+            }
+        };
+    </script>
+    <script>
+        (() => {
+            const storageKey = "easy-lottery.visual-style";
+            const root = document.documentElement;
+
+            function applyThemeKey(key) {
+                const safeKey = key === "arcade-neon" ? "dashboard-console" : (key || "dashboard-console");
+                root.dataset.visualStyle = safeKey;
+
+                if (document.body) {
+                    document.body.dataset.visualStyle = safeKey;
+                }
+
+                try {
+                    window.localStorage.setItem(storageKey, safeKey);
+                } catch {
+                }
+            }
+
+            let storedKey = "dashboard-console";
+            try {
+                storedKey = window.localStorage.getItem(storageKey) || storedKey;
+            } catch {
+            }
+
+            if (storedKey === "arcade-neon") {
+                storedKey = "dashboard-console";
+            }
+
+            applyThemeKey(storedKey);
+
+            window.easyLotteryTheme = {
+                apply: (key) => applyThemeKey(key),
+                getStoredKey: () => {
+                    try {
+                        return window.localStorage.getItem(storageKey) || "";
+                    } catch {
+                        return "";
+                    }
+                }
+            };
+        })();
+    </script>
+    <script>
+        window.easyLotteryClipboard = {
+            copyText: async (text) => {
+                const safeText = text == null ? "" : String(text);
+
+                if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+                    await navigator.clipboard.writeText(safeText);
+                    return;
+                }
+
+                const textarea = document.createElement("textarea");
+                textarea.value = safeText;
+                textarea.setAttribute("readonly", "true");
+                textarea.style.position = "fixed";
+                textarea.style.opacity = "0";
+                document.body.appendChild(textarea);
+                textarea.select();
+                document.execCommand("copy");
+                textarea.remove();
+            }
+        };
+    </script>
         <script src="_framework/blazor.webassembly.js"></script>


### PR DESCRIPTION
## Summary
- Add overtime chat message template presets with a default single-line mode and a pixel HUD mode.
- Persist the new template selection and text animation selection in overtime overlay settings.
- Render the OBS overtime overlay with a pixel-card layout when the pixel HUD template is selected.

## Validation
- `dotnet build src/EasyLotteryWasm/EasyLotteryWasm.csproj -c Debug`

Closes #80
