### PR TITLE
feat: add Donate lottery activities

### DIFF
--- a/src/EasyLotteryAPI/Payments/PaymentCallbackProcessor.cs
+++ b/src/EasyLotteryAPI/Payments/PaymentCallbackProcessor.cs
@@ -1,5 +1,8 @@
 using System.Text.Json;
+using System.Net;
+using System.Net.Mail;
 using EasyLotteryDomain.Models.Config;
+using EasyLotteryDomain.Services;
 using EasyLotteryDomain.Models.Overtime;
 using Microsoft.AspNetCore.SignalR;
 using YamlDotNet.Serialization;
@@ -20,6 +23,10 @@ public sealed class PaymentCallbackProcessor
     private readonly IDeserializer _yaml = new DeserializerBuilder()
         .WithNamingConvention(CamelCaseNamingConvention.Instance)
         .IgnoreUnmatchedProperties()
+        .Build();
+    private readonly ISerializer _yamlSerializer = new SerializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull | DefaultValuesHandling.OmitDefaults)
         .Build();
 
     public PaymentCallbackProcessor(
@@ -81,6 +88,7 @@ public sealed class PaymentCallbackProcessor
             });
             await WriteJsonAsync(_paymentEventsPath, paymentEvents, cancellationToken);
 
+            var donateWins = await ProcessDonateLotteryAsync(notification, cancellationToken);
             var feed = await ReadJsonAsync<List<OvertimeSupportEvent>>(_overtimeFeedPath, cancellationToken) ?? [];
             feed.Add(new OvertimeSupportEvent
             {
@@ -94,7 +102,25 @@ public sealed class PaymentCallbackProcessor
                 OccurredAtUtc = notification.OccurredAtUtc,
                 ExternalId = notification.ExternalId
             });
+            foreach (var win in donateWins)
+            {
+                feed.Add(new OvertimeSupportEvent
+                {
+                    Source = OvertimeSupportSource.ThirdPartyPayment,
+                    SourceLabel = "Donate 抽獎中獎",
+                    DisplayName = win.DonorName,
+                    Message = $"抽中 {win.PrizeName}",
+                    Amount = win.Amount,
+                    AmountDisplay = $"NT${win.Amount:N0}",
+                    Currency = notification.Currency,
+                    AvatarUrl = win.PrizeImageUrl,
+                    Color = "#ffd166",
+                    OccurredAtUtc = win.DrawnAtUtc,
+                    ExternalId = $"{win.PaymentExternalId}:{win.Id}"
+                });
+            }
             await WriteJsonAsync(_overtimeFeedPath, feed, cancellationToken);
+            await SendResultNotificationAsync(donateWins, cancellationToken);
         }
         finally
         {
@@ -103,6 +129,49 @@ public sealed class PaymentCallbackProcessor
 
         await _hub.Clients.All.SendAsync("OvertimeFeedChanged", cancellationToken);
         return PaymentCallbackProcessResult.Success();
+    }
+
+    private async Task<IReadOnlyList<DonateLotteryDrawRecord>> ProcessDonateLotteryAsync(PaymentNotification notification, CancellationToken cancellationToken)
+    {
+        var path = File.Exists(_configPath) ? _configPath : _legacyConfigPath;
+        if (!File.Exists(path)) return [];
+
+        var document = _yaml.Deserialize<EasyLotteryConfigDocument>(await File.ReadAllTextAsync(path, cancellationToken)) ?? new();
+        var result = DonateLotteryEngine.Process(document, notification.ExternalId, notification.DisplayName, notification.Amount, notification.OccurredAtUtc);
+        if (!result.Processed) return [];
+
+        var temporaryPath = $"{_configPath}.{Guid.NewGuid():N}.tmp";
+        await File.WriteAllTextAsync(temporaryPath, _yamlSerializer.Serialize(document), cancellationToken);
+        File.Move(temporaryPath, _configPath, overwrite: true);
+        return result.Wins;
+    }
+
+    private async Task SendResultNotificationAsync(IReadOnlyList<DonateLotteryDrawRecord> wins, CancellationToken cancellationToken)
+    {
+        if (wins.Count == 0) return;
+        try
+        {
+            var path = File.Exists(_configPath) ? _configPath : _legacyConfigPath;
+            if (!File.Exists(path)) return;
+            var document = _yaml.Deserialize<EasyLotteryConfigDocument>(await File.ReadAllTextAsync(path, cancellationToken));
+            var settings = document?.SystemSettings;
+            if (settings is null || string.IsNullOrWhiteSpace(settings.ResultNotificationEmail) || !settings.MailDelivery.HasConfiguration) return;
+            using var message = new MailMessage(new MailAddress(settings.MailDelivery.FromAddress, settings.MailDelivery.FromName), new MailAddress(settings.ResultNotificationEmail))
+            {
+                Subject = "EasyLottery Donate 抽獎結果",
+                Body = string.Join(Environment.NewLine, wins.Select(win => $"{win.DonorName} 贊助 NT${win.Amount:N0}，抽中：{win.PrizeName}"))
+            };
+            using var client = new SmtpClient(settings.MailDelivery.SmtpHost, settings.MailDelivery.SmtpPort)
+            {
+                EnableSsl = settings.MailDelivery.EnableSsl,
+                Credentials = new NetworkCredential(settings.MailDelivery.SmtpUsername, settings.MailDelivery.SmtpPassword)
+            };
+            await client.SendMailAsync(message, cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogWarning(exception, "Unable to send Donate lottery result notification.");
+        }
     }
 
     private async Task<DonationProviderSettings?> LoadSettingsAsync(string providerId, CancellationToken cancellationToken)

--- a/src/EasyLotteryDomain/Models/Config/DonateLotteryActivity.cs
+++ b/src/EasyLotteryDomain/Models/Config/DonateLotteryActivity.cs
@@ -1,0 +1,42 @@
+namespace EasyLotteryDomain.Models.Config;
+
+public enum DonateLotteryActivityType
+{
+    Postcard,
+    Polaroid
+}
+
+public sealed class DonateLotteryActivity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
+    public DonateLotteryActivityType Type { get; set; }
+    public decimal MinimumDonationAmount { get; set; } = 100m;
+    public DateTimeOffset StartsAtUtc { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset EndsAtUtc { get; set; } = DateTimeOffset.UtcNow.AddDays(1);
+    public decimal WinProbability { get; set; } = 1m;
+    public bool IsEnabled { get; set; }
+    public List<DonateLotteryPrize> Prizes { get; set; } = [];
+}
+
+public sealed class DonateLotteryPrize
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
+    public string ImageUrl { get; set; } = "";
+    public int Quantity { get; set; } = 1;
+    public int RemainingQuantity { get; set; } = 1;
+}
+
+public sealed class DonateLotteryDrawRecord
+{
+    public int Id { get; set; }
+    public int ActivityId { get; set; }
+    public string PaymentExternalId { get; set; } = "";
+    public string DonorName { get; set; } = "匿名贊助者";
+    public decimal Amount { get; set; }
+    public int DrawCount { get; set; }
+    public string PrizeName { get; set; } = "";
+    public string PrizeImageUrl { get; set; } = "";
+    public DateTimeOffset DrawnAtUtc { get; set; } = DateTimeOffset.UtcNow;
+}

--- a/src/EasyLotteryDomain/Models/Config/EasyLotteryConfigDocument.cs
+++ b/src/EasyLotteryDomain/Models/Config/EasyLotteryConfigDocument.cs
@@ -20,6 +20,9 @@ namespace EasyLotteryDomain.Models.Config
         public List<DrawingRulePreset> DrawingRulePresets { get; set; } = new();
 
         public DrawingRuleSettings DrawingRules { get; set; } = new();
+        public List<DonateLotteryActivity> DonateLotteryActivities { get; set; } = [];
+        public List<DonateLotteryDrawRecord> DonateLotteryDrawRecords { get; set; } = [];
+        public List<string> ProcessedDonatePaymentIds { get; set; } = [];
         public VisualStyleSettings VisualStyle { get; set; } = new();
         public ObsLayoutSettings ObsLayout { get; set; } = new();
         public SoundCueSettings SoundCue { get; set; } = new();
@@ -287,6 +290,10 @@ namespace EasyLotteryDomain.Models.Config
         public int NextActivityResultId { get; set; } = 1;
 
         public int NextAuditRecordId { get; set; } = 1;
+
+        public int NextDonateLotteryActivityId { get; set; } = 1;
+        public int NextDonateLotteryPrizeId { get; set; } = 1;
+        public int NextDonateLotteryDrawRecordId { get; set; } = 1;
     }
 
     public sealed class DrawingRuleSettings

--- a/src/EasyLotteryDomain/Services/DonateLotteryActivityService.cs
+++ b/src/EasyLotteryDomain/Services/DonateLotteryActivityService.cs
@@ -1,0 +1,50 @@
+using EasyLotteryDomain.Models.Config;
+
+namespace EasyLotteryDomain.Services;
+
+public sealed class DonateLotteryActivityService
+{
+    private readonly IEasyLotteryConfigStore _configStore;
+
+    public DonateLotteryActivityService(IEasyLotteryConfigStore configStore) => _configStore = configStore;
+
+    public async Task<IReadOnlyList<DonateLotteryActivity>> ListAsync(CancellationToken cancellationToken = default)
+    {
+        var document = await _configStore.LoadAsync(cancellationToken);
+        return document.DonateLotteryActivities.OrderByDescending(activity => activity.Id).ToList();
+    }
+
+    public async Task<DonateLotteryActivity> SaveAsync(DonateLotteryActivity activity, CancellationToken cancellationToken = default)
+    {
+        var document = await _configStore.LoadAsync(cancellationToken);
+        activity.Name = activity.Name?.Trim() ?? "";
+        if (string.IsNullOrWhiteSpace(activity.Name)) throw new InvalidOperationException("請輸入活動名稱。");
+        if (activity.MinimumDonationAmount <= 0m) throw new InvalidOperationException("最低贊助金額必須大於 0。");
+        if (activity.EndsAtUtc <= activity.StartsAtUtc) throw new InvalidOperationException("活動結束時間必須晚於開始時間。");
+        activity.WinProbability = Math.Clamp(activity.WinProbability, 0m, 1m);
+        activity.Prizes ??= [];
+        foreach (var prize in activity.Prizes)
+        {
+            prize.Id = prize.Id <= 0 ? document.IdSequence.NextDonateLotteryPrizeId++ : prize.Id;
+            prize.Name = prize.Name?.Trim() ?? "";
+            prize.ImageUrl = prize.ImageUrl?.Trim() ?? "";
+            prize.Quantity = Math.Max(0, prize.Quantity);
+            prize.RemainingQuantity = Math.Clamp(prize.RemainingQuantity, 0, prize.Quantity);
+        }
+
+        if (activity.Id <= 0)
+        {
+            activity.Id = document.IdSequence.NextDonateLotteryActivityId++;
+            document.DonateLotteryActivities.Add(activity);
+        }
+        else
+        {
+            var index = document.DonateLotteryActivities.FindIndex(item => item.Id == activity.Id);
+            if (index < 0) throw new InvalidOperationException("找不到 Donate 活動。");
+            document.DonateLotteryActivities[index] = activity;
+        }
+
+        await _configStore.SaveAsync(document, cancellationToken);
+        return activity;
+    }
+}

--- a/src/EasyLotteryDomain/Services/DonateLotteryEngine.cs
+++ b/src/EasyLotteryDomain/Services/DonateLotteryEngine.cs
@@ -1,0 +1,71 @@
+using EasyLotteryDomain.Models.Config;
+
+namespace EasyLotteryDomain.Services;
+
+public static class DonateLotteryEngine
+{
+    public static DonateLotteryProcessResult Process(
+        EasyLotteryConfigDocument document,
+        string paymentExternalId,
+        string donorName,
+        decimal amount,
+        DateTimeOffset occurredAtUtc,
+        Func<double>? nextRandom = null)
+    {
+        if (string.IsNullOrWhiteSpace(paymentExternalId))
+        {
+            return DonateLotteryProcessResult.Ignored("付款識別碼不可為空白。");
+        }
+
+        if (document.ProcessedDonatePaymentIds.Any(id => string.Equals(id, paymentExternalId, StringComparison.Ordinal)))
+        {
+            return DonateLotteryProcessResult.Ignored("此付款已處理過。");
+        }
+
+        document.ProcessedDonatePaymentIds.Add(paymentExternalId);
+        var results = new List<DonateLotteryDrawRecord>();
+        var random = nextRandom ?? Random.Shared.NextDouble;
+        foreach (var activity in document.DonateLotteryActivities.Where(activity =>
+                     activity.IsEnabled && occurredAtUtc >= activity.StartsAtUtc && occurredAtUtc <= activity.EndsAtUtc))
+        {
+            var drawCount = activity.MinimumDonationAmount <= 0m ? 0 : (int)(amount / activity.MinimumDonationAmount);
+            for (var draw = 0; draw < drawCount; draw++)
+            {
+                if (random() >= (double)Math.Clamp(activity.WinProbability, 0m, 1m))
+                {
+                    continue;
+                }
+
+                var available = activity.Prizes.Where(prize => prize.RemainingQuantity > 0).ToList();
+                if (available.Count == 0)
+                {
+                    break;
+                }
+
+                var prize = available[Math.Min((int)(random() * available.Count), available.Count - 1)];
+                prize.RemainingQuantity--;
+                var record = new DonateLotteryDrawRecord
+                {
+                    Id = document.IdSequence.NextDonateLotteryDrawRecordId++,
+                    ActivityId = activity.Id,
+                    PaymentExternalId = paymentExternalId,
+                    DonorName = string.IsNullOrWhiteSpace(donorName) ? "匿名贊助者" : donorName.Trim(),
+                    Amount = amount,
+                    DrawCount = drawCount,
+                    PrizeName = prize.Name,
+                    PrizeImageUrl = prize.ImageUrl,
+                    DrawnAtUtc = occurredAtUtc
+                };
+                document.DonateLotteryDrawRecords.Add(record);
+                results.Add(record);
+            }
+        }
+
+        return new DonateLotteryProcessResult(true, "", results);
+    }
+}
+
+public sealed record DonateLotteryProcessResult(bool Processed, string Reason, IReadOnlyList<DonateLotteryDrawRecord> Wins)
+{
+    public static DonateLotteryProcessResult Ignored(string reason) => new(false, reason, []);
+}

--- a/src/EasyLotteryWasm/Layout/NavMenu.razor
+++ b/src/EasyLotteryWasm/Layout/NavMenu.razor
@@ -47,6 +47,11 @@
                     加班台
                 </NavLink>
             </div>
+            <div class="nav-item px-3 nav-sub-item">
+                <NavLink class="nav-link" href="donate-activities">
+                    Donate 活動
+                </NavLink>
+            </div>
         }
 
         @* === 3. 系統配置 === *@

--- a/src/EasyLotteryWasm/Pages/DonateActivities.razor
+++ b/src/EasyLotteryWasm/Pages/DonateActivities.razor
@@ -50,7 +50,7 @@
     <tbody>
     @foreach (var activity in activities)
     {
-        <tr><td>@activity.Name <small class="text-muted">@activity.Type</small></td><td>@activity.StartsAtUtc.LocalDateTime:g — @activity.EndsAtUtc.LocalDateTime:g</td><td>NT$@activity.MinimumDonationAmount</td><td>@activity.Prizes.Sum(prize => prize.RemainingQuantity) / @activity.Prizes.Sum(prize => prize.Quantity)</td><td>@(activity.IsEnabled ? "啟用" : "停用")</td><td><Button Color="Color.Secondary" Size="Size.Small" Clicked="() => Edit(activity)">編輯</Button></td></tr>
+        <tr><td>@activity.Name <small class="text-muted">@activity.Type</small></td><td>@activity.StartsAtUtc.LocalDateTime:g — @activity.EndsAtUtc.LocalDateTime:g</td><td>NT$@activity.MinimumDonationAmount</td><td>@activity.Prizes.Sum(prize => prize.RemainingQuantity) / @activity.Prizes.Sum(prize => prize.Quantity)</td><td>@(activity.IsEnabled ? "啟用" : "停用")</td><td class="d-flex gap-2"><Button Color="Color.Secondary" Size="Size.Small" Clicked="() => Edit(activity)">編輯</Button>@if (activity.IsEnabled) { <a class="btn btn-outline-primary btn-sm" href="@($"/obs/donate/{activity.Id}")" target="_blank" rel="noopener noreferrer">開啟 OBS URL</a> } else { <Button Color="Color.Secondary" Size="Size.Small" Disabled>開啟 OBS URL</Button> }</td></tr>
     }
     </tbody>
 </table>

--- a/src/EasyLotteryWasm/Pages/DonateActivities.razor
+++ b/src/EasyLotteryWasm/Pages/DonateActivities.razor
@@ -1,0 +1,74 @@
+@page "/donate-activities"
+@using EasyLotteryDomain.Models.Config
+@using EasyLotteryDomain.Services
+
+@inject DonateLotteryActivityService DonateLotteryActivityService
+@inject IMessageService MessageService
+
+<PageTitle>Donate 活動</PageTitle>
+
+<Card class="mb-4">
+    <CardHeader><CardTitle>Donate 抽獎活動</CardTitle></CardHeader>
+    <CardBody>
+        <CardText>贊助金額每達到最低門檻即可獲得一次抽獎機會。獎項用盡後不會重複抽出。</CardText>
+        <Button Color="Color.Primary" Clicked="CreateAsync">新增活動</Button>
+    </CardBody>
+</Card>
+
+@if (editing is not null)
+{
+    <Card class="mb-4">
+        <CardHeader><CardTitle>@(editing.Id == 0 ? "新增" : "編輯") Donate 活動</CardTitle></CardHeader>
+        <CardBody>
+            <div class="row g-3">
+                <div class="col-md-6"><Field><FieldLabel>活動名稱</FieldLabel><TextInput @bind-Value="editing.Name" /></Field></div>
+                <div class="col-md-3"><Field><FieldLabel>類型</FieldLabel><Select TValue="DonateLotteryActivityType" @bind-SelectedValue="editing.Type"><SelectItem Value="DonateLotteryActivityType.Postcard">明信片</SelectItem><SelectItem Value="DonateLotteryActivityType.Polaroid">拍立得</SelectItem></Select></Field></div>
+                <div class="col-md-3"><Field><FieldLabel>最低贊助金額</FieldLabel><NumericInput TValue="decimal" @bind-Value="editing.MinimumDonationAmount" Min="1" /></Field></div>
+                <div class="col-md-4"><Field><FieldLabel>開始時間（本地時區）</FieldLabel><input class="form-control" type="datetime-local" value="@StartDateText" @onchange="OnStartDateChanged" /></Field></div>
+                <div class="col-md-4"><Field><FieldLabel>結束時間（本地時區）</FieldLabel><input class="form-control" type="datetime-local" value="@EndDateText" @onchange="OnEndDateChanged" /></Field></div>
+                <div class="col-md-2"><Field><FieldLabel>中獎機率</FieldLabel><NumericInput TValue="decimal" @bind-Value="editing.WinProbability" /></Field></div>
+                <div class="col-md-2"><Field><FieldLabel>啟用</FieldLabel><Switch TValue="bool" @bind-Value="editing.IsEnabled" /></Field></div>
+            </div>
+            <h5 class="mt-4">獎項</h5>
+            @foreach (var prize in editing.Prizes)
+            {
+                <div class="row g-2 mb-2" @key="prize">
+                    <div class="col-md-4"><TextInput @bind-Value="prize.Name" Placeholder="獎項名稱" /></div>
+                    <div class="col-md-4"><TextInput @bind-Value="prize.ImageUrl" Placeholder="圖片 URL" /></div>
+                    <div class="col-md-2"><NumericInput TValue="int" @bind-Value="prize.Quantity" Min="0" /></div>
+                    <div class="col-md-2"><Button Color="Color.Danger" Size="Size.Small" Clicked="() => editing.Prizes.Remove(prize)">移除</Button></div>
+                </div>
+            }
+            <Button Color="Color.Secondary" Size="Size.Small" Clicked="AddPrize">新增獎項</Button>
+            <div class="d-flex gap-2 mt-4"><Button Color="Color.Primary" Clicked="SaveAsync">儲存</Button><Button Color="Color.Secondary" Clicked="() => editing = null">取消</Button></div>
+        </CardBody>
+    </Card>
+}
+
+<table class="table align-middle">
+    <thead><tr><th>活動</th><th>期間</th><th>最低贊助</th><th>獎項庫存</th><th>狀態</th><th></th></tr></thead>
+    <tbody>
+    @foreach (var activity in activities)
+    {
+        <tr><td>@activity.Name <small class="text-muted">@activity.Type</small></td><td>@activity.StartsAtUtc.LocalDateTime:g — @activity.EndsAtUtc.LocalDateTime:g</td><td>NT$@activity.MinimumDonationAmount</td><td>@activity.Prizes.Sum(prize => prize.RemainingQuantity) / @activity.Prizes.Sum(prize => prize.Quantity)</td><td>@(activity.IsEnabled ? "啟用" : "停用")</td><td><Button Color="Color.Secondary" Size="Size.Small" Clicked="() => Edit(activity)">編輯</Button></td></tr>
+    }
+    </tbody>
+</table>
+
+@code {
+    private IReadOnlyList<DonateLotteryActivity> activities = [];
+    private DonateLotteryActivity? editing;
+    private string StartDateText => editing?.StartsAtUtc.LocalDateTime.ToString("yyyy-MM-ddTHH:mm") ?? "";
+    private string EndDateText => editing?.EndsAtUtc.LocalDateTime.ToString("yyyy-MM-ddTHH:mm") ?? "";
+
+    protected override async Task OnInitializedAsync() => await ReloadAsync();
+
+    private async Task ReloadAsync() => activities = await DonateLotteryActivityService.ListAsync();
+    private Task CreateAsync() { editing = new DonateLotteryActivity { StartsAtUtc = DateTimeOffset.UtcNow, EndsAtUtc = DateTimeOffset.UtcNow.AddDays(7), WinProbability = 1m, Prizes = [new()] }; return Task.CompletedTask; }
+    private void Edit(DonateLotteryActivity activity) => editing = new DonateLotteryActivity { Id = activity.Id, Name = activity.Name, Type = activity.Type, MinimumDonationAmount = activity.MinimumDonationAmount, StartsAtUtc = activity.StartsAtUtc, EndsAtUtc = activity.EndsAtUtc, WinProbability = activity.WinProbability, IsEnabled = activity.IsEnabled, Prizes = activity.Prizes.Select(prize => new DonateLotteryPrize { Id = prize.Id, Name = prize.Name, ImageUrl = prize.ImageUrl, Quantity = prize.Quantity, RemainingQuantity = prize.RemainingQuantity }).ToList() };
+    private void AddPrize() => editing?.Prizes.Add(new DonateLotteryPrize());
+    private async Task SaveAsync() { if (editing is null) return; try { await DonateLotteryActivityService.SaveAsync(editing); editing = null; await ReloadAsync(); await MessageService.Success("Donate 活動已儲存。"); } catch (Exception exception) { await MessageService.Error(exception.Message); } }
+    private void OnStartDateChanged(ChangeEventArgs args) => SetDate(args.Value?.ToString(), isStart: true);
+    private void OnEndDateChanged(ChangeEventArgs args) => SetDate(args.Value?.ToString(), isStart: false);
+    private void SetDate(string? value, bool isStart) { if (editing is null || !DateTime.TryParse(value, out var date)) return; var instant = new DateTimeOffset(DateTime.SpecifyKind(date, DateTimeKind.Local)).ToUniversalTime(); if (isStart) editing.StartsAtUtc = instant; else editing.EndsAtUtc = instant; }
+}

--- a/src/EasyLotteryWasm/Pages/DonateObs.razor
+++ b/src/EasyLotteryWasm/Pages/DonateObs.razor
@@ -1,0 +1,78 @@
+@page "/obs/donate/{ActivityId:int}"
+@using EasyLotteryDomain.Models.Config
+@inject IEasyLotteryConfigStore ConfigStore
+@implements IAsyncDisposable
+
+<PageTitle>Donate 抽獎 OBS</PageTitle>
+
+<div class="donate-obs-shell">
+    @if (activity is null)
+    {
+        <div class="donate-obs-empty">找不到 Donate 活動</div>
+    }
+    else if (latestWin is null)
+    {
+        <div class="donate-obs-empty">@activity.Name<br /><small>等待中獎結果…</small></div>
+    }
+    else
+    {
+        <div class="donate-reveal" @key="latestWin.Id">
+            <div class="donate-reveal-label">DONATE WINNER</div>
+            @if (!string.IsNullOrWhiteSpace(latestWin.PrizeImageUrl) && !prizeImageFailed)
+            {
+                <img class="donate-reveal-image" src="@latestWin.PrizeImageUrl" alt="@latestWin.PrizeName" @onerror="() => prizeImageFailed = true" />
+            }
+            else { <div class="donate-reveal-fallback">@latestWin.PrizeName</div> }
+            <div class="donate-reveal-prize">@latestWin.PrizeName</div>
+            <div class="donate-reveal-donor">@latestWin.DonorName · NT$@latestWin.Amount:N0</div>
+        </div>
+    }
+</div>
+
+<style>
+    .donate-obs-shell { min-height: 100vh; display:grid; place-items:center; background:transparent; color:white; font-family:system-ui,sans-serif; }
+    .donate-obs-empty { text-align:center; padding:2rem 3rem; border-radius:1.5rem; background:rgba(8,10,26,.72); font-size:2rem; }
+    .donate-reveal { text-align:center; padding:2rem; animation:donate-reveal .65s cubic-bezier(.16,1,.3,1); text-shadow:0 3px 18px #000; }
+    .donate-reveal-label { color:#ffd166; font-weight:900; letter-spacing:.22em; margin-bottom:1rem; }
+    .donate-reveal-image { max-width:min(68vw,640px); max-height:62vh; object-fit:contain; border:6px solid #ffd166; border-radius:1.25rem; box-shadow:0 0 45px rgba(255,209,102,.8); }
+    .donate-reveal-fallback { width:min(68vw,640px); aspect-ratio:1; display:grid; place-items:center; border:6px solid #ffd166; border-radius:1.25rem; background:linear-gradient(135deg,#6d28d9,#f59e0b); font-size:clamp(2rem,7vw,5rem); font-weight:900; }
+    .donate-reveal-prize { font-size:clamp(2rem,6vw,4.5rem); font-weight:900; margin-top:1rem; }
+    .donate-reveal-donor { font-size:clamp(1.15rem,3vw,2rem); }
+    @@keyframes donate-reveal { from { opacity:0; transform:scale(.45) rotate(-4deg); } to { opacity:1; transform:scale(1) rotate(0); } }
+</style>
+
+@code {
+    [Parameter] public int ActivityId { get; set; }
+    private DonateLotteryActivity? activity;
+    private DonateLotteryDrawRecord? latestWin;
+    private int? displayedWinId;
+    private bool prizeImageFailed;
+    private readonly CancellationTokenSource cancellation = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        await RefreshAsync();
+        _ = PollAsync();
+    }
+
+    private async Task PollAsync()
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(2));
+        try { while (await timer.WaitForNextTickAsync(cancellation.Token)) { await RefreshAsync(); await InvokeAsync(StateHasChanged); } }
+        catch (OperationCanceledException) { }
+    }
+
+    private async Task RefreshAsync()
+    {
+        var document = await ConfigStore.LoadAsync(cancellation.Token);
+        activity = document.DonateLotteryActivities.FirstOrDefault(item => item.Id == ActivityId);
+        latestWin = document.DonateLotteryDrawRecords.Where(item => item.ActivityId == ActivityId).OrderByDescending(item => item.Id).FirstOrDefault();
+        if (displayedWinId != latestWin?.Id)
+        {
+            displayedWinId = latestWin?.Id;
+            prizeImageFailed = false;
+        }
+    }
+
+    public ValueTask DisposeAsync() { cancellation.Cancel(); cancellation.Dispose(); return ValueTask.CompletedTask; }
+}

--- a/src/EasyLotteryWasm/Program.cs
+++ b/src/EasyLotteryWasm/Program.cs
@@ -35,6 +35,7 @@ builder.Services.AddScoped<SystemSettingsService>();
 builder.Services.AddScoped<ObsLayoutService>();
 builder.Services.AddScoped<SoundCueService>();
 builder.Services.AddScoped<ActivityResultService>();
+builder.Services.AddScoped<DonateLotteryActivityService>();
 builder.Services.AddScoped<ResultNotificationService>();
 builder.Services.AddScoped<VisualStyleService>();
 builder.Services.AddScoped<OvertimeFeedClient>();

--- a/src/EasyLotteryWasm/Services/YamlEasyLotteryConfigStore.cs
+++ b/src/EasyLotteryWasm/Services/YamlEasyLotteryConfigStore.cs
@@ -140,6 +140,9 @@ namespace EasyLotteryWasm.Services
             document.ActivityResults ??= new List<ActivityResultRecord>();
             document.DrawingRulePresets ??= new List<DrawingRulePreset>();
             document.DrawingRules ??= new DrawingRuleSettings();
+            document.DonateLotteryActivities ??= new List<DonateLotteryActivity>();
+            document.DonateLotteryDrawRecords ??= new List<DonateLotteryDrawRecord>();
+            document.ProcessedDonatePaymentIds ??= new List<string>();
             document.VisualStyle ??= new VisualStyleSettings();
             document.VisualStyle.ActiveThemeKey = VisualStyleCatalog.NormalizeKey(document.VisualStyle.ActiveThemeKey);
             document.VisualStyle.BackgroundImageUrl = NormalizeExternalHttpsUrl(document.VisualStyle.BackgroundImageUrl);
@@ -241,6 +244,9 @@ namespace EasyLotteryWasm.Services
             document.IdSequence.NextRouletteSegmentId = Math.Max(document.IdSequence.NextRouletteSegmentId, document.RouletteTemplates.SelectMany(t => t.Segments).Select(s => s.Id).DefaultIfEmpty(0).Max() + 1);
             document.IdSequence.NextActivityResultId = Math.Max(document.IdSequence.NextActivityResultId, document.ActivityResults.Select(result => result.Id).DefaultIfEmpty(0).Max() + 1);
             document.IdSequence.NextAuditRecordId = Math.Max(document.IdSequence.NextAuditRecordId, document.AuditRecords.Select(record => record.Id).DefaultIfEmpty(0).Max() + 1);
+            document.IdSequence.NextDonateLotteryActivityId = Math.Max(document.IdSequence.NextDonateLotteryActivityId, document.DonateLotteryActivities.Select(activity => activity.Id).DefaultIfEmpty(0).Max() + 1);
+            document.IdSequence.NextDonateLotteryPrizeId = Math.Max(document.IdSequence.NextDonateLotteryPrizeId, document.DonateLotteryActivities.SelectMany(activity => activity.Prizes ?? []).Select(prize => prize.Id).DefaultIfEmpty(0).Max() + 1);
+            document.IdSequence.NextDonateLotteryDrawRecordId = Math.Max(document.IdSequence.NextDonateLotteryDrawRecordId, document.DonateLotteryDrawRecords.Select(record => record.Id).DefaultIfEmpty(0).Max() + 1);
             document.SystemSettings.Audit.ActorName = string.IsNullOrWhiteSpace(document.SystemSettings.Audit.ActorName) ? "本機操作" : document.SystemSettings.Audit.ActorName.Trim();
             document.SystemSettings.ResultNotificationEmail = document.SystemSettings.ResultNotificationEmail.Trim();
 

--- a/tests/EasyLotteryDomainTests/Services/DonateLotteryEngineTests.cs
+++ b/tests/EasyLotteryDomainTests/Services/DonateLotteryEngineTests.cs
@@ -1,0 +1,66 @@
+using EasyLotteryDomain.Models.Config;
+using EasyLotteryDomain.Services;
+
+namespace EasyLotteryDomainTests.Services;
+
+[TestClass]
+public sealed class DonateLotteryEngineTests
+{
+    [TestMethod]
+    public void Process_UsesDonationMultiplesAndNeverDrawsBeyondInventory()
+    {
+        var document = ActiveDocument();
+        document.DonateLotteryActivities[0].Prizes[0].Quantity = 1;
+        document.DonateLotteryActivities[0].Prizes[0].RemainingQuantity = 1;
+
+        var result = DonateLotteryEngine.Process(document, "payment-1", "Alice", 300m, DateTimeOffset.UtcNow, () => 0d);
+
+        Assert.IsTrue(result.Processed);
+        Assert.AreEqual(1, result.Wins.Count);
+        Assert.AreEqual(0, document.DonateLotteryActivities[0].Prizes[0].RemainingQuantity);
+        Assert.AreEqual(3, result.Wins[0].DrawCount);
+    }
+
+    [TestMethod]
+    public void Process_RejectsDuplicatePaymentBeforeChangingInventory()
+    {
+        var document = ActiveDocument();
+        DonateLotteryEngine.Process(document, "payment-1", "Alice", 100m, DateTimeOffset.UtcNow, () => 0d);
+
+        var duplicate = DonateLotteryEngine.Process(document, "payment-1", "Alice", 100m, DateTimeOffset.UtcNow, () => 0d);
+
+        Assert.IsFalse(duplicate.Processed);
+        Assert.AreEqual(1, document.DonateLotteryDrawRecords.Count);
+    }
+
+    [TestMethod]
+    public void Process_SkipsInactiveOrOutOfWindowActivities()
+    {
+        var document = ActiveDocument();
+        document.DonateLotteryActivities[0].IsEnabled = false;
+
+        var result = DonateLotteryEngine.Process(document, "payment-1", "Alice", 100m, DateTimeOffset.UtcNow, () => 0d);
+
+        Assert.IsTrue(result.Processed);
+        Assert.AreEqual(0, result.Wins.Count);
+    }
+
+    private static EasyLotteryConfigDocument ActiveDocument() => new()
+    {
+        DonateLotteryActivities =
+        [
+            new DonateLotteryActivity
+            {
+                Id = 1,
+                Name = "拍立得",
+                Type = DonateLotteryActivityType.Polaroid,
+                MinimumDonationAmount = 100m,
+                StartsAtUtc = DateTimeOffset.UtcNow.AddHours(-1),
+                EndsAtUtc = DateTimeOffset.UtcNow.AddHours(1),
+                IsEnabled = true,
+                WinProbability = 1m,
+                Prizes = [new DonateLotteryPrize { Id = 1, Name = "獎項", RemainingQuantity = 2, Quantity = 2 }]
+            }
+        ]
+    };
+}


### PR DESCRIPTION
Closes #85

## Summary

- add configurable postcard and Polaroid Donate activities with schedules, thresholds, win probabilities, stock, and enablement controls
- process successful payment callbacks into idempotent Donate draws; persist draw records and decrement prize stock without duplicates
- add activity-specific OBS URLs with a prize reveal effect, image fallback, and disabled controls for inactive activities
- publish winning results to the existing overtime feed and email configured result recipients without allowing notification failures to interrupt payments

## Validation

- `dotnet test EasyLottery.generated.sln --no-restore` (88 passed)
