### PR TITLE
fix: use browser clock for transparent overtime OBS

### DIFF
--- a/src/EasyLotteryWasm/EasyLotteryWasm.csproj
+++ b/src/EasyLotteryWasm/EasyLotteryWasm.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="DistributedCache" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.29" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.10" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.29" />
     <PackageReference Include="MiniExcel" Version="1.45.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Serilog" Version="4.4.0" />

--- a/src/EasyLotteryWasm/Pages/Config/OvertimeOverlay.razor
+++ b/src/EasyLotteryWasm/Pages/Config/OvertimeOverlay.razor
@@ -829,10 +829,8 @@ else
 
         if (entry != null && isStarted)
         {
-            settings.PlannedEndAtUtc = entry.SessionEndAtUtc;
-            document.OvertimeOverlay = settings;
-            await ConfigStore.SaveAsync(document);
-            await PublishPlannedEndMarkerAsync(settings.PlannedEndAtUtc);
+            await UpdateCurrentSessionEndAsync(entry.SessionEndAtUtc);
+            await PublishPlannedEndMarkerAsync(entry.SessionEndAtUtc);
             await MessageService.Success("已送出示範 SuperChat。");
         }
     }
@@ -864,10 +862,8 @@ else
 
         if (entry != null && isStarted)
         {
-            settings.PlannedEndAtUtc = entry.SessionEndAtUtc;
-            document.OvertimeOverlay = settings;
-            await ConfigStore.SaveAsync(document);
-            await PublishPlannedEndMarkerAsync(settings.PlannedEndAtUtc);
+            await UpdateCurrentSessionEndAsync(entry.SessionEndAtUtc);
+            await PublishPlannedEndMarkerAsync(entry.SessionEndAtUtc);
             await MessageService.Success("已送出示範綠界 Donate。");
         }
     }
@@ -896,6 +892,20 @@ else
     {
         var latestDocument = await ConfigStore.LoadAsync();
         return latestDocument.OvertimeOverlay?.PlannedEndAtUtc ?? settings.PlannedEndAtUtc;
+    }
+
+    private async Task UpdateCurrentSessionEndAsync(DateTimeOffset? plannedEndAtUtc)
+    {
+        // Settings pages can remain open while OBS controls a session in another
+        // browser. Only update the end time on the current document so a demo
+        // donation cannot reset StreamStartedAtUtc or SessionState.
+        var latestDocument = await ConfigStore.LoadAsync();
+        latestDocument.OvertimeOverlay ??= new OvertimeOverlaySettings();
+        latestDocument.OvertimeOverlay.PlannedEndAtUtc = plannedEndAtUtc;
+        await ConfigStore.SaveAsync(latestDocument);
+
+        document = latestDocument;
+        settings = latestDocument.OvertimeOverlay;
     }
 
     private async Task PublishPlannedEndMarkerAsync(DateTimeOffset? plannedEndAtUtc)

--- a/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
+++ b/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
@@ -46,15 +46,20 @@ else
             {
                 <div class="overtime-minimal-overlay">
                     <div class="overtime-progress-wrap">
-                        <div class="overtime-progress-panel">
+                        <div id="overtime-progress-panel"
+                             class="overtime-progress-panel"
+                             data-start-ms="@ToUnixMilliseconds(settings.StreamStartedAtUtc)"
+                             data-end-ms="@ToUnixMilliseconds(SessionEndAtUtc)"
+                             data-paused-at-ms="@ToUnixMilliseconds(settings.PausedAtUtc)"
+                             data-is-paused="@IsPaused.ToString().ToLowerInvariant()">
                             <div class="overtime-progress-header">
                                 <div class="overtime-progress-label">加班<br />時間</div>
-                                <div class="overtime-remaining-time">@RemainingTimeText</div>
+                                <div id="overtime-remaining-time" class="overtime-remaining-time">@RemainingTimeText</div>
                             </div>
                             <div class="overtime-progress-title">加班進度</div>
                             <div class="overtime-progress-track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="@ProgressPercent">
-                                <div class="overtime-progress-fill" style="@ProgressStyle"></div>
-                                <div class="overtime-progress-value">@ProgressPercent.ToString("0.00")%</div>
+                                <div id="overtime-progress-fill" class="overtime-progress-fill" style="@ProgressStyle"></div>
+                                <div id="overtime-progress-value" class="overtime-progress-value">@ProgressPercent.ToString("0.00")%</div>
                             </div>
                         </div>
                         <div class="overtime-standby-actions overtime-obs-controls">
@@ -274,7 +279,6 @@ else
         border-radius: 0;
         background: linear-gradient(180deg, #73ef81, #32c94e);
         box-shadow: inset 0 2px 0 rgba(255, 255, 255, 0.5);
-        transition: width 0.05s linear;
     }
 
     .overtime-progress-title {
@@ -1018,7 +1022,6 @@ else
     private DateTimeOffset? fireworksStartedAtUtc;
     private int fireworksGifCycle;
     private DateTimeOffset displayClockUtc = DateTimeOffset.UtcNow;
-    private DotNetObjectReference<OvertimeOverlay>? clockReference;
     private string previousSessionState = OvertimeSessionStates.Idle;
     private EasyLotteryConfigDocument document = new();
     private OvertimeOverlaySettings settings = new();
@@ -1065,8 +1068,7 @@ else
             return;
         }
 
-        clockReference = DotNetObjectReference.Create(this);
-        await JSRuntime.InvokeVoidAsync("easyLotteryObs.startOverlayClock", clockReference);
+        await JSRuntime.InvokeVoidAsync("easyLotteryObs.startOverlayClock");
     }
 
     private async void OnTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
@@ -1089,18 +1091,6 @@ else
         {
             isRefreshing = false;
         }
-    }
-
-    [JSInvokable]
-    public Task UpdateOverlayClock(long unixTimeMilliseconds)
-    {
-        displayClockUtc = DateTimeOffset.FromUnixTimeMilliseconds(unixTimeMilliseconds);
-        if (fireworksStartedAtUtc.HasValue)
-        {
-            fireworksGifCycle = (int)((displayClockUtc - fireworksStartedAtUtc.Value).TotalSeconds / 2d);
-        }
-
-        return InvokeAsync(StateHasChanged);
     }
 
     private async Task ReloadOverlayAsync()
@@ -1328,6 +1318,9 @@ else
         return $"{totalHours:00}:{remaining.Minutes:00}:{remaining.Seconds:00}";
     }
 
+    private static long ToUnixMilliseconds(DateTimeOffset? value) =>
+        value.HasValue ? value.Value.ToUnixTimeMilliseconds() : 0;
+
     private static string BuildPlannedCloseText(DateTimeOffset? plannedEndAtUtc)
     {
         if (!plannedEndAtUtc.HasValue || plannedEndAtUtc.Value.Year < 2000)
@@ -1346,17 +1339,12 @@ else
             refreshTimer.Dispose();
         }
 
-        if (clockReference != null)
+        try
         {
-            try
-            {
-                await JSRuntime.InvokeVoidAsync("easyLotteryObs.stopOverlayClock");
-            }
-            catch (JSDisconnectedException)
-            {
-            }
-
-            clockReference.Dispose();
+            await JSRuntime.InvokeVoidAsync("easyLotteryObs.stopOverlayClock");
+        }
+        catch (JSDisconnectedException)
+        {
         }
     }
 }

--- a/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
+++ b/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
@@ -46,13 +46,17 @@ else
             {
                 <div class="overtime-minimal-overlay">
                     <div class="overtime-progress-wrap">
-                        <div class="overtime-progress-line">
+                        <div class="overtime-progress-panel">
+                            <div class="overtime-progress-header">
+                                <div class="overtime-progress-label">加班<br />時間</div>
+                                <div class="overtime-remaining-time">@RemainingTimeText</div>
+                            </div>
+                            <div class="overtime-progress-title">加班進度</div>
                             <div class="overtime-progress-track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="@ProgressPercent">
                                 <div class="overtime-progress-fill" style="@ProgressStyle"></div>
+                                <div class="overtime-progress-value">@ProgressPercent.ToString("0.00")%</div>
                             </div>
-                            <div class="overtime-remaining-time">@RemainingTimeText</div>
                         </div>
-                        <div class="overtime-progress-caption">已完成 @ProgressPercent.ToString("0.00")%</div>
                         <div class="overtime-standby-actions overtime-obs-controls">
                             @if (IsRunning)
                             {
@@ -218,47 +222,78 @@ else
         align-items: center;
     }
 
-    .overtime-progress-track {
-        flex: 1;
-        height: 18px;
-        overflow: hidden;
-        border: 2px solid rgba(255, 255, 255, 0.8);
-        border-radius: 999px;
-        background: rgba(15, 23, 42, 0.35);
-        box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.24);
+    .overtime-progress-panel {
+        width: min(47vw, 520px);
+        box-sizing: border-box;
+        padding: 10px 18px 14px;
+        border: 7px solid #0d4c91;
+        background: #a9cff4;
+        box-shadow: 0 5px 0 rgba(4, 35, 73, 0.45);
+        color: #102c50;
     }
 
-    .overtime-progress-line {
-        width: min(47vw, 520px);
+    .overtime-progress-header {
         display: flex;
         align-items: center;
-        gap: 16px;
+        justify-content: center;
+        gap: 12px;
+    }
+
+    .overtime-progress-label {
+        color: #1f4f7f;
+        font-size: clamp(1rem, 1.7vw, 1.65rem);
+        font-weight: 950;
+        line-height: 1.02;
+        letter-spacing: 0.04em;
+    }
+
+    .overtime-progress-track {
+        position: relative;
+        width: 100%;
+        height: 38px;
+        overflow: hidden;
+        border: 3px solid #1b5773;
+        border-radius: 0;
+        background: #e0f7d8;
+        box-shadow: inset 0 2px 4px rgba(10, 55, 42, 0.34);
     }
 
     .overtime-remaining-time {
-        min-width: 212px;
-        color: #ffffff;
-        font-size: clamp(1.25rem, 2vw, 2rem);
+        color: #f8fbff;
+        font-size: clamp(1.9rem, 3.5vw, 3.8rem);
         font-weight: 950;
-        letter-spacing: 0.06em;
+        letter-spacing: 0.035em;
         font-variant-numeric: tabular-nums;
         white-space: nowrap;
-        text-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
+        -webkit-text-stroke: 1px #40556b;
+        text-shadow: 2px 2px 0 rgba(28, 57, 84, 0.28);
     }
 
     .overtime-progress-fill {
         height: 100%;
-        border-radius: inherit;
-        background: linear-gradient(90deg, #fff0a8, var(--overtime-accent), #ff8f3d);
-        box-shadow: 0 0 18px var(--overtime-glow);
-        transition: width 0.8s linear;
+        border-radius: 0;
+        background: linear-gradient(180deg, #73ef81, #32c94e);
+        box-shadow: inset 0 2px 0 rgba(255, 255, 255, 0.5);
+        transition: width 0.05s linear;
     }
 
-    .overtime-progress-caption {
-        color: rgba(255, 255, 255, 0.88);
-        font-size: 0.95rem;
-        font-weight: 800;
-        font-variant-numeric: tabular-nums;
+    .overtime-progress-title {
+        margin: 2px 0 4px;
+        color: #183755;
+        font-size: clamp(0.95rem, 1.5vw, 1.35rem);
+        font-weight: 950;
+        text-align: center;
+    }
+
+    .overtime-progress-value {
+        position: absolute;
+        inset: 0;
+        display: grid;
+        place-items: center;
+        color: #102f1d;
+        font-size: clamp(1.2rem, 2.3vw, 2rem);
+        font-weight: 950;
+        text-shadow: 1px 1px 0 rgba(255, 255, 255, 0.55);
     }
 
     .overtime-countdown-line {
@@ -294,13 +329,8 @@ else
     }
 
     @@media (max-width: 767px) {
-        .overtime-progress-line {
-            align-items: flex-end;
-            flex-direction: column;
-        }
-
-        .overtime-progress-track {
-            width: 100%;
+        .overtime-progress-panel {
+            width: min(92vw, 520px);
         }
     }
 

--- a/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
+++ b/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
@@ -7,6 +7,8 @@
 @using EasyLotteryWasm.Models
 @inject IEasyLotteryConfigStore ConfigStore
 @inject OvertimeFeedClient OvertimeFeedClient
+@inject IJSRuntime JSRuntime
+@implements IAsyncDisposable
 
 <PageTitle>加班台 - OBS</PageTitle>
 
@@ -155,8 +157,9 @@ else
 }
 
 <style>
-    html, body, #app, .obs-layout {
-        background: transparent !important;
+    html, body, #app, .obs-layout, .overtime-overlay, .overtime-shell {
+        background-color: transparent !important;
+        background-image: none !important;
         margin: 0;
         padding: 0;
     }
@@ -980,12 +983,12 @@ else
 
     private bool isLoading = true;
     private System.Timers.Timer? refreshTimer;
-    private System.Timers.Timer? displayTimer;
     private bool isRefreshing;
     private bool shouldPlayCompletionFireworks;
     private DateTimeOffset? fireworksStartedAtUtc;
     private int fireworksGifCycle;
     private DateTimeOffset displayClockUtc = DateTimeOffset.UtcNow;
+    private DotNetObjectReference<OvertimeOverlay>? clockReference;
     private string previousSessionState = OvertimeSessionStates.Idle;
     private EasyLotteryConfigDocument document = new();
     private OvertimeOverlaySettings settings = new();
@@ -1023,10 +1026,17 @@ else
         refreshTimer.AutoReset = true;
         refreshTimer.Start();
 
-        displayTimer = new System.Timers.Timer(50);
-        displayTimer.Elapsed += OnDisplayTimerElapsed;
-        displayTimer.AutoReset = true;
-        displayTimer.Start();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+        {
+            return;
+        }
+
+        clockReference = DotNetObjectReference.Create(this);
+        await JSRuntime.InvokeVoidAsync("easyLotteryObs.startOverlayClock", clockReference);
     }
 
     private async void OnTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
@@ -1051,18 +1061,16 @@ else
         }
     }
 
-    private async void OnDisplayTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    [JSInvokable]
+    public Task UpdateOverlayClock(long unixTimeMilliseconds)
     {
-        await InvokeAsync(() =>
+        displayClockUtc = DateTimeOffset.FromUnixTimeMilliseconds(unixTimeMilliseconds);
+        if (fireworksStartedAtUtc.HasValue)
         {
-            displayClockUtc = DateTimeOffset.UtcNow;
-            if (fireworksStartedAtUtc.HasValue)
-            {
-                fireworksGifCycle = (int)((DateTimeOffset.UtcNow - fireworksStartedAtUtc.Value).TotalSeconds / 2d);
-            }
+            fireworksGifCycle = (int)((displayClockUtc - fireworksStartedAtUtc.Value).TotalSeconds / 2d);
+        }
 
-            StateHasChanged();
-        });
+        return InvokeAsync(StateHasChanged);
     }
 
     private async Task ReloadOverlayAsync()
@@ -1300,7 +1308,7 @@ else
         return plannedEndAtUtc.Value.ToLocalTime().ToString("yyyy/MM/dd HH:mm");
     }
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         if (refreshTimer != null)
         {
@@ -1308,10 +1316,17 @@ else
             refreshTimer.Dispose();
         }
 
-        if (displayTimer != null)
+        if (clockReference != null)
         {
-            displayTimer.Elapsed -= OnDisplayTimerElapsed;
-            displayTimer.Dispose();
+            try
+            {
+                await JSRuntime.InvokeVoidAsync("easyLotteryObs.stopOverlayClock");
+            }
+            catch (JSDisconnectedException)
+            {
+            }
+
+            clockReference.Dispose();
         }
     }
 }

--- a/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
+++ b/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
@@ -229,7 +229,7 @@ else
     }
 
     .overtime-progress-line {
-        width: min(94vw, 1040px);
+        width: min(47vw, 520px);
         display: flex;
         align-items: center;
         gap: 16px;

--- a/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
+++ b/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
@@ -7,6 +7,7 @@
 @using EasyLotteryWasm.Models
 @inject IEasyLotteryConfigStore ConfigStore
 @inject OvertimeFeedClient OvertimeFeedClient
+@inject OvertimeRealtimeClient OvertimeRealtimeClient
 @inject IJSRuntime JSRuntime
 @implements IAsyncDisposable
 
@@ -1054,6 +1055,18 @@ else
     {
         await ReloadOverlayAsync();
 
+        OvertimeRealtimeClient.StateChanged += HandleRealtimeUpdateAsync;
+        OvertimeRealtimeClient.FeedChanged += HandleRealtimeUpdateAsync;
+        try
+        {
+            await OvertimeRealtimeClient.StartAsync();
+        }
+        catch
+        {
+            // The standalone WASM dev server has no SignalR host. The page retains
+            // its local fallback while the Web Host provides live synchronization.
+        }
+
         refreshTimer = new System.Timers.Timer(1000);
         refreshTimer.Elapsed += OnTimerElapsed;
         refreshTimer.AutoReset = true;
@@ -1092,6 +1105,12 @@ else
             isRefreshing = false;
         }
     }
+
+    private Task HandleRealtimeUpdateAsync() => InvokeAsync(async () =>
+    {
+        await ReloadOverlayStateAsync();
+        StateHasChanged();
+    });
 
     private async Task ReloadOverlayAsync()
     {
@@ -1346,5 +1365,9 @@ else
         catch (JSDisconnectedException)
         {
         }
+
+        OvertimeRealtimeClient.StateChanged -= HandleRealtimeUpdateAsync;
+        OvertimeRealtimeClient.FeedChanged -= HandleRealtimeUpdateAsync;
+        await OvertimeRealtimeClient.DisposeAsync();
     }
 }

--- a/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
+++ b/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
@@ -1294,8 +1294,8 @@ else
             remaining = TimeSpan.Zero;
         }
 
-        var centiseconds = remaining.Milliseconds / 10;
-        return $"{remaining.Days:00}D{remaining.Hours:00}H{remaining.Minutes:00}M{remaining.Seconds:00}.{centiseconds:00}S";
+        var totalHours = (int)Math.Floor(remaining.TotalHours);
+        return $"{totalHours:00}:{remaining.Minutes:00}:{remaining.Seconds:00}";
     }
 
     private static string BuildPlannedCloseText(DateTimeOffset? plannedEndAtUtc)

--- a/src/EasyLotteryWasm/Program.cs
+++ b/src/EasyLotteryWasm/Program.cs
@@ -41,6 +41,7 @@ builder.Services.AddScoped<ActivityResultService>();
 builder.Services.AddScoped<ResultNotificationService>();
 builder.Services.AddScoped<VisualStyleService>();
 builder.Services.AddScoped<OvertimeFeedClient>();
+builder.Services.AddScoped<OvertimeRealtimeClient>();
 builder.Services.AddScoped<EasyLotteryAuditService>();
 
 // 添加服務

--- a/src/EasyLotteryWasm/Services/OvertimeRealtimeClient.cs
+++ b/src/EasyLotteryWasm/Services/OvertimeRealtimeClient.cs
@@ -1,0 +1,61 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace EasyLotteryWasm.Services;
+
+public sealed class OvertimeRealtimeClient : IAsyncDisposable
+{
+    private readonly NavigationManager _navigationManager;
+    private HubConnection? _connection;
+
+    public event Func<Task>? StateChanged;
+    public event Func<Task>? FeedChanged;
+
+    public OvertimeRealtimeClient(NavigationManager navigationManager)
+    {
+        _navigationManager = navigationManager;
+    }
+
+    public async Task StartAsync()
+    {
+        if (_connection is not null)
+        {
+            return;
+        }
+
+        _connection = new HubConnectionBuilder()
+            .WithUrl(_navigationManager.ToAbsoluteUri("/hubs/overtime"), options =>
+            {
+                options.Transports = Microsoft.AspNetCore.Http.Connections.HttpTransportType.WebSockets;
+            })
+            .WithAutomaticReconnect()
+            .Build();
+
+        _connection.On("OvertimeStateChanged", async () => await NotifyAsync(StateChanged));
+        _connection.On("OvertimeFeedChanged", async () => await NotifyAsync(FeedChanged));
+        await _connection.StartAsync();
+    }
+
+    private static async Task NotifyAsync(Func<Task>? handlers)
+    {
+        if (handlers is null)
+        {
+            return;
+        }
+
+        foreach (var handler in handlers.GetInvocationList().Cast<Func<Task>>())
+        {
+            await handler();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_connection is null)
+        {
+            return;
+        }
+
+        await _connection.DisposeAsync();
+    }
+}

--- a/src/EasyLotteryWasm/wwwroot/index.html
+++ b/src/EasyLotteryWasm/wwwroot/index.html
@@ -32,6 +32,40 @@
 
     <script src="js/configStorage.js"></script>
     <script>
+        (() => {
+            let overlayClockFrame = 0;
+            let overlayClockLastTick = 0;
+
+            function makeTransparent() {
+                for (const element of [document.documentElement, document.body, document.getElementById("app")]) {
+                    if (!element) continue;
+                    element.style.setProperty("background", "transparent", "important");
+                    element.style.setProperty("background-color", "transparent", "important");
+                    element.style.setProperty("background-image", "none", "important");
+                }
+            }
+
+            window.easyLotteryObs = {
+                startOverlayClock: (dotNetReference) => {
+                    cancelAnimationFrame(overlayClockFrame);
+                    overlayClockLastTick = 0;
+                    makeTransparent();
+
+                    const tick = (now) => {
+                        if (now - overlayClockLastTick >= 50) {
+                            overlayClockLastTick = now;
+                            dotNetReference.invokeMethodAsync("UpdateOverlayClock", Date.now());
+                        }
+                        overlayClockFrame = requestAnimationFrame(tick);
+                    };
+
+                    overlayClockFrame = requestAnimationFrame(tick);
+                },
+                stopOverlayClock: () => cancelAnimationFrame(overlayClockFrame)
+            };
+        })();
+    </script>
+    <script>
         window.easyLotteryMail = {
             send: async (request) => {
                 const response = await fetch("/api/result-notification", {

--- a/src/EasyLotteryWasm/wwwroot/index.html
+++ b/src/EasyLotteryWasm/wwwroot/index.html
@@ -45,8 +45,36 @@
                 }
             }
 
+            function syncOvertimeProgress() {
+                const panel = document.getElementById("overtime-progress-panel");
+                if (!panel) return;
+
+                const start = Number(panel.dataset.startMs || 0);
+                const end = Number(panel.dataset.endMs || 0);
+                if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) return;
+
+                const paused = panel.dataset.isPaused === "true";
+                const pausedAt = Number(panel.dataset.pausedAtMs || 0);
+                const now = paused && pausedAt > 0 ? pausedAt : Date.now();
+                const progress = Math.max(0, Math.min(100, ((now - start) / (end - start)) * 100));
+                const remainingMs = Math.max(0, end - now);
+                const remainingSeconds = Math.floor(remainingMs / 1000);
+                const hours = Math.floor(remainingSeconds / 3600);
+                const minutes = Math.floor((remainingSeconds % 3600) / 60);
+                const seconds = remainingSeconds % 60;
+
+                const fill = document.getElementById("overtime-progress-fill");
+                const value = document.getElementById("overtime-progress-value");
+                const remaining = document.getElementById("overtime-remaining-time");
+                if (fill) fill.style.width = `${progress.toFixed(4)}%`;
+                if (value) value.textContent = `${progress.toFixed(2)}%`;
+                if (remaining) {
+                    remaining.textContent = `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+                }
+            }
+
             window.easyLotteryObs = {
-                startOverlayClock: (dotNetReference) => {
+                startOverlayClock: () => {
                     cancelAnimationFrame(overlayClockFrame);
                     overlayClockLastTick = 0;
                     makeTransparent();
@@ -54,7 +82,7 @@
                     const tick = (now) => {
                         if (now - overlayClockLastTick >= 50) {
                             overlayClockLastTick = now;
-                            dotNetReference.invokeMethodAsync("UpdateOverlayClock", Date.now());
+                            syncOvertimeProgress();
                         }
                         overlayClockFrame = requestAnimationFrame(tick);
                     };

--- a/src/EasyLotteryWeb/OvertimeHub.cs
+++ b/src/EasyLotteryWeb/OvertimeHub.cs
@@ -1,0 +1,5 @@
+using Microsoft.AspNetCore.SignalR;
+
+public sealed class OvertimeHub : Hub
+{
+}

--- a/src/EasyLotteryWeb/Program.cs
+++ b/src/EasyLotteryWeb/Program.cs
@@ -1,8 +1,10 @@
 using System.Text;
 using System.Net;
 using System.Net.Mail;
+using Microsoft.AspNetCore.SignalR;
 
 var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddSignalR();
 
 var storageDirectory = builder.Configuration["Storage:Directory"]
     ?? Path.Combine(builder.Environment.ContentRootPath, "App_Data");
@@ -23,10 +25,11 @@ app.MapGet("/easy-lottery-config.yaml", async (HttpContext context) =>
     return Results.Text(content, "text/yaml", Encoding.UTF8);
 });
 
-app.MapPut("/easy-lottery-config.yaml", async (HttpContext context) =>
+app.MapPut("/easy-lottery-config.yaml", async (HttpContext context, IHubContext<OvertimeHub> hub) =>
 {
     var content = await ReadRequestBodyAsync(context.Request, context.RequestAborted);
     await WriteFileAsync(configPath, content, storageGate, context.RequestAborted);
+    await hub.Clients.All.SendAsync("OvertimeStateChanged", context.RequestAborted);
     return Results.NoContent();
 });
 
@@ -36,16 +39,18 @@ app.MapGet("/easy-lottery-overtime-feed.json", async (HttpContext context) =>
     return Results.Text(content, "application/json", Encoding.UTF8);
 });
 
-app.MapPut("/easy-lottery-overtime-feed.json", async (HttpContext context) =>
+app.MapPut("/easy-lottery-overtime-feed.json", async (HttpContext context, IHubContext<OvertimeHub> hub) =>
 {
     var content = await ReadRequestBodyAsync(context.Request, context.RequestAborted);
     await WriteFileAsync(overtimeFeedPath, content, storageGate, context.RequestAborted);
+    await hub.Clients.All.SendAsync("OvertimeFeedChanged", context.RequestAborted);
     return Results.NoContent();
 });
 
-app.MapDelete("/easy-lottery-overtime-feed.json", async (HttpContext context) =>
+app.MapDelete("/easy-lottery-overtime-feed.json", async (HttpContext context, IHubContext<OvertimeHub> hub) =>
 {
     await WriteFileAsync(overtimeFeedPath, "[]", storageGate, context.RequestAborted);
+    await hub.Clients.All.SendAsync("OvertimeFeedChanged", context.RequestAborted);
     return Results.NoContent();
 });
 
@@ -75,6 +80,8 @@ app.MapPost("/api/result-notification", async (ResultNotificationRequest request
     await client.SendMailAsync(message);
     return Results.NoContent();
 });
+
+app.MapHub<OvertimeHub>("/hubs/overtime");
 
 app.MapFallbackToFile("index.html");
 


### PR DESCRIPTION
## Summary
- force the rendered document background transparent for OBS Browser Source
- render progress locally with requestAnimationFrame for reliable OBS updates
- synchronize overtime YAML state and feed changes through a SignalR WebSocket hub
- refresh OBS immediately after start, pause, resume, end, donate, or feed changes
- move host controls away from the progress and donate presentation areas

## Verification
- dotnet restore EasyLottery.generated.sln
- dotnet test EasyLottery.generated.sln --no-restore
- dotnet build EasyLottery.generated.sln --no-restore