### PR TITLE
fix: protect settings secrets and add Donate test mode

### DIFF
--- a/src/EasyLotteryAPI/ConfigSecretRedactor.cs
+++ b/src/EasyLotteryAPI/ConfigSecretRedactor.cs
@@ -30,6 +30,7 @@ public sealed class ConfigSecretRedactor
 
         var document = Deserialize(yaml);
         Redact(document.SystemSettings?.DonationIntegration);
+        RedactSystemSecrets(document.SystemSettings);
         return _serializer.Serialize(document);
     }
 
@@ -57,6 +58,7 @@ public sealed class ConfigSecretRedactor
         MigrateLegacySettings(existing.SystemSettings?.DonationIntegration);
         MigrateLegacySettings(submitted.SystemSettings?.DonationIntegration);
         MergeSecrets(existing.SystemSettings?.DonationIntegration, submitted.SystemSettings?.DonationIntegration);
+        MergeSystemSecrets(existing.SystemSettings, submitted.SystemSettings);
         return _serializer.Serialize(submitted);
     }
 
@@ -74,6 +76,22 @@ public sealed class ConfigSecretRedactor
         Redact(settings.NewebPay);
         Redact(settings.OenTw);
         Redact(settings.TwitchBits);
+    }
+
+    private static void RedactSystemSecrets(LotterySystemSettings? settings)
+    {
+        if (settings is null) return;
+        settings.YouTube.ApiKey = ToMask(settings.YouTube.ApiKey);
+        settings.OpenAIKey = ToMask(settings.OpenAIKey);
+        settings.MailDelivery.SmtpPassword = ToMask(settings.MailDelivery.SmtpPassword);
+    }
+
+    private static void MergeSystemSecrets(LotterySystemSettings? existing, LotterySystemSettings? submitted)
+    {
+        if (existing is null || submitted is null) return;
+        submitted.YouTube.ApiKey = PreserveIfMasked(submitted.YouTube.ApiKey, existing.YouTube.ApiKey);
+        submitted.OpenAIKey = PreserveIfMasked(submitted.OpenAIKey, existing.OpenAIKey);
+        submitted.MailDelivery.SmtpPassword = PreserveIfMasked(submitted.MailDelivery.SmtpPassword, existing.MailDelivery.SmtpPassword);
     }
 
     private static void MigrateLegacySettings(DonationIntegrationSettings? settings)

--- a/src/EasyLotteryWasm/Pages/DonateObs.razor
+++ b/src/EasyLotteryWasm/Pages/DonateObs.razor
@@ -1,6 +1,8 @@
 @page "/obs/donate/{ActivityId:int}"
 @using EasyLotteryDomain.Models.Config
+@using EasyLotteryDomain.Services
 @inject IEasyLotteryConfigStore ConfigStore
+@inject NavigationManager Navigation
 @implements IAsyncDisposable
 
 <PageTitle>Donate 抽獎 OBS</PageTitle>
@@ -29,6 +31,18 @@
     }
 </div>
 
+@if (testMode)
+{
+    <details class="donate-test-panel" open>
+        <summary>Donate 測試模式</summary>
+        <p>只會建立測試抽獎紀錄，不會送出金流請求。</p>
+        <input @bind="testDonorName" placeholder="贊助者名稱" aria-label="測試贊助者名稱" />
+        <input type="number" min="1" @bind="testAmount" aria-label="測試贊助金額" />
+        <button @onclick="RunTestAsync">模擬 Donate 並抽獎</button>
+        @if (!string.IsNullOrWhiteSpace(testResult)) { <div role="status">@testResult</div> }
+    </details>
+}
+
 <style>
     .donate-obs-shell { min-height: 100vh; display:grid; place-items:center; background:transparent; color:white; font-family:system-ui,sans-serif; }
     .donate-obs-empty { text-align:center; padding:2rem 3rem; border-radius:1.5rem; background:rgba(8,10,26,.72); font-size:2rem; }
@@ -38,6 +52,9 @@
     .donate-reveal-fallback { width:min(68vw,640px); aspect-ratio:1; display:grid; place-items:center; border:6px solid #ffd166; border-radius:1.25rem; background:linear-gradient(135deg,#6d28d9,#f59e0b); font-size:clamp(2rem,7vw,5rem); font-weight:900; }
     .donate-reveal-prize { font-size:clamp(2rem,6vw,4.5rem); font-weight:900; margin-top:1rem; }
     .donate-reveal-donor { font-size:clamp(1.15rem,3vw,2rem); }
+    .donate-test-panel { position:fixed; right:1rem; bottom:1rem; z-index:10; max-width:24rem; padding:1rem; border-radius:.75rem; background:#fff; color:#172033; box-shadow:0 8px 30px rgba(0,0,0,.35); }
+    .donate-test-panel input { display:block; width:100%; margin:.5rem 0; padding:.45rem; }
+    .donate-test-panel button { padding:.45rem .75rem; border:0; border-radius:.35rem; background:#2563eb; color:#fff; }
     @@keyframes donate-reveal { from { opacity:0; transform:scale(.45) rotate(-4deg); } to { opacity:1; transform:scale(1) rotate(0); } }
 </style>
 
@@ -47,12 +64,27 @@
     private DonateLotteryDrawRecord? latestWin;
     private int? displayedWinId;
     private bool prizeImageFailed;
+    private bool testMode;
+    private string testDonorName = "測試贊助者";
+    private decimal testAmount = 100m;
+    private string testResult = "";
     private readonly CancellationTokenSource cancellation = new();
 
     protected override async Task OnInitializedAsync()
     {
+        testMode = Navigation.Uri.Contains("test=true", StringComparison.OrdinalIgnoreCase);
         await RefreshAsync();
         _ = PollAsync();
+    }
+
+    private async Task RunTestAsync()
+    {
+        var document = await ConfigStore.LoadAsync(cancellation.Token);
+        var testId = $"obs-test:{ActivityId}:{Guid.NewGuid():N}";
+        var result = DonateLotteryEngine.Process(document, testId, testDonorName, testAmount, DateTimeOffset.UtcNow);
+        await ConfigStore.SaveAsync(document, cancellation.Token);
+        testResult = result.Wins.Count == 0 ? "測試完成：未中獎（請確認活動是否啟用、期間、門檻與庫存）。" : $"測試完成：抽中 {string.Join("、", result.Wins.Select(win => win.PrizeName))}";
+        await RefreshAsync();
     }
 
     private async Task PollAsync()

--- a/tests/EasyLotteryAPITests/ConfigSecretRedactorTests.cs
+++ b/tests/EasyLotteryAPITests/ConfigSecretRedactorTests.cs
@@ -28,6 +28,9 @@ public sealed class ConfigSecretRedactorTests
         Assert.AreEqual(ConfigSecretRedactor.UnchangedSecretMask, browserDocument.SystemSettings.DonationIntegration.Ecpay.SecretKey);
         Assert.AreEqual(ConfigSecretRedactor.UnchangedSecretMask, browserDocument.SystemSettings.DonationIntegration.OenTw.AccessToken);
         Assert.AreEqual("merchant-id", browserDocument.SystemSettings.DonationIntegration.Ecpay.MerchantId);
+        Assert.AreEqual(ConfigSecretRedactor.UnchangedSecretMask, browserDocument.SystemSettings.YouTube.ApiKey);
+        Assert.AreEqual(ConfigSecretRedactor.UnchangedSecretMask, browserDocument.SystemSettings.OpenAIKey);
+        Assert.AreEqual(ConfigSecretRedactor.UnchangedSecretMask, browserDocument.SystemSettings.MailDelivery.SmtpPassword);
     }
 
     [TestMethod]
@@ -43,6 +46,9 @@ public sealed class ConfigSecretRedactorTests
         Assert.AreEqual("api-key", saved.SystemSettings.DonationIntegration.Ecpay.Testing.ApiKey);
         Assert.AreEqual("replacement-secret", saved.SystemSettings.DonationIntegration.Ecpay.Testing.SecretKey);
         Assert.AreEqual("access-token", saved.SystemSettings.DonationIntegration.OenTw.Testing.AccessToken);
+        Assert.AreEqual("youtube-key", saved.SystemSettings.YouTube.ApiKey);
+        Assert.AreEqual("openai-key", saved.SystemSettings.OpenAIKey);
+        Assert.AreEqual("smtp-password", saved.SystemSettings.MailDelivery.SmtpPassword);
     }
 
     private static EasyLotteryConfigDocument CreateDocument() => new()
@@ -53,7 +59,10 @@ public sealed class ConfigSecretRedactorTests
             {
                 Ecpay = new DonationProviderSettings { MerchantId = "merchant-id", ApiKey = "api-key", SecretKey = "secret-key" },
                 OenTw = new DonationProviderSettings { AccessToken = "access-token" }
-            }
+            },
+            YouTube = new YouTubeApiSettings { ApiKey = "youtube-key" },
+            OpenAIKey = "openai-key",
+            MailDelivery = new MailDeliverySettings { SmtpPassword = "smtp-password" }
         }
     };
 }


### PR DESCRIPTION
## Summary

- redact and preserve YouTube, OpenAI, and SMTP credentials alongside payment secrets when browser settings are read or saved
- add guarded-by-query Donate OBS test controls at `/obs/donate/{id}?test=true` to simulate a donation through the same draw and inventory logic
- add regression coverage for the newly protected secrets

## Validation

- `dotnet test EasyLottery.generated.sln --no-restore` (88 passed)
