### PR TITLE
feat: add activity market and reports

### DIFF
--- a/src/EasyLotteryWasm/Layout/NavMenu.razor
+++ b/src/EasyLotteryWasm/Layout/NavMenu.razor
@@ -37,11 +37,7 @@
                     轉盤
                 </NavLink>
             </div>
-            <div class="nav-item px-3 nav-sub-item">
-                <NavLink class="nav-link" href="activity-results">
-                    活動結果
-                </NavLink>
-            </div>
+            <div class="nav-item px-3 nav-sub-item"><NavLink class="nav-link" href="market">活動市集</NavLink></div>
             <div class="nav-item px-3 nav-sub-item">
                 <NavLink class="nav-link" href="activity/overtime">
                     加班台
@@ -52,6 +48,15 @@
                     Donate 活動
                 </NavLink>
             </div>
+        }
+
+        <div class="nav-group-header px-3" @onclick="ToggleReportGroup">
+            <span class="bi bi-bar-chart-fill" aria-hidden="true"></span><span class="nav-group-title">Report</span>
+            <span class="nav-group-chevron @(reportGroupExpanded ? "expanded" : "")">&#9656;</span>
+        </div>
+        @if (reportGroupExpanded)
+        {
+            <div class="nav-item px-3 nav-sub-item"><NavLink class="nav-link" href="activity-results">活動與 Donate 結果</NavLink></div>
         }
 
         @* === 3. 系統配置 === *@
@@ -116,6 +121,7 @@
     private bool collapseNavMenu = false;
     private bool activityGroupExpanded = false;
     private bool systemGroupExpanded = false;
+    private bool reportGroupExpanded = false;
     private bool hasYoutubeApiKey = false;
 
     private string? NavMenuCssClass => collapseNavMenu ? "collapse" : null;
@@ -139,5 +145,6 @@
     {
         systemGroupExpanded = !systemGroupExpanded;
     }
+    private void ToggleReportGroup() => reportGroupExpanded = !reportGroupExpanded;
 
 }

--- a/src/EasyLotteryWasm/Pages/ActivityResults.razor
+++ b/src/EasyLotteryWasm/Pages/ActivityResults.razor
@@ -7,8 +7,14 @@
 @inject ActivityResultService ActivityResultService
 @inject IMessageService MessageService
 @inject IJSRuntime JSRuntime
+@inject IEasyLotteryConfigStore ConfigStore
 
 <PageTitle>活動結果</PageTitle>
+
+@if (donateSummary is not null)
+{
+    <Card class="mb-4"><CardBody><h4>Donate 統計</h4><div class="row"><div class="col">贊助筆數：@donateSummary.Value.Count</div><div class="col">總金額：NT$@donateSummary.Value.Total:N0</div><div class="col">平均金額：NT$@donateSummary.Value.Average:N0</div><div class="col">中獎結果：@donateSummary.Value.Wins</div></div></CardBody></Card>
+}
 
 <div class="activity-results-page">
     <section class="results-hero">
@@ -644,6 +650,7 @@
     private string activityTypeFilter = "all";
     private string startDateText = "";
     private string endDateText = "";
+    private (int Count, decimal Total, decimal Average, int Wins)? donateSummary;
 
     private List<ActivityResultRecord> FilteredRecords => ActivityResultService.FilterActivityResults(
         records,
@@ -660,6 +667,9 @@
     protected override async Task OnInitializedAsync()
     {
         records = await ActivityResultService.ListActivityResultsAsync();
+        var document = await ConfigStore.LoadAsync();
+        var draws = document.DonateLotteryDrawRecords;
+        donateSummary = (draws.Select(item => item.PaymentExternalId).Distinct().Count(), draws.GroupBy(item => item.PaymentExternalId).Select(group => group.First().Amount).Sum(), draws.Select(item => item.PaymentExternalId).Distinct().Any() ? draws.GroupBy(item => item.PaymentExternalId).Select(group => group.First().Amount).Average() : 0m, draws.Count);
         isLoading = false;
     }
 

--- a/src/EasyLotteryWasm/Pages/Market.razor
+++ b/src/EasyLotteryWasm/Pages/Market.razor
@@ -1,0 +1,15 @@
+@page "/market"
+@using EasyLotteryDomain.Models.Entities
+@using EasyLotteryDomain.Services
+@inject PokeService PokeService
+@inject RouletteService RouletteService
+@inject NavigationManager Navigation
+
+<PageTitle>活動市集</PageTitle>
+<Card class="mb-4"><CardBody><h2>活動市集</h2><p class="mb-0">瀏覽已安裝的內建活動模板；模板會保留在共用設定中，不會覆蓋任何歷史活動結果。</p></CardBody></Card>
+@if (loading) { <p>載入中…</p> } else { <div class="row g-3">@foreach (var item in items) { <div class="col-md-6 col-xl-4"><Card class="h-100"><CardBody><Badge Color="Color.Info">@item.Type</Badge><h4 class="mt-2">@item.Name</h4><p>@item.Description</p><small class="text-muted">版本 1.0 · @(item.IsInstalled ? "已安裝" : "尚未安裝")</small><div class="mt-3"><a class="btn btn-primary" href="@item.Link">@(item.IsInstalled ? "開啟並啟用" : "下載／安裝")</a></div></CardBody></Card></div> }</div> }
+@code {
+ private sealed record MarketItem(string Type,string Name,string Description,string Link,bool IsInstalled);
+ private List<MarketItem> items=[]; private bool loading=true;
+ protected override async Task OnInitializedAsync(){ var pokes=await PokeService.ListTemplatesAsync(); var roulettes=await RouletteService.ListTemplatesAsync(); items=pokes.Where(x=>x.IsBuiltIn && x.PublicationStatus==TemplatePublicationStatus.Published).Select(x=>new MarketItem("戳戳樂",x.Name,x.Description,$"/pokebox/editor/{x.Id}",true)).Concat(roulettes.Where(x=>x.IsBuiltIn && x.PublicationStatus==TemplatePublicationStatus.Published).Select(x=>new MarketItem("轉盤",x.Name,x.Description,$"/roulette/editor/{x.Id}",true))).ToList(); loading=false; }
+}


### PR DESCRIPTION
Closes #86

## Summary

- add an Activity Market entry point that lists installed, published built-in PokeBox and Roulette packages without altering historical results
- move activity results into a dedicated Report navigation group
- add Donate aggregate metrics to the activity report alongside existing filtering and historical result views

## Validation

- `dotnet test EasyLottery.generated.sln --no-restore` (88 passed)
