### PR TITLE
feat: add public callback tunnel controls

### DIFF
--- a/src/EasyLotteryDomain/Models/Config/EasyLotteryConfigDocument.cs
+++ b/src/EasyLotteryDomain/Models/Config/EasyLotteryConfigDocument.cs
@@ -32,6 +32,8 @@ namespace EasyLotteryDomain.Models.Config
 
         public DonationIntegrationSettings DonationIntegration { get; set; } = new();
 
+        public PublicCallbackSettings PublicCallback { get; set; } = new();
+
         public MailDeliverySettings MailDelivery { get; set; } = new();
 
         public bool EnableYouTubeSuperChat { get; set; }
@@ -87,6 +89,34 @@ namespace EasyLotteryDomain.Models.Config
         public DonationProviderSettings TwitchBits { get; set; } = new()
         {
             Name = "Twitch 小奇點"
+        };
+    }
+
+    public sealed class PublicCallbackSettings
+    {
+        public string CustomDomain { get; set; } = "";
+
+        public string TunnelProvider { get; set; } = PublicCallbackTunnelProviders.CloudflareQuick;
+
+        public string ActivePublicBaseUrl { get; set; } = "";
+
+        public string GetConfiguredBaseUrl()
+        {
+            return string.IsNullOrWhiteSpace(CustomDomain)
+                ? ActivePublicBaseUrl.Trim()
+                : CustomDomain.Trim();
+        }
+    }
+
+    public static class PublicCallbackTunnelProviders
+    {
+        public const string CloudflareQuick = "cloudflare-quick";
+        public const string DevTunnels = "dev-tunnels";
+
+        public static string Normalize(string? value) => value?.Trim().ToLowerInvariant() switch
+        {
+            DevTunnels => DevTunnels,
+            _ => CloudflareQuick
         };
     }
 

--- a/src/EasyLotteryWasm/Pages/Config/PaymentSettings.razor
+++ b/src/EasyLotteryWasm/Pages/Config/PaymentSettings.razor
@@ -33,6 +33,46 @@
             <Row Margin="Margin.Is3.FromTop">
                 <Column ColumnSize="ColumnSize.Is12">
                     <Card>
+                        <CardHeader><CardTitle>公開回呼入口（Notify URL）</CardTitle></CardHeader>
+                        <CardBody>
+                            <Alert Color="Color.Info" Visible>
+                                <AlertMessage>金流服務商必須能透過 HTTPS 連線至此系統。</AlertMessage>
+                                <AlertDescription>已設定自訂網域時會優先使用；未設定時可選擇 Cloudflare Quick Tunnel 或 Microsoft Dev Tunnels。</AlertDescription>
+                            </Alert>
+                            <Field>
+                                <FieldLabel>自訂 HTTPS Domain</FieldLabel>
+                                <TextInput @bind-Value="settings.PublicCallback.CustomDomain" Placeholder="https://easy-lottery.example.com" />
+                                <div class="text-muted mt-1">正式環境建議使用固定 HTTPS 網域；填入後會覆蓋下方 Tunnel 選擇。</div>
+                            </Field>
+                            <Field>
+                                <FieldLabel>未設定網域時使用</FieldLabel>
+                                <Select TValue="string" @bind-SelectedValue="settings.PublicCallback.TunnelProvider" Disabled="@HasCustomDomain">
+                                    <SelectItem Value="@PublicCallbackTunnelProviders.CloudflareQuick">Cloudflare Quick Tunnel</SelectItem>
+                                    <SelectItem Value="@PublicCallbackTunnelProviders.DevTunnels">Microsoft Dev Tunnels</SelectItem>
+                                </Select>
+                            </Field>
+                            <Field>
+                                <FieldLabel>目前公開網址</FieldLabel>
+                                <TextInput Value="@settings.PublicCallback.GetConfiguredBaseUrl()" Disabled />
+                                <div class="text-muted mt-1">Tunnel 啟動後會自動更新；暫時 Tunnel 重啟後網址可能變更，需重新貼回金流後台。</div>
+                            </Field>
+                            <div class="mb-3">
+                                <div><strong>綠界 Notify URL：</strong>@BuildNotifyUrl("ecpay")</div>
+                                <div><strong>藍新 Notify URL：</strong>@BuildNotifyUrl("newebpay")</div>
+                            </div>
+                            <div class="d-flex flex-wrap gap-2">
+                                <a class="btn btn-outline-secondary btn-sm" href="https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/trycloudflare/" target="_blank" rel="noopener noreferrer">Cloudflare Quick Tunnel 文件</a>
+                                <a class="btn btn-outline-secondary btn-sm" href="https://developers.cloudflare.com/tunnel/setup/" target="_blank" rel="noopener noreferrer">Cloudflare Named Tunnel 文件</a>
+                                <a class="btn btn-outline-secondary btn-sm" href="https://learn.microsoft.com/azure/developer/dev-tunnels/get-started" target="_blank" rel="noopener noreferrer">Microsoft Dev Tunnels 文件</a>
+                            </div>
+                        </CardBody>
+                    </Card>
+                </Column>
+            </Row>
+
+            <Row Margin="Margin.Is3.FromTop">
+                <Column ColumnSize="ColumnSize.Is12">
+                    <Card>
                         <CardHeader><CardTitle>SMTP 寄信設定</CardTitle></CardHeader>
                         <CardBody>
                             <Alert Color="@(settings.MailDelivery.HasConfiguration ? Color.Success : Color.Warning)" Visible>
@@ -209,6 +249,16 @@
 
 @code {
     private LotterySystemSettings? settings;
+
+    private bool HasCustomDomain => !string.IsNullOrWhiteSpace(settings?.PublicCallback.CustomDomain);
+
+    private string BuildNotifyUrl(string provider)
+    {
+        var baseUrl = settings?.PublicCallback.GetConfiguredBaseUrl();
+        return string.IsNullOrWhiteSpace(baseUrl)
+            ? "尚未取得公開網址"
+            : $"{baseUrl.TrimEnd('/')}/api/payments/{provider}/notify";
+    }
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/EasyLotteryWasm/Pages/Config/PaymentSettings.razor
+++ b/src/EasyLotteryWasm/Pages/Config/PaymentSettings.razor
@@ -3,6 +3,7 @@
 
 @inject SystemSettingsService SystemSettingsService
 @inject IMessageService MessageService
+@inject TunnelRuntimeClient TunnelRuntimeClient
 
 <PageTitle>支付配置</PageTitle>
 
@@ -56,6 +57,17 @@
                                 <TextInput Value="@settings.PublicCallback.GetConfiguredBaseUrl()" Disabled />
                                 <div class="text-muted mt-1">Tunnel 啟動後會自動更新；暫時 Tunnel 重啟後網址可能變更，需重新貼回金流後台。</div>
                             </Field>
+                            @if (!HasCustomDomain)
+                            {
+                                <Alert Color="@(tunnelStatus.State == "running" ? Color.Success : Color.Warning)" Visible>
+                                    <AlertMessage>@TunnelStatusMessage</AlertMessage>
+                                    <AlertDescription>Cloudflare Quick Tunnel 與 Dev Tunnels 都是暫時入口；停止或重啟後請重新確認 Notify URL。</AlertDescription>
+                                </Alert>
+                                <div class="d-flex flex-wrap gap-2 mb-3">
+                                    <Button Color="Color.Primary" Clicked="@StartTunnelAsync" Disabled="@isStartingTunnel">@(isStartingTunnel ? "建立 Tunnel 中…" : "啟動 Tunnel")</Button>
+                                    <Button Color="Color.Secondary" Clicked="@StopTunnelAsync" Disabled="@(isStartingTunnel || tunnelStatus.State != "running")">停止 Tunnel</Button>
+                                </div>
+                            }
                             <div class="mb-3">
                                 <div><strong>綠界 Notify URL：</strong>@BuildNotifyUrl("ecpay")</div>
                                 <div><strong>藍新 Notify URL：</strong>@BuildNotifyUrl("newebpay")</div>
@@ -249,6 +261,8 @@
 
 @code {
     private LotterySystemSettings? settings;
+    private TunnelRuntimeStatus tunnelStatus = new();
+    private bool isStartingTunnel;
 
     private bool HasCustomDomain => !string.IsNullOrWhiteSpace(settings?.PublicCallback.CustomDomain);
 
@@ -260,9 +274,25 @@
             : $"{baseUrl.TrimEnd('/')}/api/payments/{provider}/notify";
     }
 
+    private string TunnelStatusMessage => tunnelStatus.State switch
+    {
+        "running" => $"{tunnelStatus.Provider} 已啟動。",
+        "starting" => "Tunnel 啟動中，等待公開網址。",
+        "failed" => string.IsNullOrWhiteSpace(tunnelStatus.Error) ? "Tunnel 啟動失敗。" : tunnelStatus.Error,
+        _ => "尚未啟動 Tunnel。"
+    };
+
     protected override async Task OnInitializedAsync()
     {
         settings = await SystemSettingsService.GetSettingsAsync();
+        try
+        {
+            tunnelStatus = await TunnelRuntimeClient.GetStatusAsync();
+        }
+        catch
+        {
+            tunnelStatus = new TunnelRuntimeStatus { State = "unavailable", Error = "目前不是由 EasyLotteryWeb Host 提供服務。" };
+        }
     }
 
     private async Task SaveAsync()
@@ -275,5 +305,56 @@
         await SystemSettingsService.SaveSettingsAsync(settings);
         settings = await SystemSettingsService.GetSettingsAsync();
         await MessageService.Success("已儲存支付配置。");
+    }
+
+    private async Task StartTunnelAsync()
+    {
+        if (settings is null || HasCustomDomain)
+        {
+            return;
+        }
+
+        isStartingTunnel = true;
+        try
+        {
+            tunnelStatus = await TunnelRuntimeClient.StartAsync(settings.PublicCallback.TunnelProvider);
+            if (tunnelStatus.State == "running" && !string.IsNullOrWhiteSpace(tunnelStatus.PublicBaseUrl))
+            {
+                settings.PublicCallback.ActivePublicBaseUrl = tunnelStatus.PublicBaseUrl;
+                await SystemSettingsService.SaveSettingsAsync(settings);
+                await MessageService.Success("Tunnel 已啟動，Notify URL 已更新。");
+            }
+            else
+            {
+                await MessageService.Error(TunnelStatusMessage);
+            }
+        }
+        catch (Exception ex)
+        {
+            await MessageService.Error($"無法啟動 Tunnel：{ex.Message}");
+        }
+        finally
+        {
+            isStartingTunnel = false;
+        }
+    }
+
+    private async Task StopTunnelAsync()
+    {
+        try
+        {
+            await TunnelRuntimeClient.StopAsync();
+            tunnelStatus = new TunnelRuntimeStatus();
+            if (settings is not null)
+            {
+                settings.PublicCallback.ActivePublicBaseUrl = "";
+                await SystemSettingsService.SaveSettingsAsync(settings);
+            }
+            await MessageService.Success("Tunnel 已停止，公開網址已清除。");
+        }
+        catch (Exception ex)
+        {
+            await MessageService.Error($"無法停止 Tunnel：{ex.Message}");
+        }
     }
 }

--- a/src/EasyLotteryWasm/Program.cs
+++ b/src/EasyLotteryWasm/Program.cs
@@ -29,7 +29,7 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddDistributedMemoryCache();
 
-var apiBaseUrl = builder.Configuration["Api:BaseUrl"] ?? "http://localhost:5297/";
+var apiBaseUrl = builder.Configuration["Api:BaseUrl"] ?? builder.HostEnvironment.BaseAddress;
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(apiBaseUrl) });
 
 builder.Services.AddScoped<IEasyLotteryConfigStore, YamlEasyLotteryConfigStore>();
@@ -42,6 +42,7 @@ builder.Services.AddScoped<ResultNotificationService>();
 builder.Services.AddScoped<VisualStyleService>();
 builder.Services.AddScoped<OvertimeFeedClient>();
 builder.Services.AddScoped<OvertimeRealtimeClient>();
+builder.Services.AddScoped<TunnelRuntimeClient>();
 builder.Services.AddScoped<EasyLotteryAuditService>();
 
 // 添加服務

--- a/src/EasyLotteryWasm/Services/TunnelRuntimeClient.cs
+++ b/src/EasyLotteryWasm/Services/TunnelRuntimeClient.cs
@@ -1,0 +1,39 @@
+using System.Net.Http.Json;
+
+namespace EasyLotteryWasm.Services;
+
+public sealed class TunnelRuntimeClient
+{
+    private readonly HttpClient _httpClient;
+
+    public TunnelRuntimeClient(HttpClient httpClient) => _httpClient = httpClient;
+
+    public async Task<TunnelRuntimeStatus> GetStatusAsync(CancellationToken cancellationToken = default) =>
+        await _httpClient.GetFromJsonAsync<TunnelRuntimeStatus>("api/tunnel", cancellationToken) ?? new TunnelRuntimeStatus();
+
+    public async Task<TunnelRuntimeStatus> StartAsync(string provider, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.PostAsJsonAsync("api/tunnel/start", new TunnelStartRequest { Provider = provider }, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<TunnelRuntimeStatus>(cancellationToken: cancellationToken) ?? new TunnelRuntimeStatus();
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.DeleteAsync("api/tunnel", cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
+}
+
+public sealed class TunnelRuntimeStatus
+{
+    public string Provider { get; set; } = "";
+    public string State { get; set; } = "stopped";
+    public string PublicBaseUrl { get; set; } = "";
+    public string Error { get; set; } = "";
+}
+
+public sealed class TunnelStartRequest
+{
+    public string Provider { get; set; } = "";
+}

--- a/src/EasyLotteryWasm/Services/YamlEasyLotteryConfigStore.cs
+++ b/src/EasyLotteryWasm/Services/YamlEasyLotteryConfigStore.cs
@@ -128,6 +128,7 @@ namespace EasyLotteryWasm.Services
             document.SystemSettings ??= new LotterySystemSettings();
             document.SystemSettings.YouTube ??= new YouTubeApiSettings();
             document.SystemSettings.DonationIntegration ??= new DonationIntegrationSettings();
+            document.SystemSettings.PublicCallback ??= new PublicCallbackSettings();
             document.SystemSettings.MailDelivery ??= new MailDeliverySettings();
             document.SystemSettings.DonationIntegration.Ecpay ??= new DonationProviderSettings { Name = "綠界" };
             document.SystemSettings.DonationIntegration.NewebPay ??= new DonationProviderSettings { Name = "藍新" };
@@ -156,6 +157,9 @@ namespace EasyLotteryWasm.Services
             document.OvertimeOverlay.TextAnimationKey = OvertimeTextAnimationPreset.NormalizeKey(document.OvertimeOverlay.TextAnimationKey);
             document.OvertimeOverlay.MaxVisibleItems = Math.Max(1, document.OvertimeOverlay.MaxVisibleItems);
             document.SystemSettings.ResultNotificationEmail = document.SystemSettings.ResultNotificationEmail.Trim();
+            document.SystemSettings.PublicCallback.CustomDomain = NormalizePublicHttpsUrl(document.SystemSettings.PublicCallback.CustomDomain);
+            document.SystemSettings.PublicCallback.ActivePublicBaseUrl = NormalizePublicHttpsUrl(document.SystemSettings.PublicCallback.ActivePublicBaseUrl);
+            document.SystemSettings.PublicCallback.TunnelProvider = PublicCallbackTunnelProviders.Normalize(document.SystemSettings.PublicCallback.TunnelProvider);
             document.SystemSettings.DonationIntegration.Ecpay.Name = string.IsNullOrWhiteSpace(document.SystemSettings.DonationIntegration.Ecpay.Name) ? "綠界" : document.SystemSettings.DonationIntegration.Ecpay.Name.Trim();
             document.SystemSettings.DonationIntegration.NewebPay.Name = string.IsNullOrWhiteSpace(document.SystemSettings.DonationIntegration.NewebPay.Name) ? "藍新" : document.SystemSettings.DonationIntegration.NewebPay.Name.Trim();
             document.SystemSettings.DonationIntegration.OenTw.Name = string.IsNullOrWhiteSpace(document.SystemSettings.DonationIntegration.OenTw.Name) ? "oen.tw" : document.SystemSettings.DonationIntegration.OenTw.Name.Trim();
@@ -229,6 +233,23 @@ namespace EasyLotteryWasm.Services
             document.SystemSettings.ResultNotificationEmail = document.SystemSettings.ResultNotificationEmail.Trim();
 
             return document;
+        }
+
+        private static string NormalizePublicHttpsUrl(string? value)
+        {
+            var trimmed = value?.Trim() ?? "";
+            if (string.IsNullOrWhiteSpace(trimmed))
+            {
+                return "";
+            }
+
+            if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var uri) ||
+                !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+            {
+                return "";
+            }
+
+            return uri.GetLeftPart(UriPartial.Authority).TrimEnd('/');
         }
 
         private static EasyLotteryConfigDocument CloneDocument(EasyLotteryConfigDocument document)

--- a/src/EasyLotteryWeb/Program.cs
+++ b/src/EasyLotteryWeb/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.SignalR;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddSignalR();
+builder.Services.AddSingleton<TunnelRuntimeService>();
 
 var storageDirectory = builder.Configuration["Storage:Directory"]
     ?? Path.Combine(builder.Environment.ContentRootPath, "App_Data");
@@ -82,6 +83,15 @@ app.MapPost("/api/result-notification", async (ResultNotificationRequest request
 });
 
 app.MapHub<OvertimeHub>("/hubs/overtime");
+
+app.MapGet("/api/tunnel", (TunnelRuntimeService tunnelRuntime) => Results.Ok(tunnelRuntime.GetStatus()));
+app.MapPost("/api/tunnel/start", async (TunnelStartRequest request, TunnelRuntimeService tunnelRuntime, CancellationToken cancellationToken) =>
+    Results.Ok(await tunnelRuntime.StartAsync(request.Provider, cancellationToken)));
+app.MapDelete("/api/tunnel", async (TunnelRuntimeService tunnelRuntime, CancellationToken cancellationToken) =>
+{
+    await tunnelRuntime.StopAsync(cancellationToken);
+    return Results.NoContent();
+});
 
 app.MapFallbackToFile("index.html");
 

--- a/src/EasyLotteryWeb/TunnelRuntimeService.cs
+++ b/src/EasyLotteryWeb/TunnelRuntimeService.cs
@@ -1,0 +1,125 @@
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+
+public sealed class TunnelRuntimeService : IAsyncDisposable
+{
+    private static readonly Regex PublicUrlPattern = new(@"https://[^\s""']+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private readonly IConfiguration _configuration;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private Process? _process;
+    private TunnelRuntimeStatus _status = new();
+
+    public TunnelRuntimeService(IConfiguration configuration) => _configuration = configuration;
+
+    public TunnelRuntimeStatus GetStatus() => _status;
+
+    public async Task<TunnelRuntimeStatus> StartAsync(string provider, CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            await StopInternalAsync();
+            var port = _configuration.GetValue<int?>("Tunnel:LocalPort") ?? 18930;
+            var normalizedProvider = provider?.Trim().ToLowerInvariant();
+            var (command, arguments) = normalizedProvider switch
+            {
+                "cloudflare-quick" => (_configuration["Tunnel:CloudflareCommand"] ?? "cloudflared", $"tunnel --url http://127.0.0.1:{port}"),
+                "dev-tunnels" => (_configuration["Tunnel:DevTunnelsCommand"] ?? "devtunnel", $"host -p {port} --allow-anonymous"),
+                _ => throw new InvalidOperationException("Unsupported tunnel provider.")
+            };
+
+            var startInfo = new ProcessStartInfo(command, arguments)
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+            var process = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
+            var urlReady = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            void ReadOutput(object? _, DataReceivedEventArgs eventArgs)
+            {
+                var match = PublicUrlPattern.Match(eventArgs.Data ?? string.Empty);
+                if (match.Success)
+                {
+                    urlReady.TrySetResult(match.Value.TrimEnd('/', '.', ','));
+                }
+            }
+
+            process.OutputDataReceived += ReadOutput;
+            process.ErrorDataReceived += ReadOutput;
+            if (!process.Start())
+            {
+                throw new InvalidOperationException($"Unable to start {command}.");
+            }
+
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+            _process = process;
+            _status = new TunnelRuntimeStatus { Provider = normalizedProvider, State = "starting" };
+
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeout.CancelAfter(TimeSpan.FromSeconds(20));
+            try
+            {
+                var publicUrl = await urlReady.Task.WaitAsync(timeout.Token);
+                _status = new TunnelRuntimeStatus { Provider = normalizedProvider, State = "running", PublicBaseUrl = publicUrl };
+            }
+            catch (OperationCanceledException)
+            {
+                _status = new TunnelRuntimeStatus
+                {
+                    Provider = normalizedProvider,
+                    State = process.HasExited ? "failed" : "starting",
+                    Error = process.HasExited ? $"{command} exited before returning a public URL." : "Tunnel is starting; check its CLI login and network access."
+                };
+            }
+
+            return _status;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _status = new TunnelRuntimeStatus { Provider = provider ?? "", State = "failed", Error = ex.Message };
+            return _status;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try { await StopInternalAsync(); }
+        finally { _gate.Release(); }
+    }
+
+    private Task StopInternalAsync()
+    {
+        if (_process is { HasExited: false })
+        {
+            _process.Kill(entireProcessTree: true);
+            _process.WaitForExit(3000);
+        }
+        _process?.Dispose();
+        _process = null;
+        _status = new TunnelRuntimeStatus();
+        return Task.CompletedTask;
+    }
+
+    public async ValueTask DisposeAsync() => await StopAsync(CancellationToken.None);
+}
+
+public sealed class TunnelRuntimeStatus
+{
+    public string Provider { get; init; } = "";
+    public string State { get; init; } = "stopped";
+    public string PublicBaseUrl { get; init; } = "";
+    public string Error { get; init; } = "";
+}
+
+public sealed class TunnelStartRequest
+{
+    public string Provider { get; set; } = "";
+}


### PR DESCRIPTION
## Summary
- Persist public callback domain and tunnel preference in YAML.
- Provide start/stop controls for Cloudflare Quick Tunnel and Microsoft Dev Tunnels when no custom HTTPS domain is configured.
- Capture the temporary public URL, save it to configuration, and display ECPay/NewebPay Notify URL candidates.
- Add links to the corresponding tunnel documentation.

## Notes
- A custom HTTPS domain always takes precedence.
- Cloudflare Quick Tunnels and Dev Tunnels are temporary development/test entry points; their URL can change after a restart.
- Dev Tunnels requires a prior `devtunnel user login`; the host must have the selected tunnel CLI installed (or configure its command via `Tunnel:CloudflareCommand` / `Tunnel:DevTunnelsCommand`).
- This PR prepares public reachability only. Provider-specific callback endpoints, signature verification, order persistence, and donor-message ingestion remain follow-up work for #83.

## Validation
- `dotnet test EasyLottery.generated.sln --no-restore` (98 passed)
- `dotnet build EasyLottery.generated.sln --no-restore`