### PR TITLE
fix: support second-precision overtime targets

### DIFF
--- a/src/EasyLotteryWasm/Pages/Config/OvertimeOverlay.razor
+++ b/src/EasyLotteryWasm/Pages/Config/OvertimeOverlay.razor
@@ -89,6 +89,7 @@ else
                                             <FieldLabel>預計結束時間</FieldLabel>
                                               <input class="overtime-datetime-input"
                                                   type="datetime-local"
+                                                  step="1"
                                                   value="@PlannedEndAtInput"
                                                   @oninput="OnPlannedEndAtInputChanged" />
                                         </Field>
@@ -953,7 +954,7 @@ else
             return "";
         }
 
-        return utcValue.ToLocalTime().DateTime.ToString("yyyy-MM-ddTHH:mm", CultureInfo.InvariantCulture);
+        return utcValue.ToLocalTime().DateTime.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture);
     }
 
     private static DateTimeOffset? ParseDateTimeLocal(string? value)

--- a/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
+++ b/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
@@ -1165,12 +1165,12 @@ else
     private async Task StartCountdownAsync()
     {
         var plannedEndAtUtc = PlannedEndMarker?.SessionEndAtUtc ?? settings.PlannedEndAtUtc;
-        if (!plannedEndAtUtc.HasValue || plannedEndAtUtc.Value.Year < 2000)
+        var nowUtc = DateTimeOffset.UtcNow;
+        if (!plannedEndAtUtc.HasValue || plannedEndAtUtc.Value.Year < 2000 || plannedEndAtUtc.Value <= nowUtc)
         {
             return;
         }
 
-        var nowUtc = DateTimeOffset.UtcNow;
         settings.StreamStartedAtUtc = nowUtc;
         settings.PlannedEndAtUtc = plannedEndAtUtc;
         settings.PausedAtUtc = null;


### PR DESCRIPTION
## Summary
- allow second-level precision when configuring an overtime target
- preserve seconds when loading an existing target into the settings form
- refuse to start a session whose target is already in the past

## Verification
- dotnet test EasyLottery.generated.sln --no-restore
- dotnet build EasyLottery.generated.sln --no-restore