### PR TITLE
chore: unify API and WASM debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 bin/
 obj/
 TestResults/
-.vscode
+.vscode/*
+!.vscode/
+!.vscode/launch.json
+!.vscode/tasks.json
 .vs
 src/EasyLottery/.pnpm-store
 src/EasyLottery/node_modules

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "EasyLottery API + WASM (Local Debug)",
+      "type": "blazorwasm",
+      "request": "launch",
+      "hosted": true,
+      "preLaunchTask": "dotnet: build solution",
+      "program": "${workspaceFolder}/src/EasyLotteryAPI/bin/Debug/net10.0/EasyLotteryApi.dll",
+      "cwd": "${workspaceFolder}/src/EasyLotteryAPI",
+      "url": "http://localhost:18930",
+      "browser": "chrome"
+    },
+    {
+      "name": "EasyLottery Docker Compose (Browser Preview)",
+      "type": "pwa-chrome",
+      "request": "launch",
+      "url": "http://localhost:18930",
+      "webRoot": "${workspaceFolder}/src/EasyLotteryWasm",
+      "preLaunchTask": "compose: up api",
+      "postDebugTask": "compose: down api"
+    }
+  ],
+  "compounds": []
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,77 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "dotnet: restore",
+      "type": "shell",
+      "command": "dotnet",
+      "args": [
+        "restore",
+        "EasyLottery.generated.sln"
+      ],
+      "group": "build",
+      "problemMatcher": []
+    },
+    {
+      "label": "dotnet: build solution",
+      "type": "shell",
+      "command": "dotnet",
+      "args": [
+        "build",
+        "EasyLottery.generated.sln",
+        "-c",
+        "Debug"
+      ],
+      "group": "build",
+      "dependsOn": "dotnet: restore",
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "dotnet: run api",
+      "type": "shell",
+      "command": "dotnet",
+      "args": [
+        "run",
+        "--project",
+        "src/EasyLotteryAPI/EasyLotteryApi.csproj",
+        "--launch-profile",
+        "EasyLotteryAPI"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "dotnet: stop api port",
+      "type": "shell",
+      "command": "bash",
+      "args": [
+        "-lc",
+        "pids=$(lsof -tiTCP:5297 -sTCP:LISTEN); if [ -n \"$pids\" ]; then kill $pids; fi"
+      ],
+      "problemMatcher": []
+    },
+    {
+      "label": "compose: up api",
+      "type": "shell",
+      "command": "docker",
+      "args": [
+        "compose",
+        "up",
+        "-d",
+        "--build",
+        "api"
+      ],
+      "problemMatcher": []
+    },
+    {
+      "label": "compose: down api",
+      "type": "shell",
+      "command": "docker",
+      "args": [
+        "compose",
+        "down",
+        "--remove-orphans"
+      ],
+      "problemMatcher": []
+    }
+  ]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  web:
+  api:
     build:
       context: .
       dockerfile: src/EasyLotteryAPI/Dockerfile


### PR DESCRIPTION
## Summary

- Use one Docker Compose `api` service, which hosts both EasyLotteryAPI and the WASM assets in a single image.
- Add a VS Code local compound launch that starts the API debugger and WASM browser debugger together.
- Keep a Docker Compose browser-debug launch for container runs.
- Track only the shared VS Code `launch.json` and `tasks.json`; personal editor settings remain ignored.

## Validation

- `jq empty .vscode/launch.json .vscode/tasks.json`
- `dotnet build EasyLottery.generated.sln --no-restore`

Docker CLI is unavailable in this environment, so `docker compose config` must be verified by CI or a Docker-enabled workstation.