### PR TITLE
feat: add overtime OBS progress controls

### DIFF
--- a/src/EasyLotteryDomain/Models/Config/OvertimeOverlaySettings.cs
+++ b/src/EasyLotteryDomain/Models/Config/OvertimeOverlaySettings.cs
@@ -28,6 +28,18 @@ namespace EasyLotteryDomain.Models.Config
 
         public DateTimeOffset? PlannedEndAtUtc { get; set; }
 
+        public string SessionState { get; set; } = OvertimeSessionStates.Idle;
+
+        public DateTimeOffset? PausedAtUtc { get; set; }
+
+        public DateTimeOffset? CompletedAtUtc { get; set; }
+
+        public bool EnableCompletionFireworks { get; set; } = true;
+
+        public string CompletionFireworksStyle { get; set; } = "classic";
+
+        public int CompletionFireworksDurationSeconds { get; set; } = 6;
+
         public int SupportMessageVisibleSeconds { get; set; } = 8;
 
         public List<OvertimeRewardRule> RewardRules { get; set; } = new()
@@ -50,6 +62,24 @@ namespace EasyLotteryDomain.Models.Config
                 AmountThreshold = 1000,
                 AddHours = 2
             }
+        };
+    }
+
+    public static class OvertimeSessionStates
+    {
+        public const string Idle = "idle";
+        public const string Running = "running";
+        public const string Paused = "paused";
+        public const string Completed = "completed";
+        public const string Ended = "ended";
+
+        public static string Normalize(string? value) => value?.Trim().ToLowerInvariant() switch
+        {
+            Running => Running,
+            Paused => Paused,
+            Completed => Completed,
+            Ended => Ended,
+            _ => Idle
         };
     }
 }

--- a/src/EasyLotteryDomain/Services/OvertimeSessionTimeCalculator.cs
+++ b/src/EasyLotteryDomain/Services/OvertimeSessionTimeCalculator.cs
@@ -81,6 +81,26 @@ namespace EasyLotteryDomain.Services
             return baseline + addition;
         }
 
+        public static DateTimeOffset? ExtendForPause(
+            DateTimeOffset? plannedEndAtUtc,
+            DateTimeOffset? pausedAtUtc,
+            DateTimeOffset resumedAtUtc)
+        {
+            if (!IsValidUtcDateTime(plannedEndAtUtc) || !IsValidUtcDateTime(pausedAtUtc))
+            {
+                return plannedEndAtUtc;
+            }
+
+            var pauseStartedAtUtc = pausedAtUtc!.Value.ToUniversalTime();
+            var resumedAtUtcValue = resumedAtUtc.ToUniversalTime();
+            if (resumedAtUtcValue <= pauseStartedAtUtc)
+            {
+                return plannedEndAtUtc;
+            }
+
+            return plannedEndAtUtc!.Value.ToUniversalTime() + (resumedAtUtcValue - pauseStartedAtUtc);
+        }
+
         public static double? CalculateProgressPercent(
             DateTimeOffset? startedAtUtc,
             DateTimeOffset? plannedEndAtUtc,

--- a/src/EasyLotteryWasm/Pages/Config/OvertimeOverlay.razor
+++ b/src/EasyLotteryWasm/Pages/Config/OvertimeOverlay.razor
@@ -102,6 +102,31 @@ else
                                         </Field>
                                     </Column>
                                 </Row>
+                                <Row Margin="Margin.Is2.FromTop">
+                                    <Column ColumnSize="ColumnSize.Is4">
+                                        <Field>
+                                            <FieldLabel>達標煙火</FieldLabel>
+                                            <Switch TValue="bool" @bind-Value="settings.EnableCompletionFireworks">
+                                                @(settings.EnableCompletionFireworks ? "啟用" : "停用")
+                                            </Switch>
+                                        </Field>
+                                    </Column>
+                                    <Column ColumnSize="ColumnSize.Is4">
+                                        <Field>
+                                            <FieldLabel>煙火風格</FieldLabel>
+                                            <select class="form-select" @bind="settings.CompletionFireworksStyle" disabled="@(!settings.EnableCompletionFireworks)">
+                                                <option value="classic">經典煙火</option>
+                                                <option value="pixel">像素煙火</option>
+                                            </select>
+                                        </Field>
+                                    </Column>
+                                    <Column ColumnSize="ColumnSize.Is4">
+                                        <Field>
+                                            <FieldLabel>播放秒數</FieldLabel>
+                                            <NumericInput TValue="int" @bind-Value="settings.CompletionFireworksDurationSeconds" Min="2" Max="15" Disabled="@(!settings.EnableCompletionFireworks)" />
+                                        </Field>
+                                    </Column>
+                                </Row>
                             </div>
 
                             <div class="overtime-rules-card">
@@ -751,8 +776,6 @@ else
 
 @code {
     private const string PlannedEndMarkerLabel = "預計關台時間";
-    private const string SessionStartMarkerLabel = "加班開始";
-    private const string SessionStopMarkerLabel = "加班停止";
 
     private bool isLoading = true;
     private EasyLotteryConfigDocument document = new();
@@ -844,6 +867,19 @@ else
         PlannedEndAtInput = await JSRuntime.InvokeAsync<string>("easyLotteryDom.getValue", ".overtime-datetime-input");
         selectedTextAnimationKey = await JSRuntime.InvokeAsync<string>("easyLotteryDom.getValue", ".overtime-animation-select");
         settings.PlannedEndAtUtc = ParseDateTimeLocal(PlannedEndAtInput);
+        var latestDocument = await ConfigStore.LoadAsync();
+        var latestSession = latestDocument.OvertimeOverlay;
+        if (latestSession is not null)
+        {
+            // The OBS page owns the live session controls.  Preserve its state when
+            // a settings page that was opened earlier saves visual configuration.
+            settings.SessionState = latestSession.SessionState;
+            settings.StreamStartedAtUtc = latestSession.StreamStartedAtUtc;
+            settings.PausedAtUtc = latestSession.PausedAtUtc;
+            settings.CompletedAtUtc = latestSession.CompletedAtUtc;
+        }
+
+        document = latestDocument;
         document.OvertimeOverlay = settings;
         document.OvertimeOverlay.ThemeKey = selectedThemeKey;
         document.OvertimeOverlay.MessageTemplateKey = selectedMessageTemplateKey;
@@ -950,19 +986,14 @@ else
 
     private async Task<bool> IsSessionStartedAsync()
     {
-        var events = await OvertimeFeedClient.GetEventsAsync();
-        var marker = events.FirstOrDefault(item =>
-            item.Source == OvertimeSupportSource.Manual &&
-            (string.Equals(item.SourceLabel, SessionStartMarkerLabel, StringComparison.OrdinalIgnoreCase) ||
-             string.Equals(item.SourceLabel, SessionStopMarkerLabel, StringComparison.OrdinalIgnoreCase)));
-
-        return marker != null && string.Equals(marker.SourceLabel, SessionStartMarkerLabel, StringComparison.OrdinalIgnoreCase);
+        var latestDocument = await ConfigStore.LoadAsync();
+        return latestDocument.OvertimeOverlay?.SessionState == OvertimeSessionStates.Running;
     }
 
     private async Task<DateTimeOffset?> GetCurrentSessionEndAtAsync()
     {
-        var events = await OvertimeFeedClient.GetEventsAsync();
-        return events.FirstOrDefault(item => item.SessionEndAtUtc.HasValue)?.SessionEndAtUtc ?? settings.PlannedEndAtUtc;
+        var latestDocument = await ConfigStore.LoadAsync();
+        return latestDocument.OvertimeOverlay?.PlannedEndAtUtc ?? settings.PlannedEndAtUtc;
     }
 
     private async Task PublishPlannedEndMarkerAsync(DateTimeOffset? plannedEndAtUtc)

--- a/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
+++ b/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
@@ -20,7 +20,7 @@ else
 {
     <div class="overtime-overlay obs-layout-surface" style="@ThemeStyle">
         <div class="overtime-shell">
-            @if (!HasSessionStarted)
+            @if (IsIdle)
             {
                 <div class="overtime-standby-panel">
                     <div class="overtime-countdown-label">預計關台時間</div>
@@ -30,13 +30,35 @@ else
                     </div>
                 </div>
             }
+            else if (IsEnded)
+            {
+                <div class="overtime-standby-panel">
+                    <div class="overtime-countdown-label">加班台已結束</div>
+                    <div class="overtime-countdown-line">感謝大家的支持</div>
+                    <div class="overtime-standby-actions">
+                        <Button Color="Color.Primary" Clicked="@StartCountdownAsync">開始新一輪加班</Button>
+                    </div>
+                </div>
+            }
             else
             {
                 <div class="overtime-minimal-overlay">
                     <div class="overtime-progress-wrap">
                         <div class="overtime-countdown-line">@CountdownText</div>
+                        <div class="overtime-progress-track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="@ProgressPercent">
+                            <div class="overtime-progress-fill" style="@ProgressStyle"></div>
+                        </div>
+                        <div class="overtime-progress-caption">已完成 @ProgressPercent.ToString("0.0")%</div>
                         <div class="overtime-standby-actions">
-                            <Button Color="Color.Secondary" Clicked="@StopCountdownAsync">停止加班</Button>
+                            @if (IsRunning)
+                            {
+                                <Button Color="Color.Warning" Clicked="@PauseCountdownAsync">暫停加班</Button>
+                            }
+                            else if (IsPaused)
+                            {
+                                <Button Color="Color.Primary" Clicked="@ResumeCountdownAsync">繼續加班</Button>
+                            }
+                            <Button Color="Color.Secondary" Clicked="@StopCountdownAsync">結束加班</Button>
                         </div>
                     </div>
 
@@ -101,6 +123,21 @@ else
                                 }
                             </div>
                         }
+                    }
+                </div>
+            }
+
+            @if (shouldPlayCompletionFireworks)
+            {
+                <div class="overtime-fireworks @settings.CompletionFireworksStyle" style="--fireworks-duration: @(settings.CompletionFireworksDurationSeconds)s;" aria-hidden="true">
+                    @for (var burst = 0; burst < 4; burst++)
+                    {
+                        <div class="overtime-firework-burst burst-@burst">
+                            @for (var particle = 0; particle < 12; particle++)
+                            {
+                                <span class="particle particle-@particle" style="@GetParticleStyle(particle)"></span>
+                            }
+                        </div>
                     }
                 </div>
             }
@@ -187,8 +224,33 @@ else
     .overtime-progress-wrap {
         display: flex;
         flex-direction: column;
-        gap: 0;
+        gap: 10px;
         align-items: center;
+    }
+
+    .overtime-progress-track {
+        width: min(88vw, 840px);
+        height: 18px;
+        overflow: hidden;
+        border: 2px solid rgba(255, 255, 255, 0.8);
+        border-radius: 999px;
+        background: rgba(15, 23, 42, 0.35);
+        box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.24);
+    }
+
+    .overtime-progress-fill {
+        height: 100%;
+        border-radius: inherit;
+        background: linear-gradient(90deg, #fff0a8, var(--overtime-accent), #ff8f3d);
+        box-shadow: 0 0 18px var(--overtime-glow);
+        transition: width 0.8s linear;
+    }
+
+    .overtime-progress-caption {
+        color: rgba(255, 255, 255, 0.88);
+        font-size: 0.95rem;
+        font-weight: 800;
+        font-variant-numeric: tabular-nums;
     }
 
     .overtime-countdown-line {
@@ -206,6 +268,71 @@ else
         justify-content: center;
         gap: 10px;
         flex-wrap: wrap;
+    }
+
+    .overtime-fireworks {
+        position: absolute;
+        inset: 0;
+        z-index: 5;
+        overflow: hidden;
+        pointer-events: none;
+    }
+
+    .overtime-firework-burst {
+        position: absolute;
+        width: 12px;
+        height: 12px;
+        animation: overtime-firework-flash var(--fireworks-duration) ease-out forwards;
+    }
+
+    .overtime-firework-burst.burst-0 { left: 19%; top: 28%; }
+    .overtime-firework-burst.burst-1 { left: 76%; top: 23%; animation-delay: 0.25s; }
+    .overtime-firework-burst.burst-2 { left: 34%; top: 56%; animation-delay: 0.55s; }
+    .overtime-firework-burst.burst-3 { left: 68%; top: 61%; animation-delay: 0.8s; }
+
+    .overtime-firework-burst .particle {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: hsl(calc(var(--particle-index) * 30), 100%, 70%);
+        box-shadow: 0 0 10px currentColor;
+        animation: overtime-firework-particle var(--fireworks-duration) cubic-bezier(.16,.84,.32,1) forwards;
+    }
+
+    .overtime-fireworks.pixel .particle {
+        width: 9px;
+        height: 9px;
+        border-radius: 0;
+        image-rendering: pixelated;
+        box-shadow: 3px 3px 0 rgba(15, 23, 42, 0.55);
+    }
+
+    .particle-0 { --particle-index: 0; }
+    .particle-1 { --particle-index: 1; }
+    .particle-2 { --particle-index: 2; }
+    .particle-3 { --particle-index: 3; }
+    .particle-4 { --particle-index: 4; }
+    .particle-5 { --particle-index: 5; }
+    .particle-6 { --particle-index: 6; }
+    .particle-7 { --particle-index: 7; }
+    .particle-8 { --particle-index: 8; }
+    .particle-9 { --particle-index: 9; }
+    .particle-10 { --particle-index: 10; }
+    .particle-11 { --particle-index: 11; }
+
+    @@keyframes overtime-firework-flash {
+        0%, 12% { opacity: 1; transform: scale(0.2); }
+        22%, 100% { opacity: 0; transform: scale(1); }
+    }
+
+    @@keyframes overtime-firework-particle {
+        0% { opacity: 0; transform: translate(-50%, -50%) scale(0.2); }
+        8% { opacity: 1; }
+        68% { opacity: 1; transform: translate(calc(-50% + var(--travel-x)), calc(-50% + var(--travel-y))) scale(1); }
+        100% { opacity: 0; transform: translate(calc(-50% + var(--fall-x)), calc(-50% + var(--fall-y))) scale(0.2); }
     }
 
     .overtime-live-line {
@@ -810,11 +937,14 @@ else
 @code {
     private const string PlannedEndMarkerLabel = "預計關台時間";
     private const string SessionStartMarkerLabel = "加班開始";
-    private const string SessionStopMarkerLabel = "加班停止";
+    private const string SessionStopMarkerLabel = "加班結束";
 
     private bool isLoading = true;
     private System.Timers.Timer? refreshTimer;
     private bool isRefreshing;
+    private bool shouldPlayCompletionFireworks;
+    private DateTimeOffset? fireworksStartedAtUtc;
+    private string previousSessionState = OvertimeSessionStates.Idle;
     private EasyLotteryConfigDocument document = new();
     private OvertimeOverlaySettings settings = new();
     private IReadOnlyList<OvertimeSupportEvent> events = [];
@@ -825,15 +955,18 @@ else
     private OvertimeSupportEvent? PlannedEndMarker => events.FirstOrDefault(item =>
         item.Source == OvertimeSupportSource.Manual &&
         string.Equals(item.SourceLabel, PlannedEndMarkerLabel, StringComparison.OrdinalIgnoreCase));
-    private OvertimeSupportEvent? SessionStateMarker => events.FirstOrDefault(item =>
-        item.Source == OvertimeSupportSource.Manual &&
-        (string.Equals(item.SourceLabel, SessionStartMarkerLabel, StringComparison.OrdinalIgnoreCase) ||
-         string.Equals(item.SourceLabel, SessionStopMarkerLabel, StringComparison.OrdinalIgnoreCase)));
-    private bool HasSessionStarted => string.Equals(SessionStateMarker?.SourceLabel, SessionStartMarkerLabel, StringComparison.OrdinalIgnoreCase);
     private OvertimeSupportEvent? VisibleEvent => events.FirstOrDefault(item => item.Source != OvertimeSupportSource.Manual && OvertimeSessionTimeCalculator.IsEventVisible(item.OccurredAtUtc, DateTimeOffset.UtcNow, settings.SupportMessageVisibleSeconds));
-    private DateTimeOffset? SessionEndAtUtc => events.FirstOrDefault(item => item.SessionEndAtUtc.HasValue)?.SessionEndAtUtc ?? PlannedEndMarker?.SessionEndAtUtc ?? settings.PlannedEndAtUtc;
+    private DateTimeOffset? SessionEndAtUtc => settings.PlannedEndAtUtc ?? events.FirstOrDefault(item => item.SessionEndAtUtc.HasValue)?.SessionEndAtUtc ?? PlannedEndMarker?.SessionEndAtUtc;
+    private DateTimeOffset SessionClockUtc => IsPaused && settings.PausedAtUtc.HasValue ? settings.PausedAtUtc.Value : DateTimeOffset.UtcNow;
+    private bool IsIdle => settings.SessionState == OvertimeSessionStates.Idle;
+    private bool IsRunning => settings.SessionState == OvertimeSessionStates.Running;
+    private bool IsPaused => settings.SessionState == OvertimeSessionStates.Paused;
+    private bool IsCompleted => settings.SessionState == OvertimeSessionStates.Completed;
+    private bool IsEnded => settings.SessionState == OvertimeSessionStates.Ended;
     private string PlannedCloseText => BuildPlannedCloseText(PlannedEndMarker?.SessionEndAtUtc ?? settings.PlannedEndAtUtc);
-    private string CountdownText => BuildCountdownText(SessionEndAtUtc);
+    private string CountdownText => IsCompleted ? "目標已達成！" : BuildCountdownText(SessionEndAtUtc, SessionClockUtc);
+    private double ProgressPercent => OvertimeSessionTimeCalculator.CalculateProgressPercent(settings.StreamStartedAtUtc, SessionEndAtUtc, SessionClockUtc) ?? 0d;
+    private string ProgressStyle => $"width: {ProgressPercent.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture)}%;";
     private string LiveEventAnimationClass => OvertimeTextAnimationPreset.NormalizeKey(settings.TextAnimationKey) switch
     {
         "fade-in" => "animation-fade-in",
@@ -888,6 +1021,26 @@ else
         settings.ThemeKey = string.IsNullOrWhiteSpace(settings.ThemeKey) ? OvertimeThemePreset.Catalog[0].Key : settings.ThemeKey;
         settings.TextAnimationKey = OvertimeTextAnimationPreset.NormalizeKey(settings.TextAnimationKey);
         await ReloadEventsAsync();
+
+        if (IsRunning && SessionEndAtUtc.HasValue && SessionEndAtUtc.Value <= DateTimeOffset.UtcNow)
+        {
+            settings.SessionState = OvertimeSessionStates.Completed;
+            settings.CompletedAtUtc = DateTimeOffset.UtcNow;
+            document.OvertimeOverlay = settings;
+            await ConfigStore.SaveAsync(document);
+        }
+
+        if (previousSessionState == OvertimeSessionStates.Running &&
+            settings.SessionState == OvertimeSessionStates.Completed &&
+            settings.EnableCompletionFireworks)
+        {
+            fireworksStartedAtUtc = DateTimeOffset.UtcNow;
+        }
+
+        shouldPlayCompletionFireworks = fireworksStartedAtUtc.HasValue &&
+            settings.EnableCompletionFireworks &&
+            DateTimeOffset.UtcNow - fireworksStartedAtUtc.Value < TimeSpan.FromSeconds(settings.CompletionFireworksDurationSeconds);
+        previousSessionState = settings.SessionState;
     }
 
     private async Task ReloadEventsAsync()
@@ -910,6 +1063,16 @@ else
             return;
         }
 
+        var nowUtc = DateTimeOffset.UtcNow;
+        settings.StreamStartedAtUtc = nowUtc;
+        settings.PlannedEndAtUtc = plannedEndAtUtc;
+        settings.PausedAtUtc = null;
+        settings.CompletedAtUtc = null;
+        settings.SessionState = OvertimeSessionStates.Running;
+        fireworksStartedAtUtc = null;
+        document.OvertimeOverlay = settings;
+        await ConfigStore.SaveAsync(document);
+
         await OvertimeFeedClient.PostManualAsync(new OvertimeSupportEvent
         {
             Source = OvertimeSupportSource.Manual,
@@ -922,7 +1085,7 @@ else
             AvatarUrl = "",
             Color = "#8bd3ff",
             ExternalId = Guid.NewGuid().ToString("N"),
-            OccurredAtUtc = DateTimeOffset.UtcNow,
+            OccurredAtUtc = nowUtc,
             SessionEndAtUtc = plannedEndAtUtc
         });
 
@@ -930,8 +1093,49 @@ else
         StateHasChanged();
     }
 
+    private async Task PauseCountdownAsync()
+    {
+        if (!IsRunning)
+        {
+            return;
+        }
+
+        settings.PausedAtUtc = DateTimeOffset.UtcNow;
+        settings.SessionState = OvertimeSessionStates.Paused;
+        document.OvertimeOverlay = settings;
+        await ConfigStore.SaveAsync(document);
+        await ReloadEventsAsync();
+        StateHasChanged();
+    }
+
+    private async Task ResumeCountdownAsync()
+    {
+        if (!IsPaused)
+        {
+            return;
+        }
+
+        var nowUtc = DateTimeOffset.UtcNow;
+        settings.PlannedEndAtUtc = OvertimeSessionTimeCalculator.ExtendForPause(
+            SessionEndAtUtc,
+            settings.PausedAtUtc,
+            nowUtc);
+        settings.PausedAtUtc = null;
+        settings.SessionState = OvertimeSessionStates.Running;
+        document.OvertimeOverlay = settings;
+        await ConfigStore.SaveAsync(document);
+        await ReloadEventsAsync();
+        StateHasChanged();
+    }
+
     private async Task StopCountdownAsync()
     {
+        settings.PausedAtUtc = null;
+        settings.SessionState = OvertimeSessionStates.Ended;
+        fireworksStartedAtUtc = null;
+        document.OvertimeOverlay = settings;
+        await ConfigStore.SaveAsync(document);
+
         await OvertimeFeedClient.PostManualAsync(new OvertimeSupportEvent
         {
             Source = OvertimeSupportSource.Manual,
@@ -950,6 +1154,21 @@ else
 
         await ReloadEventsAsync();
         StateHasChanged();
+    }
+
+    private static string GetParticleStyle(int particle)
+    {
+        var angleRadians = particle * 30d * Math.PI / 180d;
+        var travelX = Math.Cos(angleRadians) * 160d;
+        var travelY = Math.Sin(angleRadians) * 160d;
+        var fallX = Math.Cos(angleRadians) * 200d;
+        var fallY = Math.Sin(angleRadians) * 200d + 45d;
+        var culture = System.Globalization.CultureInfo.InvariantCulture;
+
+        return $"--travel-x: {travelX.ToString("0.##", culture)}px; " +
+               $"--travel-y: {travelY.ToString("0.##", culture)}px; " +
+               $"--fall-x: {fallX.ToString("0.##", culture)}px; " +
+               $"--fall-y: {fallY.ToString("0.##", culture)}px;";
     }
 
     private bool TryGetRewardSummary(OvertimeSupportEvent item, out string summary)
@@ -992,14 +1211,14 @@ else
         };
     }
 
-    private static string BuildCountdownText(DateTimeOffset? plannedEndAtUtc)
+    private static string BuildCountdownText(DateTimeOffset? plannedEndAtUtc, DateTimeOffset nowUtc)
     {
         if (!plannedEndAtUtc.HasValue || plannedEndAtUtc.Value.Year < 2000)
         {
             return "尚未設定預計關台時間";
         }
 
-        return OvertimeSessionTimeCalculator.DescribeRemaining(plannedEndAtUtc, DateTimeOffset.UtcNow);
+        return OvertimeSessionTimeCalculator.DescribeRemaining(plannedEndAtUtc, nowUtc);
     }
 
     private static string BuildPlannedCloseText(DateTimeOffset? plannedEndAtUtc)

--- a/src/EasyLotteryWasm/Services/YamlEasyLotteryConfigStore.cs
+++ b/src/EasyLotteryWasm/Services/YamlEasyLotteryConfigStore.cs
@@ -176,6 +176,17 @@ namespace EasyLotteryWasm.Services
             document.OvertimeOverlay.SupportMessageVisibleSeconds = Math.Clamp(document.OvertimeOverlay.SupportMessageVisibleSeconds, 1, 60);
             document.OvertimeOverlay.StreamStartedAtUtc = NormalizeDateTimeOffset(document.OvertimeOverlay.StreamStartedAtUtc);
             document.OvertimeOverlay.PlannedEndAtUtc = NormalizeDateTimeOffset(document.OvertimeOverlay.PlannedEndAtUtc);
+            document.OvertimeOverlay.SessionState = OvertimeSessionStates.Normalize(document.OvertimeOverlay.SessionState);
+            document.OvertimeOverlay.PausedAtUtc = NormalizeDateTimeOffset(document.OvertimeOverlay.PausedAtUtc);
+            document.OvertimeOverlay.CompletedAtUtc = NormalizeDateTimeOffset(document.OvertimeOverlay.CompletedAtUtc);
+            document.OvertimeOverlay.CompletionFireworksStyle = document.OvertimeOverlay.CompletionFireworksStyle?.Trim().ToLowerInvariant() == "pixel"
+                ? "pixel"
+                : "classic";
+            document.OvertimeOverlay.CompletionFireworksDurationSeconds = Math.Clamp(document.OvertimeOverlay.CompletionFireworksDurationSeconds, 2, 15);
+            if (document.OvertimeOverlay.SessionState != OvertimeSessionStates.Paused)
+            {
+                document.OvertimeOverlay.PausedAtUtc = null;
+            }
             document.OvertimeOverlay.RewardRules ??= new List<OvertimeRewardRule>();
             NormalizeOvertimeRewardRules(document.OvertimeOverlay.RewardRules);
             document.AuditRecords ??= new List<ChangeAuditRecord>();

--- a/tests/EasyLotteryDomainTests/Services/OvertimeSessionTimeCalculatorTests.cs
+++ b/tests/EasyLotteryDomainTests/Services/OvertimeSessionTimeCalculatorTests.cs
@@ -78,6 +78,18 @@ namespace EasyLotteryDomainTests.Services
         }
 
         [TestMethod]
+        public void ExtendForPause_AddsPausedDurationToPlannedEnd()
+        {
+            var plannedEnd = new DateTimeOffset(2026, 3, 28, 13, 0, 0, TimeSpan.Zero);
+            var pausedAt = new DateTimeOffset(2026, 3, 28, 12, 15, 0, TimeSpan.Zero);
+            var resumedAt = new DateTimeOffset(2026, 3, 28, 12, 45, 0, TimeSpan.Zero);
+
+            var result = OvertimeSessionTimeCalculator.ExtendForPause(plannedEnd, pausedAt, resumedAt);
+
+            Assert.AreEqual(new DateTimeOffset(2026, 3, 28, 13, 30, 0, TimeSpan.Zero), result);
+        }
+
+        [TestMethod]
         public void IsEventVisible_RespectsConfiguredSeconds()
         {
             var occurredAt = new DateTimeOffset(2026, 3, 28, 12, 0, 0, TimeSpan.Zero);


### PR DESCRIPTION
## 目標

完成 #84：把加班倒數改為可操作的進度條，且由台主在 OBS 頁管理，觀眾不會看到控制與其他設定。

## 行為規格

- 按下「開始加班」時，以該時間作為進度起點，目標為目前設定的預計結束時間。
- Donate 延長後，目標結束時間會往後推進，進度總區間隨之更新。
- 「暫停加班」會凍結畫面上的倒數與進度；恢復時，暫停多久就把目標結束時間延後多久。
- 暫停期間不會將流逝時間算入加班進度。
- 「結束加班」會結束本輪，畫面停留在已結束狀態；可由台主手動開始新一輪。
- 倒數到達目標後進入完成狀態，維持至手動結束或開始新一輪。

## 畫面與控制

- OBS 加班頁新增開始、暫停、繼續與結束按鈕。
- 進行中顯示完成百分比、進度條與倒數。
- 控制不放在一般設定頁；設定頁只保留時間、樣式與煙火配置。
- 達成目標可播放程式產生的煙火，支援經典與像素兩種風格，並可設定啟用與播放秒數。

## 跨瀏覽器與設定保存

- 加班 session state、暫停時間、完成時間與煙火設定會保存到 YAML。
- OBS 與設定頁重新載入時會讀取相同 YAML 狀態。
- 設定頁在另一個瀏覽器儲存視覺設定時，會保留 OBS 正在進行的 session state，避免覆寫。

## 技術變更

- 新增 `idle`、`running`、`paused`、`completed`、`ended` session states。
- 新增暫停時間計算，恢復時延長 planned end。
- 新增 YAML 正規化與合理範圍限制：煙火秒數 2 至 15 秒。

Closes #84

## 驗證

- `dotnet test EasyLottery.generated.sln --no-restore`：98 passed
- `dotnet build EasyLottery.generated.sln --no-restore`：成功（既有 Home.razor 警告 2 項）