### PR TITLE
feat: add reusable sound cue presets

### DIFF
--- a/src/EasyLotteryDomain/Models/Config/EasyLotteryConfigDocument.cs
+++ b/src/EasyLotteryDomain/Models/Config/EasyLotteryConfigDocument.cs
@@ -21,6 +21,7 @@ namespace EasyLotteryDomain.Models.Config
         public DrawingRuleSettings DrawingRules { get; set; } = new();
         public VisualStyleSettings VisualStyle { get; set; } = new();
         public ObsLayoutSettings ObsLayout { get; set; } = new();
+        public SoundCueSettings SoundCue { get; set; } = new();
         public OvertimeOverlaySettings OvertimeOverlay { get; set; } = new();
         public List<ChangeAuditRecord> AuditRecords { get; set; } = new();
     }
@@ -59,6 +60,11 @@ namespace EasyLotteryDomain.Models.Config
     public sealed class ObsLayoutSettings
     {
         public string ActiveLayoutKey { get; set; } = "stage-spotlight";
+    }
+
+    public sealed class SoundCueSettings
+    {
+        public string ActivePresetKey { get; set; } = "arcade-stage";
     }
 
     public sealed class DonationIntegrationSettings

--- a/src/EasyLotteryWasm/Layout/NavMenu.razor
+++ b/src/EasyLotteryWasm/Layout/NavMenu.razor
@@ -74,6 +74,11 @@
                 </NavLink>
             </div>
             <div class="nav-item px-3 nav-sub-item">
+                <NavLink class="nav-link" href="system/sound-cues">
+                    音效模板
+                </NavLink>
+            </div>
+            <div class="nav-item px-3 nav-sub-item">
                 <NavLink class="nav-link" href="system/audit">
                     審計紀錄
                 </NavLink>

--- a/src/EasyLotteryWasm/Models/SoundCuePreset.cs
+++ b/src/EasyLotteryWasm/Models/SoundCuePreset.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EasyLotteryWasm.Models
+{
+    public sealed class SoundCuePreset
+    {
+        public string Key { get; init; } = "";
+
+        public string Name { get; init; } = "";
+
+        public string Description { get; init; } = "";
+
+        public string CountdownCue { get; init; } = "";
+
+        public string SpinCue { get; init; } = "";
+
+        public string PokeCue { get; init; } = "";
+
+        public string RevealCue { get; init; } = "";
+
+        public string ResultCue { get; init; } = "";
+
+        public static IReadOnlyList<SoundCuePreset> Catalog { get; } = new[]
+        {
+            new SoundCuePreset
+            {
+                Key = "arcade-stage",
+                Name = "街機舞台",
+                Description = "偏明亮的短促提示音，適合節奏較快的直播。",
+                CountdownCue = "tone:784:140:square",
+                SpinCue = "tone:988:180:triangle",
+                PokeCue = "tone:659:120:sine",
+                RevealCue = "tone:932:180:sawtooth",
+                ResultCue = "tone:1046:240:triangle"
+            },
+            new SoundCuePreset
+            {
+                Key = "soft-stage",
+                Name = "柔和舞台",
+                Description = "較溫和的提示音，適合長時間直播或較安靜的場景。",
+                CountdownCue = "tone:523:160:sine",
+                SpinCue = "tone:659:220:triangle",
+                PokeCue = "tone:440:120:sine",
+                RevealCue = "tone:587:200:sine",
+                ResultCue = "tone:740:260:triangle"
+            },
+            new SoundCuePreset
+            {
+                Key = "retro-pixel",
+                Name = "復古像素",
+                Description = "顆粒感更強的音色，適合點陣 HUD 與遊戲化版型。",
+                CountdownCue = "tone:880:100:square",
+                SpinCue = "tone:1175:160:square",
+                PokeCue = "tone:740:90:square",
+                RevealCue = "tone:988:140:sawtooth",
+                ResultCue = "tone:1319:220:triangle"
+            }
+        };
+
+        public static SoundCuePreset GetByKey(string? key)
+        {
+            var normalizedKey = NormalizeKey(key);
+            return Catalog.FirstOrDefault(item => string.Equals(item.Key, normalizedKey, System.StringComparison.OrdinalIgnoreCase)) ?? Catalog[0];
+        }
+
+        public static string NormalizeKey(string? key)
+        {
+            return Catalog.Any(item => string.Equals(item.Key, key, System.StringComparison.OrdinalIgnoreCase))
+                ? key!.Trim()
+                : Catalog[0].Key;
+        }
+    }
+}

--- a/src/EasyLotteryWasm/Pages/Config/SoundCues.razor
+++ b/src/EasyLotteryWasm/Pages/Config/SoundCues.razor
@@ -1,0 +1,142 @@
+@page "/system/sound-cues"
+@using EasyLotteryWasm.Models
+
+@inject EasyLotteryWasm.Services.SoundCueService SoundCueService
+@inject IMessageService MessageService
+
+<PageTitle>音效模板</PageTitle>
+
+<Card class="sound-cue-page-hero mb-4">
+    <CardBody>
+        <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3">
+            <div>
+                <div class="sound-cue-page-eyebrow">SOUND CUE PRESETS</div>
+                <h2 class="mb-2">選擇直播用的音效模板</h2>
+                <p class="mb-0 sound-cue-page-description">
+                    這些模板會把倒數、轉動、戳擊、揭曉與結果音效統一在同一套風格裡，讓整個流程更像舞台事件。
+                </p>
+            </div>
+            <Badge Color="Color.Info" class="align-self-start align-self-lg-center">
+                目前使用：@activePreset?.Name
+            </Badge>
+        </div>
+    </CardBody>
+</Card>
+
+@if (isLoading)
+{
+    <p>載入中…</p>
+}
+else
+{
+    <div class="row g-4">
+        @foreach (var preset in presets)
+        {
+            <div class="col-12 col-lg-4">
+                <Card class="@(GetCardClass(preset))">
+                    <CardBody class="d-flex flex-column">
+                        <CardTitle>
+                            <div class="d-flex justify-content-between align-items-center gap-2">
+                                <h4 class="mb-0">@preset.Name</h4>
+                                @if (preset.Key == activePresetKey)
+                                {
+                                    <Badge Color="Color.Success">已啟用</Badge>
+                                }
+                            </div>
+                        </CardTitle>
+                        <CardText class="flex-grow-1">
+                            <p>@preset.Description</p>
+                            <ul class="sound-cue-list">
+                                <li>倒數：@preset.CountdownCue</li>
+                                <li>轉動：@preset.SpinCue</li>
+                                <li>戳擊：@preset.PokeCue</li>
+                                <li>揭曉：@preset.RevealCue</li>
+                                <li>結果：@preset.ResultCue</li>
+                            </ul>
+                        </CardText>
+                        <Button Color="@(preset.Key == activePresetKey ? Color.Secondary : Color.Primary)"
+                                Clicked="@(() => ApplyPresetAsync(preset.Key))"
+                                Disabled="@(preset.Key == activePresetKey)">
+                            @(preset.Key == activePresetKey ? "目前使用" : "套用模板")
+                        </Button>
+                    </CardBody>
+                </Card>
+            </div>
+        }
+    </div>
+}
+
+@code {
+    private IReadOnlyList<SoundCuePreset> presets = Array.Empty<SoundCuePreset>();
+    private string activePresetKey = SoundCuePreset.Catalog[0].Key;
+    private SoundCuePreset? activePreset;
+    private bool isLoading = true;
+
+    protected override async Task OnInitializedAsync()
+    {
+        presets = SoundCueService.Presets;
+        activePresetKey = await SoundCueService.GetActivePresetKeyAsync();
+        activePreset = SoundCueService.GetPreset(activePresetKey);
+        isLoading = false;
+    }
+
+    private async Task ApplyPresetAsync(string presetKey)
+    {
+        activePreset = await SoundCueService.SetActivePresetAsync(presetKey);
+        activePresetKey = activePreset.Key;
+        await MessageService.Success($"已切換為「{activePreset.Name}」。");
+    }
+
+    private string GetCardClass(SoundCuePreset preset)
+    {
+        var classes = new List<string> { "sound-cue-card", "h-100" };
+        if (preset.Key == activePresetKey)
+        {
+            classes.Add("is-active");
+        }
+
+        return string.Join(" ", classes);
+    }
+}
+
+<style>
+    .sound-cue-page-hero {
+        border-radius: 28px;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        background:
+            radial-gradient(circle at top left, rgba(255, 255, 255, 0.12), transparent 28%),
+            linear-gradient(135deg, rgba(17, 24, 39, 0.96), rgba(55, 65, 81, 0.92));
+        color: #fff;
+    }
+
+    .sound-cue-page-eyebrow {
+        letter-spacing: 0.28em;
+        text-transform: uppercase;
+        font-size: 0.78rem;
+        font-weight: 800;
+        color: rgba(255, 255, 255, 0.7);
+    }
+
+    .sound-cue-page-description {
+        max-width: 60ch;
+        color: rgba(255, 255, 255, 0.86);
+    }
+
+    .sound-cue-card {
+        overflow: hidden;
+        border-radius: 24px;
+        border: 1px solid rgba(148, 163, 184, 0.18);
+        background: #fff;
+        box-shadow: 0 18px 48px rgba(15, 23, 42, 0.1);
+    }
+
+    .sound-cue-card.is-active {
+        border-color: rgba(59, 130, 246, 0.45);
+        box-shadow: 0 20px 52px rgba(59, 130, 246, 0.12);
+    }
+
+    .sound-cue-list {
+        margin: 12px 0 0;
+        padding-left: 18px;
+    }
+</style>

--- a/src/EasyLotteryWasm/Pages/PokeBox/PokeBoxObs.razor
+++ b/src/EasyLotteryWasm/Pages/PokeBox/PokeBoxObs.razor
@@ -3,10 +3,12 @@
 @using EasyLotteryDomain.Models.Entities
 @using EasyLotteryDomain.Services
 @using EasyLotteryWasm.Layout
+@using EasyLotteryWasm.Models
 
 @inject ActivityResultService ActivityResultService
 @inject ResultNotificationService ResultNotificationService
 @inject PokeService PokeService
+@inject EasyLotteryWasm.Services.SoundCueService SoundCueService
 
 <PageTitle>戳戳樂 - OBS</PageTitle>
 
@@ -27,6 +29,12 @@ else
 {
     <div class="obs-poke-wrapper obs-layout-surface" style="@WrapperStyle">
         <div class="obs-stage">
+            <LiveDrawFlowGuide Title="戳戳樂流程"
+                               Subtitle="@template.Name"
+                               Phase="@flowPhase"
+                               CountdownRemaining="@countdownRemaining"
+                               DetailText="@FlowDetailText" />
+
             <div class="poke-grid" style="@GridStyle">
                 @foreach (var cell in template.Cells.OrderBy(c => c.Index))
                 {
@@ -385,15 +393,30 @@ else
     private PokeTemplate? template;
     private int? lastPokedIndex;
     private bool isLoading = true;
+    private LiveDrawPhase flowPhase = LiveDrawPhase.Ready;
+    private int? countdownRemaining;
     private bool isRecording;
     private string? lastRecordedSignature;
     private string? statusMessage;
     private bool statusIsError;
 
     private const int AnimationDurationMs = 650;
+    private const int RevealCountdownSeconds = 2;
+    private const int RevealHoldMs = 450;
 
     private int RevealedCount => template?.Cells.Count(c => c.IsRevealed) ?? 0;
     private bool CanRecordCurrentActivity => template != null && RevealedCount > 0 && BuildRecordSignature() != lastRecordedSignature;
+    private bool IsBusy => countdownRemaining.HasValue || flowPhase == LiveDrawPhase.CountingDown || flowPhase == LiveDrawPhase.Spinning;
+
+    private string FlowDetailText => flowPhase switch
+    {
+        LiveDrawPhase.Ready => "選好格子後，畫面會依序進入倒數、揭露與結果階段。",
+        LiveDrawPhase.CountingDown => "準備揭露，請留意接下來的動畫節奏。",
+        LiveDrawPhase.Spinning => "戳戳樂正在揭露中。",
+        LiveDrawPhase.ShowingResult when RevealedCount >= (template?.Cells.Count ?? 0) => "本次戳戳樂已全部揭露完成。",
+        LiveDrawPhase.ShowingResult => "結果已顯示，還可以繼續揭露下一格。",
+        _ => "戳戳樂流程已就緒。"
+    };
 
     private string WrapperStyle =>
         string.IsNullOrEmpty(template?.BackgroundImageUrl)
@@ -446,32 +469,28 @@ else
         if (template.Mode != PokeMode.Manual) return;
         if (cell.IsRevealed && !template.AllowRePoking) return;
 
-        var poked = await PokeService.PokeCellByIndexAsync(template.Id, cell.Index);
-        if (poked != null)
+        await RunRevealSequenceAsync(() => PokeService.PokeCellByIndexAsync(template.Id, cell.Index), poked =>
         {
             cell.IsRevealed = true;
             cell.RevealedAt = poked.RevealedAt;
             lastPokedIndex = cell.Index;
-            StateHasChanged();
-            await ClearAnimationAfterDelay();
-        }
+        });
     }
 
     private async Task PokeRandom()
     {
         if (template == null) return;
-        var poked = await PokeService.PokeRandomCellAsync(template.Id);
-        if (poked == null) return;
 
-        var cell = template.Cells.FirstOrDefault(c => c.Index == poked.Index);
-        if (cell != null)
+        await RunRevealSequenceAsync(() => PokeService.PokeRandomCellAsync(template.Id), poked =>
         {
-            cell.IsRevealed = true;
-            cell.RevealedAt = poked.RevealedAt;
-            lastPokedIndex = cell.Index;
-            StateHasChanged();
-            await ClearAnimationAfterDelay();
-        }
+            var cell = template.Cells.FirstOrDefault(c => c.Index == poked.Index);
+            if (cell != null)
+            {
+                cell.IsRevealed = true;
+                cell.RevealedAt = poked.RevealedAt;
+                lastPokedIndex = cell.Index;
+            }
+        });
     }
 
     private async Task ResetTemplate()
@@ -486,7 +505,7 @@ else
 
     private async Task EndActivityAndRecord()
     {
-        if (template == null || !CanRecordCurrentActivity || isRecording) return;
+        if (template == null || !CanRecordCurrentActivity || isRecording || IsBusy) return;
 
         isRecording = true;
         try
@@ -510,6 +529,53 @@ else
     {
         await Task.Delay(AnimationDurationMs);
         lastPokedIndex = null;
+        StateHasChanged();
+    }
+
+    private async Task RunRevealSequenceAsync(Func<Task<PokeCell?>> revealAsync, Action<PokeCell> applyReveal)
+    {
+        if (template == null || IsBusy)
+        {
+            return;
+        }
+
+        flowPhase = LiveDrawPhase.CountingDown;
+        countdownRemaining = RevealCountdownSeconds;
+        SetStatus("倒數開始，準備揭露戳戳樂。", false);
+        await SoundCueService.PlayCueAsync(SoundCueService.GetPreset(await SoundCueService.GetActivePresetKeyAsync()).CountdownCue);
+        StateHasChanged();
+
+        while (countdownRemaining > 0)
+        {
+            await Task.Delay(1000);
+            countdownRemaining--;
+            StateHasChanged();
+        }
+
+        flowPhase = LiveDrawPhase.Spinning;
+        countdownRemaining = null;
+        await SoundCueService.PlayCueAsync(SoundCueService.GetPreset(await SoundCueService.GetActivePresetKeyAsync()).PokeCue);
+        StateHasChanged();
+
+        await Task.Delay(220);
+        var poked = await revealAsync();
+        if (poked == null)
+        {
+            flowPhase = LiveDrawPhase.Ready;
+            ClearStatus();
+            StateHasChanged();
+            return;
+        }
+
+        applyReveal(poked);
+        flowPhase = LiveDrawPhase.ShowingResult;
+        await SoundCueService.PlayCueAsync(SoundCueService.GetPreset(await SoundCueService.GetActivePresetKeyAsync()).RevealCue);
+        SetStatus($"已揭露第 {poked.Index + 1} 格。", false);
+        StateHasChanged();
+
+        await Task.Delay(RevealHoldMs);
+        await ClearAnimationAfterDelay();
+        flowPhase = LiveDrawPhase.Ready;
         StateHasChanged();
     }
 

--- a/src/EasyLotteryWasm/Pages/PokeBox/PokeBoxPreview.razor
+++ b/src/EasyLotteryWasm/Pages/PokeBox/PokeBoxPreview.razor
@@ -1,6 +1,7 @@
 @page "/pokebox/preview/{Id:int}"
 @using EasyLotteryDomain.Models.Entities
 @using EasyLotteryDomain.Services
+@using EasyLotteryWasm.Models
 
 @inject ActivityResultService ActivityResultService
 @inject ResultNotificationService ResultNotificationService
@@ -45,6 +46,12 @@ else
         }
 
         <section class="poke-preview-stage" style="@PreviewWrapperStyle">
+            <LiveDrawFlowGuide Title="戳戳樂流程"
+                               Subtitle="@template.Name"
+                               Phase="@flowPhase"
+                               CountdownRemaining="@countdownRemaining"
+                               DetailText="@FlowDetailText" />
+
             <div class="poke-preview-counter">
                 已戳：@RevealedCount / @template.Cells.Count
                 @if (template.MaxPokeCount > 0)
@@ -345,14 +352,29 @@ else
 
     private PokeTemplate? template;
     private int? lastPokedIndex;
+    private LiveDrawPhase flowPhase = LiveDrawPhase.Ready;
+    private int? countdownRemaining;
     private bool isRecording;
     private string? lastRecordedSignature;
 
     // Longest CSS animation is 600ms (smoke); wait slightly longer before clearing the class
     private const int AnimationDurationMs = 650;
+    private const int RevealCountdownSeconds = 2;
+    private const int RevealHoldMs = 450;
 
     private int RevealedCount => template?.Cells.Count(c => c.IsRevealed) ?? 0;
     private bool CanRecordCurrentActivity => template != null && RevealedCount > 0 && BuildRecordSignature() != lastRecordedSignature;
+    private bool IsBusy => countdownRemaining.HasValue || flowPhase == LiveDrawPhase.CountingDown || flowPhase == LiveDrawPhase.Spinning;
+
+    private string FlowDetailText => flowPhase switch
+    {
+        LiveDrawPhase.Ready => "按下戳選後會先進入倒數，再揭露結果。",
+        LiveDrawPhase.CountingDown => "倒數中，請準備看揭露動畫。",
+        LiveDrawPhase.Spinning => "畫面正在展示戳戳樂過場。",
+        LiveDrawPhase.ShowingResult when RevealedCount >= (template?.Cells.Count ?? 0) => "本次戳戳樂已全部完成。",
+        LiveDrawPhase.ShowingResult => "目前結果已顯示，可繼續戳下一格。",
+        _ => "戳戳樂流程已就緒。"
+    };
 
     private string PreviewWrapperStyle =>
         string.IsNullOrEmpty(template?.BackgroundImageUrl)
@@ -403,35 +425,28 @@ else
         if (template.Mode != PokeMode.Manual) return;
         if (cell.IsRevealed && !template.AllowRePoking) return;
 
-        var poked = await PokeService.PokeCellByIndexAsync(template.Id, cell.Index);
-        if (poked != null)
+        await RunRevealSequenceAsync(() => PokeService.PokeCellByIndexAsync(template.Id, cell.Index), poked =>
         {
             cell.IsRevealed = true;
             cell.RevealedAt = poked.RevealedAt;
             lastPokedIndex = cell.Index;
-            StateHasChanged();
-            await ClearAnimationAfterDelay();
-        }
+        });
     }
 
     private async Task PokeRandom()
     {
         if (template == null) return;
-        var poked = await PokeService.PokeRandomCellAsync(template.Id);
-        if (poked == null)
+
+        await RunRevealSequenceAsync(() => PokeService.PokeRandomCellAsync(template.Id), poked =>
         {
-            await MessageService.Info("所有格子已全部開啟！");
-            return;
-        }
-        var cell = template.Cells.FirstOrDefault(c => c.Index == poked.Index);
-        if (cell != null)
-        {
-            cell.IsRevealed = true;
-            cell.RevealedAt = poked.RevealedAt;
-            lastPokedIndex = cell.Index;
-            StateHasChanged();
-            await ClearAnimationAfterDelay();
-        }
+            var cell = template.Cells.FirstOrDefault(c => c.Index == poked.Index);
+            if (cell != null)
+            {
+                cell.IsRevealed = true;
+                cell.RevealedAt = poked.RevealedAt;
+                lastPokedIndex = cell.Index;
+            }
+        });
     }
 
     private async Task ResetTemplate()
@@ -445,7 +460,7 @@ else
 
     private async Task EndActivityAndRecord()
     {
-        if (template == null || !CanRecordCurrentActivity || isRecording) return;
+        if (template == null || !CanRecordCurrentActivity || isRecording || IsBusy) return;
 
         isRecording = true;
         try
@@ -469,6 +484,49 @@ else
     {
         await Task.Delay(AnimationDurationMs);
         lastPokedIndex = null;
+        StateHasChanged();
+    }
+
+    private async Task RunRevealSequenceAsync(Func<Task<PokeCell?>> revealAsync, Action<PokeCell> applyReveal)
+    {
+        if (template == null || IsBusy)
+        {
+            return;
+        }
+
+        flowPhase = LiveDrawPhase.CountingDown;
+        countdownRemaining = RevealCountdownSeconds;
+        await MessageService.Info("倒數開始，準備揭露戳戳樂。");
+        StateHasChanged();
+
+        while (countdownRemaining > 0)
+        {
+            await Task.Delay(1000);
+            countdownRemaining--;
+            StateHasChanged();
+        }
+
+        flowPhase = LiveDrawPhase.Spinning;
+        countdownRemaining = null;
+        StateHasChanged();
+
+        await Task.Delay(220);
+        var poked = await revealAsync();
+        if (poked == null)
+        {
+            flowPhase = LiveDrawPhase.Ready;
+            await MessageService.Info("所有格子已全部開啟！");
+            StateHasChanged();
+            return;
+        }
+
+        applyReveal(poked);
+        flowPhase = LiveDrawPhase.ShowingResult;
+        StateHasChanged();
+
+        await Task.Delay(RevealHoldMs);
+        await ClearAnimationAfterDelay();
+        flowPhase = LiveDrawPhase.Ready;
         StateHasChanged();
     }
 

--- a/src/EasyLotteryWasm/Pages/Roulette/RouletteObs.razor
+++ b/src/EasyLotteryWasm/Pages/Roulette/RouletteObs.razor
@@ -7,6 +7,7 @@
 @inject ActivityResultService ActivityResultService
 @inject ResultNotificationService ResultNotificationService
 @inject RouletteService RouletteService
+@inject EasyLotteryWasm.Services.SoundCueService SoundCueService
 
 <PageTitle>轉盤 - OBS</PageTitle>
 
@@ -439,6 +440,8 @@ else
         {
             flowPhase = LiveDrawPhase.CountingDown;
             countdownRemaining = SpinCountdownSeconds;
+            var activeCuePreset = SoundCueService.GetPreset(await SoundCueService.GetActivePresetKeyAsync());
+            await SoundCueService.PlayCueAsync(activeCuePreset.CountdownCue);
             StateHasChanged();
 
             while (countdownRemaining > 0)
@@ -452,6 +455,8 @@ else
         flowPhase = LiveDrawPhase.Spinning;
         isSpinning = true;
         countdownRemaining = null;
+        var cuePreset = SoundCueService.GetPreset(await SoundCueService.GetActivePresetKeyAsync());
+        await SoundCueService.PlayCueAsync(cuePreset.SpinCue);
 
         var result = RouletteService.Spin(template, forced, currentRotation);
 
@@ -464,6 +469,7 @@ else
         isSpinning = false;
         lastResult = result;
         flowPhase = LiveDrawPhase.ShowingResult;
+        await SoundCueService.PlayCueAsync(cuePreset.ResultCue);
         StateHasChanged();
     }
 

--- a/src/EasyLotteryWasm/Program.cs
+++ b/src/EasyLotteryWasm/Program.cs
@@ -36,6 +36,7 @@ builder.Services.AddScoped<IEasyLotteryConfigStore, YamlEasyLotteryConfigStore>(
 builder.Services.AddScoped<IOvertimeFeedStore, BrowserOvertimeFeedStore>();
 builder.Services.AddScoped<SystemSettingsService>();
 builder.Services.AddScoped<ObsLayoutService>();
+builder.Services.AddScoped<SoundCueService>();
 builder.Services.AddScoped<ActivityResultService>();
 builder.Services.AddScoped<ResultNotificationService>();
 builder.Services.AddScoped<VisualStyleService>();

--- a/src/EasyLotteryWasm/Services/SoundCueService.cs
+++ b/src/EasyLotteryWasm/Services/SoundCueService.cs
@@ -1,0 +1,69 @@
+using EasyLotteryDomain.Models.Config;
+using EasyLotteryDomain.Services;
+using EasyLotteryWasm.Models;
+using Microsoft.JSInterop;
+
+namespace EasyLotteryWasm.Services
+{
+    public sealed class SoundCueService
+    {
+        private readonly IEasyLotteryConfigStore _configStore;
+        private readonly IJSRuntime _jsRuntime;
+        private readonly ILogger<SoundCueService> _logger;
+        private string? _activePresetKey;
+
+        public SoundCueService(
+            IEasyLotteryConfigStore configStore,
+            IJSRuntime jsRuntime,
+            ILogger<SoundCueService> logger)
+        {
+            _configStore = configStore;
+            _jsRuntime = jsRuntime;
+            _logger = logger;
+        }
+
+        public IReadOnlyList<SoundCuePreset> Presets => SoundCuePreset.Catalog;
+
+        public async Task<string> GetActivePresetKeyAsync(CancellationToken cancellationToken = default)
+        {
+            if (!string.IsNullOrWhiteSpace(_activePresetKey))
+            {
+                return _activePresetKey;
+            }
+
+            var document = await _configStore.LoadAsync(cancellationToken);
+            _activePresetKey = SoundCuePreset.NormalizeKey(document.SoundCue?.ActivePresetKey);
+            return _activePresetKey;
+        }
+
+        public SoundCuePreset GetPreset(string? key) => SoundCuePreset.GetByKey(key);
+
+        public async Task<SoundCuePreset> SetActivePresetAsync(string key, CancellationToken cancellationToken = default)
+        {
+            var normalized = SoundCuePreset.NormalizeKey(key);
+            var document = await _configStore.LoadAsync(cancellationToken);
+            document.SoundCue ??= new SoundCueSettings();
+            document.SoundCue.ActivePresetKey = normalized;
+            await _configStore.SaveAsync(document, cancellationToken);
+            _activePresetKey = normalized;
+            return SoundCuePreset.GetByKey(normalized);
+        }
+
+        public async Task PlayCueAsync(string cue, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(cue))
+            {
+                return;
+            }
+
+            try
+            {
+                await _jsRuntime.InvokeVoidAsync("easyLotteryAudio.playCue", cancellationToken, cue);
+            }
+            catch (JSException ex)
+            {
+                _logger.LogWarning(ex, "Failed to play sound cue '{Cue}'.", cue);
+            }
+        }
+    }
+}

--- a/src/EasyLotteryWasm/Services/YamlEasyLotteryConfigStore.cs
+++ b/src/EasyLotteryWasm/Services/YamlEasyLotteryConfigStore.cs
@@ -144,6 +144,8 @@ namespace EasyLotteryWasm.Services
             document.DrawingRules ??= new DrawingRuleSettings();
             document.VisualStyle ??= new VisualStyleSettings();
             document.VisualStyle.ActiveThemeKey = VisualStyleCatalog.NormalizeKey(document.VisualStyle.ActiveThemeKey);
+            document.SoundCue ??= new SoundCueSettings();
+            document.SoundCue.ActivePresetKey = SoundCuePreset.NormalizeKey(document.SoundCue.ActivePresetKey);
             document.OvertimeOverlay ??= new OvertimeOverlaySettings();
             document.OvertimeOverlay.Title = document.OvertimeOverlay.Title.Trim();
             document.OvertimeOverlay.Subtitle = document.OvertimeOverlay.Subtitle.Trim();

--- a/src/EasyLotteryWasm/wwwroot/index.html
+++ b/src/EasyLotteryWasm/wwwroot/index.html
@@ -142,6 +142,79 @@
     </script>
     <script>
         (() => {
+            if (window.easyLotteryAudio) {
+                return;
+            }
+
+            const audioContextFactory = () => {
+                const AudioContextCtor = window.AudioContext || window.webkitAudioContext;
+                return AudioContextCtor ? new AudioContextCtor() : null;
+            };
+
+            let audioContext = null;
+
+            function ensureAudioContext() {
+                if (!audioContext) {
+                    audioContext = audioContextFactory();
+                }
+
+                return audioContext;
+            }
+
+            function parseToneCue(cue) {
+                const parts = String(cue || "").split(":");
+                if (parts.length < 4 || parts[0] !== "tone") {
+                    return null;
+                }
+
+                return {
+                    frequency: Number(parts[1]) || 440,
+                    durationMs: Number(parts[2]) || 180,
+                    waveType: parts[3] || "sine"
+                };
+            }
+
+            async function playToneCue(cue) {
+                const parsed = parseToneCue(cue);
+                if (!parsed) {
+                    return;
+                }
+
+                const context = ensureAudioContext();
+                if (!context) {
+                    return;
+                }
+
+                if (context.state === "suspended") {
+                    try {
+                        await context.resume();
+                    } catch {
+                        return;
+                    }
+                }
+
+                const oscillator = context.createOscillator();
+                const gain = context.createGain();
+                oscillator.type = parsed.waveType;
+                oscillator.frequency.value = parsed.frequency;
+                gain.gain.setValueAtTime(0.0001, context.currentTime);
+                gain.gain.exponentialRampToValueAtTime(0.12, context.currentTime + 0.01);
+                gain.gain.exponentialRampToValueAtTime(0.0001, context.currentTime + parsed.durationMs / 1000);
+                oscillator.connect(gain);
+                gain.connect(context.destination);
+                oscillator.start();
+                oscillator.stop(context.currentTime + parsed.durationMs / 1000);
+            }
+
+            window.easyLotteryAudio = {
+                playCue: async (cue) => {
+                    await playToneCue(cue);
+                }
+            };
+        })();
+    </script>
+    <script>
+        (() => {
             if (window.easyLotteryDom) {
                 return;
             }


### PR DESCRIPTION
## Summary
- Add reusable sound cue presets for stream events, including countdown, spin, poke, reveal, and result cues.
- Persist the selected sound preset in the shared YAML config and expose a system settings page to switch between presets.
- Play the active preset cues from Roulette and PokeBox through a browser audio bridge so the audio style can be reused across flows.

## Validation
- `dotnet build src/EasyLotteryWasm/EasyLotteryWasm.csproj -c Debug`

## Notes
- The sound cues are implemented as browser-generated tones, so no external audio assets are required.
- The change is compatible with the existing visual/layout preset system and does not alter the core draw logic.
