### PR TITLE
feat: add layout image settings

### DIFF
--- a/src/EasyLotteryDomain/Models/Config/VisualStyleSettings.cs
+++ b/src/EasyLotteryDomain/Models/Config/VisualStyleSettings.cs
@@ -3,5 +3,11 @@ namespace EasyLotteryDomain.Models.Config
     public sealed class VisualStyleSettings
     {
         public string ActiveThemeKey { get; set; } = "dashboard-console";
+
+        /// <summary>Optional HTTPS image displayed behind the application shell.</summary>
+        public string BackgroundImageUrl { get; set; } = "";
+
+        /// <summary>Optional HTTPS image displayed in the application banner.</summary>
+        public string BannerImageUrl { get; set; } = "";
     }
 }

--- a/src/EasyLotteryWasm/Layout/NavMenu.razor
+++ b/src/EasyLotteryWasm/Layout/NavMenu.razor
@@ -73,6 +73,11 @@
                 </NavLink>
             </div>
             <div class="nav-item px-3 nav-sub-item">
+                <NavLink class="nav-link" href="system/visual-styles">
+                    版面視覺
+                </NavLink>
+            </div>
+            <div class="nav-item px-3 nav-sub-item">
                 <NavLink class="nav-link" href="system/sound-cues">
                     音效模板
                 </NavLink>

--- a/src/EasyLotteryWasm/Pages/Config/VisualStyles.razor
+++ b/src/EasyLotteryWasm/Pages/Config/VisualStyles.razor
@@ -23,6 +23,49 @@
     </CardBody>
 </Card>
 
+<Card class="mb-4">
+    <CardHeader><CardTitle>版面圖片</CardTitle></CardHeader>
+    <CardBody>
+        <CardText>
+            背景與 Banner 會套用至所有一般系統頁面。僅接受 HTTPS 圖片網址；圖片無法載入時會自動保留系統預設樣式。
+        </CardText>
+        <div class="row g-4">
+            <div class="col-12 col-lg-6">
+                <Field>
+                    <FieldLabel>背景圖片 URL</FieldLabel>
+                    <TextInput @bind-Value="backgroundImageUrl" Placeholder="https://example.com/background.jpg" />
+                </Field>
+                @if (!string.IsNullOrWhiteSpace(backgroundImageUrl))
+                {
+                    <img class="visual-image-preview" src="@backgroundImageUrl" alt="背景圖片預覽" @onerror="() => backgroundPreviewFailed = true" />
+                    @if (backgroundPreviewFailed)
+                    {
+                        <small class="text-warning">此圖片無法載入；儲存後會使用預設背景。</small>
+                    }
+                }
+            </div>
+            <div class="col-12 col-lg-6">
+                <Field>
+                    <FieldLabel>Banner 圖片 URL</FieldLabel>
+                    <TextInput @bind-Value="bannerImageUrl" Placeholder="https://example.com/banner.jpg" />
+                </Field>
+                @if (!string.IsNullOrWhiteSpace(bannerImageUrl))
+                {
+                    <img class="visual-image-preview visual-banner-preview" src="@bannerImageUrl" alt="Banner 圖片預覽" @onerror="() => bannerPreviewFailed = true" />
+                    @if (bannerPreviewFailed)
+                    {
+                        <small class="text-warning">此圖片無法載入；儲存後會使用預設 Banner。</small>
+                    }
+                }
+            </div>
+        </div>
+        <div class="d-flex flex-wrap gap-2 mt-4">
+            <Button Color="Color.Primary" Clicked="SaveImagesAsync">儲存圖片設定</Button>
+            <Button Color="Color.Secondary" Clicked="ClearImagesAsync">清除並還原預設值</Button>
+        </div>
+    </CardBody>
+</Card>
+
 @if (isLoading)
 {
     <p>載入中…</p>
@@ -75,13 +118,40 @@ else
     private string activeThemeKey = VisualStyleCatalog.DefaultThemeKey;
     private VisualStylePreset? activePreset;
     private bool isLoading = true;
+    private string backgroundImageUrl = "";
+    private string bannerImageUrl = "";
+    private bool backgroundPreviewFailed;
+    private bool bannerPreviewFailed;
 
     protected override async Task OnInitializedAsync()
     {
         presets = VisualStyleService.Presets;
         activeThemeKey = await VisualStyleService.GetActiveThemeKeyAsync();
         activePreset = VisualStyleService.GetPreset(activeThemeKey);
+        var settings = await VisualStyleService.GetSettingsAsync();
+        backgroundImageUrl = settings.BackgroundImageUrl;
+        bannerImageUrl = settings.BannerImageUrl;
         isLoading = false;
+    }
+
+    private async Task SaveImagesAsync()
+    {
+        backgroundPreviewFailed = false;
+        bannerPreviewFailed = false;
+        var settings = await VisualStyleService.SaveImagesAsync(backgroundImageUrl, bannerImageUrl);
+        backgroundImageUrl = settings.BackgroundImageUrl;
+        bannerImageUrl = settings.BannerImageUrl;
+        await MessageService.Success("版面圖片設定已儲存。");
+    }
+
+    private async Task ClearImagesAsync()
+    {
+        backgroundPreviewFailed = false;
+        bannerPreviewFailed = false;
+        var settings = await VisualStyleService.SaveImagesAsync("", "");
+        backgroundImageUrl = settings.BackgroundImageUrl;
+        bannerImageUrl = settings.BannerImageUrl;
+        await MessageService.Success("已還原預設背景與 Banner。");
     }
 
     private async Task ApplyPresetAsync(string themeKey)

--- a/src/EasyLotteryWasm/Services/VisualStyleService.cs
+++ b/src/EasyLotteryWasm/Services/VisualStyleService.cs
@@ -35,7 +35,7 @@ namespace EasyLotteryWasm.Services
             var document = await _configStore.LoadAsync(cancellationToken);
             var preset = VisualStyleCatalog.GetByKey(document.VisualStyle?.ActiveThemeKey);
             _activeThemeKey = preset.Key;
-            await ApplyThemeAsync(preset.Key, cancellationToken);
+            await ApplyThemeAsync(preset.Key, document.VisualStyle, cancellationToken);
             _initialized = true;
         }
 
@@ -61,15 +61,40 @@ namespace EasyLotteryWasm.Services
             document.VisualStyle.ActiveThemeKey = normalized;
             await _configStore.SaveAsync(document, cancellationToken);
             _activeThemeKey = normalized;
-            await ApplyThemeAsync(normalized, cancellationToken);
+            await ApplyThemeAsync(normalized, document.VisualStyle, cancellationToken);
             return VisualStyleCatalog.GetByKey(normalized);
         }
 
-        private async Task ApplyThemeAsync(string key, CancellationToken cancellationToken)
+        public async Task<VisualStyleSettings> GetSettingsAsync(CancellationToken cancellationToken = default)
+        {
+            var document = await _configStore.LoadAsync(cancellationToken);
+            return document.VisualStyle ?? new VisualStyleSettings();
+        }
+
+        public async Task<VisualStyleSettings> SaveImagesAsync(
+            string? backgroundImageUrl,
+            string? bannerImageUrl,
+            CancellationToken cancellationToken = default)
+        {
+            var document = await _configStore.LoadAsync(cancellationToken);
+            document.VisualStyle ??= new VisualStyleSettings();
+            document.VisualStyle.BackgroundImageUrl = backgroundImageUrl ?? "";
+            document.VisualStyle.BannerImageUrl = bannerImageUrl ?? "";
+            await _configStore.SaveAsync(document, cancellationToken);
+            await ApplyThemeAsync(document.VisualStyle.ActiveThemeKey, document.VisualStyle, cancellationToken);
+            return document.VisualStyle;
+        }
+
+        private async Task ApplyThemeAsync(string key, VisualStyleSettings? settings, CancellationToken cancellationToken)
         {
             try
             {
                 await _jsRuntime.InvokeVoidAsync("easyLotteryTheme.apply", cancellationToken, key);
+                await _jsRuntime.InvokeVoidAsync(
+                    "easyLotteryTheme.applyImages",
+                    cancellationToken,
+                    settings?.BackgroundImageUrl ?? "",
+                    settings?.BannerImageUrl ?? "");
             }
             catch (JSException ex)
             {

--- a/src/EasyLotteryWasm/Services/YamlEasyLotteryConfigStore.cs
+++ b/src/EasyLotteryWasm/Services/YamlEasyLotteryConfigStore.cs
@@ -142,6 +142,8 @@ namespace EasyLotteryWasm.Services
             document.DrawingRules ??= new DrawingRuleSettings();
             document.VisualStyle ??= new VisualStyleSettings();
             document.VisualStyle.ActiveThemeKey = VisualStyleCatalog.NormalizeKey(document.VisualStyle.ActiveThemeKey);
+            document.VisualStyle.BackgroundImageUrl = NormalizeExternalHttpsUrl(document.VisualStyle.BackgroundImageUrl);
+            document.VisualStyle.BannerImageUrl = NormalizeExternalHttpsUrl(document.VisualStyle.BannerImageUrl);
             document.SoundCue ??= new SoundCueSettings();
             document.SoundCue.ActivePresetKey = SoundCuePreset.NormalizeKey(document.SoundCue.ActivePresetKey);
             document.OvertimeOverlay ??= new OvertimeOverlaySettings();

--- a/src/EasyLotteryWasm/wwwroot/css/app.css
+++ b/src/EasyLotteryWasm/wwwroot/css/app.css
@@ -187,10 +187,14 @@ html {
 body {
     font-family: 'Inter', 'Segoe UI', 'Helvetica Neue', Helvetica, Arial, sans-serif;
     color: var(--el-text);
-    background:
+    background-image:
+        var(--el-custom-page-image, none),
         radial-gradient(circle at top left, rgba(37, 99, 235, 0.08), transparent 30%),
         radial-gradient(circle at bottom right, rgba(124, 58, 237, 0.07), transparent 24%),
         linear-gradient(180deg, var(--el-page-bg) 0%, var(--el-page-bg-alt) 100%);
+    background-position: center, center, center, center;
+    background-size: cover, auto, auto, auto;
+    background-attachment: fixed;
     position: relative;
     overflow-x: hidden;
 }
@@ -263,7 +267,7 @@ a, .btn-link {
 
 .app-top-banner {
     min-height: 8.5rem;
-    background-image: var(--el-topbar-overlay), var(--el-topbar-image);
+    background-image: var(--el-topbar-overlay), var(--el-custom-banner-image, var(--el-topbar-image));
     background-position: center;
     background-size: cover;
     border-bottom: 1px solid var(--el-border);
@@ -324,6 +328,23 @@ a, .btn-link {
     overflow: hidden;
     border-radius: 1.25rem;
     transition: transform 0.22s ease, box-shadow 0.22s ease, border-color 0.22s ease;
+}
+
+.visual-image-preview {
+    display: block;
+    width: 100%;
+    min-height: 9rem;
+    max-height: 14rem;
+    margin-top: 0.75rem;
+    border: 1px solid var(--el-border);
+    border-radius: 0.75rem;
+    background: var(--el-surface-soft);
+    object-fit: cover;
+    object-position: center;
+}
+
+.visual-banner-preview {
+    aspect-ratio: 3 / 1;
 }
 
 .visual-style-card:hover,

--- a/src/EasyLotteryWasm/wwwroot/index.html
+++ b/src/EasyLotteryWasm/wwwroot/index.html
@@ -328,6 +328,26 @@
                 }
             }
 
+            function isHttpsUrl(value) {
+                try {
+                    return new URL(value).protocol === "https:";
+                } catch {
+                    return false;
+                }
+            }
+
+            function applyImage(variableName, value) {
+                root.style.removeProperty(variableName);
+                if (!isHttpsUrl(value)) {
+                    return;
+                }
+
+                const image = new Image();
+                image.onload = () => root.style.setProperty(variableName, `url("${value.replaceAll('"', '%22')}")`);
+                image.onerror = () => root.style.removeProperty(variableName);
+                image.src = value;
+            }
+
             let storedKey = "dashboard-console";
             try {
                 storedKey = window.localStorage.getItem(storageKey) || storedKey;
@@ -342,6 +362,10 @@
 
             window.easyLotteryTheme = {
                 apply: (key) => applyThemeKey(key),
+                applyImages: (backgroundImageUrl, bannerImageUrl) => {
+                    applyImage("--el-custom-page-image", backgroundImageUrl);
+                    applyImage("--el-custom-banner-image", bannerImageUrl);
+                },
                 getStoredKey: () => {
                     try {
                         return window.localStorage.getItem(storageKey) || "";


### PR DESCRIPTION
Closes #88

## Summary

- add shared YAML settings for global background and banner image URLs
- provide a System Settings UI with previews, save, and reset-to-default actions
- safely apply only HTTPS images after browser load succeeds, falling back to existing visual styling on errors
- expose the visual settings page from the navigation menu

## Validation

- `dotnet test EasyLottery.generated.sln --no-restore`
