### PR TITLE
fix: refresh overtime progress clock

### DIFF
--- a/src/EasyLotteryWasm/Pages/Config/OvertimeOverlay.razor
+++ b/src/EasyLotteryWasm/Pages/Config/OvertimeOverlay.razor
@@ -33,7 +33,7 @@ else
             </div>
 
             <Row>
-                <Column ColumnSize="ColumnSize.Is7">
+                <Column ColumnSize="ColumnSize.Is12">
                     <Card class="overtime-config-card">
                         <CardBody>
                             <Row>
@@ -199,16 +199,6 @@ else
                             </div>
 
                             <Field>
-                                <FieldLabel>目前選用風格</FieldLabel>
-                                <Select TValue="string" @bind-SelectedValue="@selectedThemeKey">
-                                    @foreach (var preset in presets)
-                                    {
-                                        <SelectItem Value="@preset.Key">@preset.Name</SelectItem>
-                                    }
-                                </Select>
-                            </Field>
-
-                            <Field>
                                 <FieldLabel>單行文字動畫</FieldLabel>
                                 <select class="overtime-animation-select" value="@selectedTextAnimationKey" @onchange="OnTextAnimationChanged">
                                     @foreach (var preset in textAnimationPresets)
@@ -217,17 +207,6 @@ else
                                     }
                                 </select>
                                 <div class="text-muted mt-1">@SelectedTextAnimation.Description</div>
-                            </Field>
-
-                            <Field>
-                                <FieldLabel>聊天室樣板配置</FieldLabel>
-                                <select class="overtime-template-select" value="@selectedMessageTemplateKey" @onchange="OnMessageTemplateChanged">
-                                    @foreach (var preset in messageTemplatePresets)
-                                    {
-                                        <option value="@preset.Key">@preset.Name</option>
-                                    }
-                                </select>
-                                <div class="text-muted mt-1">@SelectedMessageTemplate.Description</div>
                             </Field>
 
                             <Row>
@@ -255,69 +234,7 @@ else
                     </Card>
                 </Column>
 
-                <Column ColumnSize="ColumnSize.Is5">
-                    <Card class="overtime-preview-card" style="@CurrentTheme.BuildPreviewStyle()">
-                        <CardBody>
-                            <div class="overtime-preview-eyebrow">PREVIEW</div>
-                            <div class="overtime-preview-title">@settings.Title</div>
-                            <div class="overtime-preview-subtitle">@settings.Subtitle</div>
-                            <div class="overtime-preview-badges">
-                                <span class="overtime-preview-badge">@CurrentTheme.Emoji @CurrentTheme.Name</span>
-                                <span class="overtime-preview-badge">最大 @settings.MaxVisibleItems 筆</span>
-                            </div>
-                            <div class="overtime-preview-sample">
-                                <div class="overtime-preview-sample-header">
-                                    <span class="sample-avatar">VT</span>
-                                    <div>
-                                        <div class="sample-name">示範觀眾</div>
-                                        <div class="sample-source">YouTube SuperChat</div>
-                                    </div>
-                                </div>
-                                <div class="sample-message">祝直播順利，這裡是示範訊息。</div>
-                                <div class="sample-amount">NT$ 300</div>
-                            </div>
-                            @if (settings.RewardRules.Count > 0)
-                            {
-                                <div class="overtime-preview-rules">
-                                    @foreach (var rule in settings.RewardRules.Where(rule => rule.IsEnabled).Take(3))
-                                    {
-                                        <span class="overtime-preview-rule">@OvertimeRewardRuleCalculator.DescribeRule(rule)</span>
-                                    }
-                                </div>
-                            }
-                        </CardBody>
-                    </Card>
-                </Column>
             </Row>
-
-            <div class="mt-4">
-                <h5 class="mb-3">風格模板</h5>
-                <Row>
-                    @foreach (var preset in presets)
-                    {
-                        <Column ColumnSize="ColumnSize.Is4">
-                            <Card class="@ThemeCardClass(preset.Key)"
-                                  style="@preset.BuildPreviewStyle()"
-                                  @onclick="@(() => SelectTheme(preset.Key))">
-                                <CardBody>
-                                    <div class="theme-card-header">
-                                        <div class="theme-card-emoji">@preset.Emoji</div>
-                                        <div class="theme-card-title">@preset.Name</div>
-                                    </div>
-                                    <div class="theme-card-ribbon" style="@ThemeRibbonStyle(preset)"></div>
-                                    <div class="theme-card-desc">@preset.Description</div>
-                                    <div class="theme-card-swatches">
-                                        <span class="theme-card-swatch" style="@SwatchStyle(preset.BackgroundStart)"></span>
-                                        <span class="theme-card-swatch" style="@SwatchStyle(preset.AccentColor)"></span>
-                                        <span class="theme-card-swatch" style="@SwatchStyle(preset.AccentSoftColor)"></span>
-                                    </div>
-                                    <div class="theme-card-key">@preset.Key</div>
-                                </CardBody>
-                            </Card>
-                        </Column>
-                    }
-                </Row>
-            </div>
 
             <div class="overtime-links-panel mt-4">
                 <div class="overtime-links-header">
@@ -785,18 +702,12 @@ else
     private bool isLoading = true;
     private EasyLotteryConfigDocument document = new();
     private OvertimeOverlaySettings settings = new();
-    private IReadOnlyList<OvertimeThemePreset> presets = OvertimeThemePreset.Catalog;
     private IReadOnlyList<OvertimeTextAnimationPreset> textAnimationPresets = OvertimeTextAnimationPreset.Catalog;
-    private IReadOnlyList<OvertimeMessageTemplatePreset> messageTemplatePresets = OvertimeMessageTemplatePreset.Catalog;
-    private string selectedThemeKey = OvertimeThemePreset.Catalog[0].Key;
     private string selectedTextAnimationKey = OvertimeTextAnimationPreset.Catalog[0].Key;
-    private string selectedMessageTemplateKey = OvertimeMessageTemplatePreset.Catalog[0].Key;
     private string OverlayUrl => NavigationManager.ToAbsoluteUri("/obs/overtime").ToString();
     private string PlannedEndAtInput { get; set; } = "";
 
-    private OvertimeThemePreset CurrentTheme => OvertimeThemePreset.GetByKey(selectedThemeKey);
     private OvertimeTextAnimationPreset SelectedTextAnimation => OvertimeTextAnimationPreset.GetByKey(selectedTextAnimationKey);
-    private OvertimeMessageTemplatePreset SelectedMessageTemplate => OvertimeMessageTemplatePreset.GetByKey(selectedMessageTemplateKey);
 
     protected override async Task OnInitializedAsync()
     {
@@ -805,9 +716,7 @@ else
         settings.RewardRules ??= new List<OvertimeRewardRule>();
         settings.DemoSuperChatAmount = Math.Max(0, settings.DemoSuperChatAmount);
         settings.DemoEcpayAmount = Math.Max(0, settings.DemoEcpayAmount);
-        selectedThemeKey = string.IsNullOrWhiteSpace(settings.ThemeKey) ? OvertimeThemePreset.Catalog[0].Key : settings.ThemeKey;
         selectedTextAnimationKey = string.IsNullOrWhiteSpace(settings.TextAnimationKey) ? OvertimeTextAnimationPreset.Catalog[0].Key : settings.TextAnimationKey;
-        selectedMessageTemplateKey = string.IsNullOrWhiteSpace(settings.MessageTemplateKey) ? OvertimeMessageTemplatePreset.Catalog[0].Key : settings.MessageTemplateKey;
         PlannedEndAtInput = FormatDateTimeLocal(settings.PlannedEndAtUtc);
         isLoading = false;
     }
@@ -823,16 +732,6 @@ else
         selectedTextAnimationKey = args.Value?.ToString() ?? OvertimeTextAnimationPreset.Catalog[0].Key;
     }
 
-    private void OnMessageTemplateChanged(ChangeEventArgs args)
-    {
-        selectedMessageTemplateKey = args.Value?.ToString() ?? OvertimeMessageTemplatePreset.Catalog[0].Key;
-    }
-
-    private void SelectTheme(string key)
-    {
-        selectedThemeKey = key;
-        settings.ThemeKey = key;
-    }
 
     private void AddRewardRule()
     {
@@ -886,8 +785,6 @@ else
 
         document = latestDocument;
         document.OvertimeOverlay = settings;
-        document.OvertimeOverlay.ThemeKey = selectedThemeKey;
-        document.OvertimeOverlay.MessageTemplateKey = selectedMessageTemplateKey;
         document.OvertimeOverlay.TextAnimationKey = selectedTextAnimationKey;
         await ConfigStore.SaveAsync(document);
 
@@ -1026,23 +923,6 @@ else
     {
         await OvertimeFeedClient.ClearAsync();
         await MessageService.Success("已清除加班台訊息。");
-    }
-
-    private string ThemeCardClass(string key)
-    {
-        var keyClass = key.ToLowerInvariant().Replace('_', '-');
-        var selectedClass = string.Equals(selectedThemeKey, key, StringComparison.OrdinalIgnoreCase) ? " selected" : "";
-        return $"theme-card theme-card-{keyClass}{selectedClass}";
-    }
-
-    private static string ThemeRibbonStyle(OvertimeThemePreset preset)
-    {
-        return $"background: linear-gradient(90deg, {preset.AccentColor}, {preset.AccentSoftColor});";
-    }
-
-    private static string SwatchStyle(string color)
-    {
-        return $"background: {color};";
     }
 
     private static string FormatAmountDisplay(decimal amount)

--- a/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
+++ b/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
@@ -18,14 +18,14 @@
 }
 else
 {
-    <div class="overtime-overlay obs-layout-surface" style="@ThemeStyle">
+    <div class="overtime-overlay">
         <div class="overtime-shell">
             @if (IsIdle)
             {
                 <div class="overtime-standby-panel">
                     <div class="overtime-countdown-label">預計關台時間</div>
                     <div class="overtime-countdown-line">@PlannedCloseText</div>
-                    <div class="overtime-standby-actions">
+                    <div class="overtime-standby-actions overtime-obs-controls">
                         <Button Color="Color.Primary" Clicked="@StartCountdownAsync">開始加班</Button>
                     </div>
                 </div>
@@ -35,7 +35,7 @@ else
                 <div class="overtime-standby-panel">
                     <div class="overtime-countdown-label">加班台已結束</div>
                     <div class="overtime-countdown-line">感謝大家的支持</div>
-                    <div class="overtime-standby-actions">
+                    <div class="overtime-standby-actions overtime-obs-controls">
                         <Button Color="Color.Primary" Clicked="@StartCountdownAsync">開始新一輪加班</Button>
                     </div>
                 </div>
@@ -51,7 +51,7 @@ else
                             <div class="overtime-remaining-time">@RemainingTimeText</div>
                         </div>
                         <div class="overtime-progress-caption">已完成 @ProgressPercent.ToString("0.00")%</div>
-                        <div class="overtime-standby-actions">
+                        <div class="overtime-standby-actions overtime-obs-controls">
                             @if (IsRunning)
                             {
                                 <Button Color="Color.Warning" Clicked="@PauseCountdownAsync">暫停加班</Button>
@@ -162,60 +162,38 @@ else
     }
 
     .overtime-overlay {
+        --overtime-accent: #fbbf24;
+        --overtime-accent-soft: #fb923c;
+        --overtime-glow: rgba(251, 191, 36, 0.7);
+        --overtime-surface: #0f172a;
+        --overtime-surface-border: rgba(255, 255, 255, 0.22);
         width: 100vw;
         height: 100vh;
         display: flex;
         align-items: center;
         justify-content: center;
-        padding: 20px;
+        padding: 28px;
         box-sizing: border-box;
-    }
-
-    .obs-layout-surface {
-        --obs-accent-gradient: linear-gradient(135deg, #ffcb47, #ff9f1a);
+        background: transparent;
     }
 
     .overtime-shell {
-        width: min(100%, 1220px);
-        height: min(100%, 860px);
+        width: 100%;
+        height: 100%;
         display: flex;
         flex-direction: column;
         gap: 14px;
         color: white;
-        border-radius: 32px;
-        padding: 20px;
-        background:
-            radial-gradient(circle at top left, rgba(255, 255, 255, 0.16), transparent 36%),
-            var(--obs-accent-gradient),
-            linear-gradient(135deg, color-mix(in srgb, var(--overtime-background-start) 92%, black), var(--overtime-background-end));
-        box-shadow: 0 28px 80px rgba(0, 0, 0, 0.36);
-        border: 1px solid var(--overtime-surface-border);
         position: relative;
-        overflow: hidden;
-    }
-
-    .overtime-shell::before {
-        content: "";
-        position: absolute;
-        inset: 0;
-        background:
-            radial-gradient(circle at 15% 20%, color-mix(in srgb, var(--overtime-glow) 35%, transparent), transparent 28%),
-            radial-gradient(circle at 85% 20%, color-mix(in srgb, var(--overtime-accent-soft) 30%, transparent), transparent 30%);
-        pointer-events: none;
-        opacity: 0.7;
-    }
-
-    .overtime-shell > * {
-        position: relative;
-        z-index: 1;
     }
 
     .overtime-minimal-overlay {
         flex: 1;
         display: flex;
         flex-direction: column;
-        justify-content: center;
-        gap: 14px;
+        justify-content: space-between;
+        gap: 48px;
+        padding: 72px 0 28px;
         min-height: 0;
     }
 
@@ -297,12 +275,30 @@ else
         flex-wrap: wrap;
     }
 
+    .overtime-obs-controls {
+        position: absolute;
+        top: 0;
+        right: 0;
+        z-index: 10;
+    }
+
     .overtime-fireworks {
         position: absolute;
         inset: 0;
         z-index: 5;
         overflow: hidden;
         pointer-events: none;
+    }
+
+    @@media (max-width: 767px) {
+        .overtime-progress-line {
+            align-items: flex-end;
+            flex-direction: column;
+        }
+
+        .overtime-progress-track {
+            width: 100%;
+        }
     }
 
     .overtime-firework-burst {
@@ -994,10 +990,7 @@ else
     private EasyLotteryConfigDocument document = new();
     private OvertimeOverlaySettings settings = new();
     private IReadOnlyList<OvertimeSupportEvent> events = [];
-    private OvertimeThemePreset CurrentTheme => OvertimeThemePreset.GetByKey(settings.ThemeKey);
-    private string ThemeStyle => CurrentTheme.BuildCssVariables();
-    private OvertimeMessageTemplatePreset MessageTemplate => OvertimeMessageTemplatePreset.GetByKey(settings.MessageTemplateKey);
-    private bool IsPixelHudTemplate => string.Equals(MessageTemplate.Key, "pixel-hud", StringComparison.OrdinalIgnoreCase);
+    private bool IsPixelHudTemplate => false;
     private OvertimeSupportEvent? PlannedEndMarker => events.FirstOrDefault(item =>
         item.Source == OvertimeSupportSource.Manual &&
         string.Equals(item.SourceLabel, PlannedEndMarkerLabel, StringComparison.OrdinalIgnoreCase));

--- a/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
+++ b/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
@@ -50,7 +50,7 @@ else
                             </div>
                             <div class="overtime-remaining-time">@RemainingTimeText</div>
                         </div>
-                        <div class="overtime-progress-caption">已完成 @ProgressPercent.ToString("0.0")%</div>
+                        <div class="overtime-progress-caption">已完成 @ProgressPercent.ToString("0.00")%</div>
                         <div class="overtime-standby-actions">
                             @if (IsRunning)
                             {
@@ -989,6 +989,7 @@ else
     private bool shouldPlayCompletionFireworks;
     private DateTimeOffset? fireworksStartedAtUtc;
     private int fireworksGifCycle;
+    private DateTimeOffset displayClockUtc = DateTimeOffset.UtcNow;
     private string previousSessionState = OvertimeSessionStates.Idle;
     private EasyLotteryConfigDocument document = new();
     private OvertimeOverlaySettings settings = new();
@@ -1002,7 +1003,7 @@ else
         string.Equals(item.SourceLabel, PlannedEndMarkerLabel, StringComparison.OrdinalIgnoreCase));
     private OvertimeSupportEvent? VisibleEvent => events.FirstOrDefault(item => item.Source != OvertimeSupportSource.Manual && OvertimeSessionTimeCalculator.IsEventVisible(item.OccurredAtUtc, DateTimeOffset.UtcNow, settings.SupportMessageVisibleSeconds));
     private DateTimeOffset? SessionEndAtUtc => settings.PlannedEndAtUtc ?? events.FirstOrDefault(item => item.SessionEndAtUtc.HasValue)?.SessionEndAtUtc ?? PlannedEndMarker?.SessionEndAtUtc;
-    private DateTimeOffset SessionClockUtc => IsPaused && settings.PausedAtUtc.HasValue ? settings.PausedAtUtc.Value : DateTimeOffset.UtcNow;
+    private DateTimeOffset SessionClockUtc => IsPaused && settings.PausedAtUtc.HasValue ? settings.PausedAtUtc.Value : displayClockUtc;
     private bool IsIdle => settings.SessionState == OvertimeSessionStates.Idle;
     private bool IsRunning => settings.SessionState == OvertimeSessionStates.Running;
     private bool IsPaused => settings.SessionState == OvertimeSessionStates.Paused;
@@ -1061,6 +1062,7 @@ else
     {
         await InvokeAsync(() =>
         {
+            displayClockUtc = DateTimeOffset.UtcNow;
             if (fireworksStartedAtUtc.HasValue)
             {
                 fireworksGifCycle = (int)((DateTimeOffset.UtcNow - fireworksStartedAtUtc.Value).TotalSeconds / 2d);
@@ -1079,6 +1081,7 @@ else
 
     private async Task ReloadOverlayStateAsync()
     {
+        displayClockUtc = DateTimeOffset.UtcNow;
         document = await ConfigStore.LoadAsync();
         settings = document.OvertimeOverlay ?? new OvertimeOverlaySettings();
         settings.ThemeKey = string.IsNullOrWhiteSpace(settings.ThemeKey) ? OvertimeThemePreset.Catalog[0].Key : settings.ThemeKey;
@@ -1290,8 +1293,8 @@ else
             remaining = TimeSpan.Zero;
         }
 
-        var fraction = (remaining.Ticks % TimeSpan.TicksPerSecond) / (TimeSpan.TicksPerSecond / 10_000);
-        return $"{remaining.Days:000}{remaining.Hours:00}{remaining.Minutes:00}{remaining.Seconds:00}{fraction:0000}";
+        var centiseconds = remaining.Milliseconds / 10;
+        return $"{remaining.Days:00}D{remaining.Hours:00}H{remaining.Minutes:00}M{remaining.Seconds:00}.{centiseconds:00}S";
     }
 
     private static string BuildPlannedCloseText(DateTimeOffset? plannedEndAtUtc)

--- a/src/EasyLotteryWasm/wwwroot/index.html
+++ b/src/EasyLotteryWasm/wwwroot/index.html
@@ -141,19 +141,28 @@
 
             const storageKey = "easy-lottery.overtime-feed";
             const remoteFeedUrl = "/easy-lottery-overtime-feed.json";
+            let nextRemoteAttemptAt = 0;
 
             function getSafeContent(content) {
                 return content == null ? "[]" : String(content);
             }
 
             async function readRemoteFeed() {
+                const now = Date.now();
+                if (now < nextRemoteAttemptAt) {
+                    return "";
+                }
+
                 try {
                     const response = await fetch(remoteFeedUrl, { cache: "no-store", mode: "cors" });
                     if (response.ok) {
+                        nextRemoteAttemptAt = 0;
                         return getSafeContent(await response.text());
                     }
                 } catch {
                 }
+
+                nextRemoteAttemptAt = now + 30_000;
 
                 return "";
             }

--- a/src/EasyLotteryWasm/wwwroot/js/configStorage.js
+++ b/src/EasyLotteryWasm/wwwroot/js/configStorage.js
@@ -6,6 +6,7 @@
     const storageKey = "easy-lottery.config.yaml";
     const remoteConfigUrl = "/easy-lottery-config.yaml";
     let memoryFallback = "";
+    let nextRemoteAttemptAt = 0;
 
     function getSafeContent(content) {
         return content == null ? "" : content;
@@ -23,14 +24,23 @@
     }
 
     async function read() {
+        const now = Date.now();
         try {
             // The web host owns the YAML file. Do not let a stale per-browser
             // localStorage value override shared settings.
-            const response = await fetch(remoteConfigUrl, { cache: "no-store" });
-            if (response.ok) {
-                return cacheFallback(await response.text());
+            if (now >= nextRemoteAttemptAt) {
+                const response = await fetch(remoteConfigUrl, { cache: "no-store" });
+                if (response.ok) {
+                    nextRemoteAttemptAt = 0;
+                    return cacheFallback(await response.text());
+                }
+
+                // The standalone WASM dev server has no YAML API. Avoid generating
+                // a 404 every overlay refresh while retaining the local fallback.
+                nextRemoteAttemptAt = now + 30_000;
             }
         } catch {
+            nextRemoteAttemptAt = now + 30_000;
         }
 
         try {


### PR DESCRIPTION
## Summary
- drive the OBS progress bar and percentage from a dedicated 50ms display clock
- format remaining time as xxDxxHxxMxx.xxS
- remove overtime style/template selection, themed preview, and background artwork
- render the OBS overtime page on a transparent canvas with progress and donate content only
- move host controls into an independent top-right control area so OBS crops can exclude them
- throttle missing Web Host config and overtime-feed retries so standalone WASM does not generate repeated 404s

## Note
Shared YAML settings and events require starting the EasyLotteryWeb host or Docker Compose, rather than the standalone WASM dev server.

## Verification
- dotnet test EasyLottery.generated.sln --no-restore
- dotnet build EasyLottery.generated.sln --no-restore