### PR TITLE
fix: coordinate settings file writes

### DIFF
--- a/src/EasyLotteryAPI/Payments/PaymentCallbackProcessor.cs
+++ b/src/EasyLotteryAPI/Payments/PaymentCallbackProcessor.cs
@@ -1,12 +1,11 @@
 using System.Text.Json;
 using System.Net;
 using System.Net.Mail;
+using EasyLotteryApi;
 using EasyLotteryDomain.Models.Config;
 using EasyLotteryDomain.Services;
 using EasyLotteryDomain.Models.Overtime;
 using Microsoft.AspNetCore.SignalR;
-using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
 
 namespace EasyLotteryApi.Payments;
 
@@ -15,35 +14,26 @@ public sealed class PaymentCallbackProcessor
     private readonly PaymentProviderFactory _factory;
     private readonly IHubContext<OvertimeHub> _hub;
     private readonly ILogger<PaymentCallbackProcessor> _logger;
-    private readonly string _configPath;
-    private readonly string _legacyConfigPath;
+    private readonly SettingsFileStore _settingsStore;
     private readonly string _paymentEventsPath;
     private readonly string _paymentOrdersPath;
     private readonly string _overtimeFeedPath;
     private readonly SemaphoreSlim _gate = new(1, 1);
-    private readonly IDeserializer _yaml = new DeserializerBuilder()
-        .WithNamingConvention(CamelCaseNamingConvention.Instance)
-        .IgnoreUnmatchedProperties()
-        .Build();
-    private readonly ISerializer _yamlSerializer = new SerializerBuilder()
-        .WithNamingConvention(CamelCaseNamingConvention.Instance)
-        .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull | DefaultValuesHandling.OmitDefaults)
-        .Build();
 
     public PaymentCallbackProcessor(
         PaymentProviderFactory factory,
         IHubContext<OvertimeHub> hub,
         ILogger<PaymentCallbackProcessor> logger,
         IConfiguration configuration,
-        IWebHostEnvironment environment)
+        IWebHostEnvironment environment,
+        SettingsFileStore settingsStore)
     {
         _factory = factory;
         _hub = hub;
         _logger = logger;
         var storageDirectory = configuration["Storage:Directory"] ?? Path.Combine(environment.ContentRootPath, "App_Data");
         Directory.CreateDirectory(storageDirectory);
-        _configPath = Path.Combine(storageDirectory, "settings.yaml");
-        _legacyConfigPath = Path.Combine(storageDirectory, "easy-lottery.yaml");
+        _settingsStore = settingsStore;
         _paymentEventsPath = Path.Combine(storageDirectory, "easy-lottery-payment-events.json");
         _paymentOrdersPath = Path.Combine(storageDirectory, "easy-lottery-payment-orders.json");
         _overtimeFeedPath = Path.Combine(storageDirectory, "easy-lottery-overtime-feed.json");
@@ -182,17 +172,8 @@ public sealed class PaymentCallbackProcessor
 
     private async Task<IReadOnlyList<DonateLotteryDrawRecord>> ProcessDonateLotteryAsync(PaymentNotification notification, CancellationToken cancellationToken)
     {
-        var path = File.Exists(_configPath) ? _configPath : _legacyConfigPath;
-        if (!File.Exists(path)) return [];
-
-        var document = _yaml.Deserialize<EasyLotteryConfigDocument>(await File.ReadAllTextAsync(path, cancellationToken)) ?? new();
-        var result = DonateLotteryEngine.Process(document, notification.ExternalId, notification.DisplayName, notification.Amount, notification.OccurredAtUtc);
-        if (!result.Processed) return [];
-
-        var temporaryPath = $"{_configPath}.{Guid.NewGuid():N}.tmp";
-        await File.WriteAllTextAsync(temporaryPath, _yamlSerializer.Serialize(document), cancellationToken);
-        File.Move(temporaryPath, _configPath, overwrite: true);
-        return result.Wins;
+        var result = await _settingsStore.UpdateAsync(document => DonateLotteryEngine.Process(document, notification.ExternalId, notification.DisplayName, notification.Amount, notification.OccurredAtUtc), cancellationToken);
+        return result.Processed ? result.Wins : [];
     }
 
     private async Task SendResultNotificationAsync(IReadOnlyList<DonateLotteryDrawRecord> wins, CancellationToken cancellationToken)
@@ -200,9 +181,7 @@ public sealed class PaymentCallbackProcessor
         if (wins.Count == 0) return;
         try
         {
-            var path = File.Exists(_configPath) ? _configPath : _legacyConfigPath;
-            if (!File.Exists(path)) return;
-            var document = _yaml.Deserialize<EasyLotteryConfigDocument>(await File.ReadAllTextAsync(path, cancellationToken));
+            var document = await _settingsStore.ReadAsync(cancellationToken);
             var settings = document?.SystemSettings;
             if (settings is null || string.IsNullOrWhiteSpace(settings.ResultNotificationEmail) || !settings.MailDelivery.HasConfiguration) return;
             using var message = new MailMessage(new MailAddress(settings.MailDelivery.FromAddress, settings.MailDelivery.FromName), new MailAddress(settings.ResultNotificationEmail))
@@ -225,13 +204,7 @@ public sealed class PaymentCallbackProcessor
 
     private async Task<DonationProviderSettings?> LoadSettingsAsync(string providerId, CancellationToken cancellationToken)
     {
-        var configPath = File.Exists(_configPath) ? _configPath : _legacyConfigPath;
-        if (!File.Exists(configPath))
-        {
-            return null;
-        }
-
-        var document = _yaml.Deserialize<EasyLotteryConfigDocument>(await File.ReadAllTextAsync(configPath, cancellationToken));
+        var document = await _settingsStore.ReadAsync(cancellationToken);
         var providers = document?.SystemSettings?.DonationIntegration;
         var provider = providerId switch
         {

--- a/src/EasyLotteryAPI/Program.cs
+++ b/src/EasyLotteryAPI/Program.cs
@@ -11,34 +11,16 @@ builder.Services.AddSingleton<TunnelRuntimeService>();
 builder.Services.AddSingleton<IPaymentProvider, EcpayBroadcasterPaymentProvider>();
 builder.Services.AddSingleton<IPaymentProvider, NewebPayDonationPaymentProvider>();
 builder.Services.AddSingleton<PaymentProviderFactory>();
+builder.Services.AddSingleton<ConfigSecretRedactor>();
+builder.Services.AddSingleton<SettingsFileStore>();
 builder.Services.AddSingleton<PaymentCallbackProcessor>();
 
 var storageDirectory = builder.Configuration["Storage:Directory"]
     ?? Path.Combine(builder.Environment.ContentRootPath, "App_Data");
 Directory.CreateDirectory(storageDirectory);
 
-var configPath = Path.Combine(storageDirectory, "settings.yaml");
-var legacyConfigPath = Path.Combine(storageDirectory, "easy-lottery.yaml");
 var overtimeFeedPath = Path.Combine(storageDirectory, "easy-lottery-overtime-feed.json");
 var storageGate = new SemaphoreSlim(1, 1);
-var configSecrets = new ConfigSecretRedactor();
-
-// Preserve existing installations while making settings.yaml the single
-// canonical configuration file from now on.
-if (!File.Exists(configPath) && File.Exists(legacyConfigPath))
-{
-    File.Move(legacyConfigPath, configPath);
-}
-
-if (File.Exists(configPath))
-{
-    var currentSettings = await File.ReadAllTextAsync(configPath);
-    var normalizedSettings = configSecrets.NormalizeForPersistence(currentSettings);
-    if (!string.Equals(currentSettings, normalizedSettings, StringComparison.Ordinal))
-    {
-        await WriteFileAsync(configPath, normalizedSettings, storageGate, CancellationToken.None);
-    }
-}
 
 var app = builder.Build();
 
@@ -64,16 +46,15 @@ if (app.Environment.IsDevelopment())
 app.UseBlazorFrameworkFiles();
 app.UseStaticFiles();
 
-Func<HttpContext, Task<IResult>> readSettings = async context =>
+Func<HttpContext, SettingsFileStore, Task<IResult>> readSettings = async (context, settingsStore) =>
 {
-    var content = await ReadFileAsync(configPath, string.Empty, context.RequestAborted);
-    return Results.Text(configSecrets.RedactForBrowser(content), "text/yaml", Encoding.UTF8);
+    return Results.Text(await settingsStore.ReadForBrowserAsync(context.RequestAborted), "text/yaml", Encoding.UTF8);
 };
 app.MapGet("/settings", readSettings);
 // Compatibility endpoint for browsers still serving a cached pre-settings.yaml build.
 app.MapGet("/easy-lottery-config.yaml", readSettings);
 
-Func<HttpContext, IHubContext<OvertimeHub>, Task<IResult>> writeSettings = async (context, hub) =>
+Func<HttpContext, IHubContext<OvertimeHub>, SettingsFileStore, Task<IResult>> writeSettings = async (context, hub, settingsStore) =>
 {
     // Public callback tunnels must never also provide a public settings write API.
     // Remote administration can be explicitly enabled only by the host operator.
@@ -84,9 +65,7 @@ Func<HttpContext, IHubContext<OvertimeHub>, Task<IResult>> writeSettings = async
     }
 
     var content = await ReadRequestBodyAsync(context.Request, context.RequestAborted);
-    var existingContent = await ReadFileAsync(configPath, string.Empty, context.RequestAborted);
-    var mergedContent = configSecrets.MergeBrowserUpdate(existingContent, content);
-    await WriteFileAsync(configPath, mergedContent, storageGate, context.RequestAborted);
+    await settingsStore.SaveBrowserUpdateAsync(content, context.RequestAborted);
     await hub.Clients.All.SendAsync("OvertimeStateChanged", context.RequestAborted);
     return Results.NoContent();
 };

--- a/src/EasyLotteryAPI/SettingsFileStore.cs
+++ b/src/EasyLotteryAPI/SettingsFileStore.cs
@@ -1,0 +1,78 @@
+using EasyLotteryDomain.Models.Config;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace EasyLotteryApi;
+
+/// <summary>Single-writer access to the shared YAML settings file.</summary>
+public sealed class SettingsFileStore
+{
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly ConfigSecretRedactor _secrets;
+    private readonly IDeserializer _deserializer = new DeserializerBuilder().WithNamingConvention(CamelCaseNamingConvention.Instance).IgnoreUnmatchedProperties().Build();
+    private readonly ISerializer _serializer = new SerializerBuilder().WithNamingConvention(CamelCaseNamingConvention.Instance).ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull | DefaultValuesHandling.OmitDefaults).Build();
+
+    public string ConfigPath { get; }
+
+    public SettingsFileStore(IConfiguration configuration, IWebHostEnvironment environment, ConfigSecretRedactor secrets)
+    {
+        _secrets = secrets;
+        var directory = configuration["Storage:Directory"] ?? Path.Combine(environment.ContentRootPath, "App_Data");
+        Directory.CreateDirectory(directory);
+        ConfigPath = Path.Combine(directory, "settings.yaml");
+        var legacyPath = Path.Combine(directory, "easy-lottery.yaml");
+        if (!File.Exists(ConfigPath) && File.Exists(legacyPath)) File.Move(legacyPath, ConfigPath);
+        if (File.Exists(ConfigPath))
+        {
+            var current = File.ReadAllText(ConfigPath);
+            var normalized = _secrets.NormalizeForPersistence(current);
+            if (!string.Equals(current, normalized, StringComparison.Ordinal)) File.WriteAllText(ConfigPath, normalized);
+        }
+    }
+
+    public async Task<string> ReadForBrowserAsync(CancellationToken cancellationToken) =>
+        _secrets.RedactForBrowser(await ReadRawAsync(cancellationToken));
+
+    public async Task SaveBrowserUpdateAsync(string submittedYaml, CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try { await WriteRawAsync(_secrets.MergeBrowserUpdate(await ReadRawUnsafeAsync(cancellationToken), submittedYaml), cancellationToken); }
+        finally { _gate.Release(); }
+    }
+
+    public async Task<EasyLotteryConfigDocument> ReadAsync(CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try { return Deserialize(await ReadRawUnsafeAsync(cancellationToken)); }
+        finally { _gate.Release(); }
+    }
+
+    public async Task<T> UpdateAsync<T>(Func<EasyLotteryConfigDocument, T> update, CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            var document = Deserialize(await ReadRawUnsafeAsync(cancellationToken));
+            var result = update(document);
+            await WriteRawAsync(_serializer.Serialize(document), cancellationToken);
+            return result;
+        }
+        finally { _gate.Release(); }
+    }
+
+    private async Task<string> ReadRawAsync(CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try { return await ReadRawUnsafeAsync(cancellationToken); }
+        finally { _gate.Release(); }
+    }
+
+    private Task<string> ReadRawUnsafeAsync(CancellationToken cancellationToken) => File.Exists(ConfigPath) ? File.ReadAllTextAsync(ConfigPath, cancellationToken) : Task.FromResult(string.Empty);
+    private EasyLotteryConfigDocument Deserialize(string yaml) => string.IsNullOrWhiteSpace(yaml) ? new() : _deserializer.Deserialize<EasyLotteryConfigDocument>(yaml) ?? new();
+    private async Task WriteRawAsync(string content, CancellationToken cancellationToken)
+    {
+        var temporaryPath = $"{ConfigPath}.{Guid.NewGuid():N}.tmp";
+        await File.WriteAllTextAsync(temporaryPath, content, cancellationToken);
+        File.Move(temporaryPath, ConfigPath, overwrite: true);
+    }
+}

--- a/tests/EasyLotteryAPITests/SettingsFileStoreTests.cs
+++ b/tests/EasyLotteryAPITests/SettingsFileStoreTests.cs
@@ -1,0 +1,43 @@
+using EasyLotteryApi;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
+
+namespace EasyLotteryApiTests;
+
+[TestClass]
+public sealed class SettingsFileStoreTests
+{
+    [TestMethod]
+    public async Task UpdateAsync_SerializesConcurrentDocumentChanges()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"easy-lottery-tests-{Guid.NewGuid():N}");
+        try
+        {
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?> { ["Storage:Directory"] = directory }).Build();
+            var store = new SettingsFileStore(configuration, new TestEnvironment(), new ConfigSecretRedactor());
+
+            await Task.WhenAll(
+                store.UpdateAsync(document => { document.SystemSettings.ResultNotificationEmail = "results@example.test"; return true; }, CancellationToken.None),
+                store.UpdateAsync(document => { document.ProcessedDonatePaymentIds.Add("payment-1"); return true; }, CancellationToken.None));
+
+            var saved = await store.ReadAsync(CancellationToken.None);
+            Assert.AreEqual("results@example.test", saved.SystemSettings.ResultNotificationEmail);
+            CollectionAssert.Contains(saved.ProcessedDonatePaymentIds, "payment-1");
+        }
+        finally
+        {
+            if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private sealed class TestEnvironment : IWebHostEnvironment
+    {
+        public string ApplicationName { get; set; } = "EasyLotteryApiTests";
+        public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
+        public string WebRootPath { get; set; } = "";
+        public string EnvironmentName { get; set; } = "Testing";
+        public string ContentRootPath { get; set; } = Path.GetTempPath();
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}


### PR DESCRIPTION
Closes #104

## Summary

- centralize server-side YAML settings reads and writes in one single-writer service
- route browser setting saves and payment callback Donate updates through the shared atomic path
- retain migration and secret-preserving browser update behavior
- add a concurrency regression test proving independent simultaneous changes both persist

## Validation

- `dotnet test EasyLottery.generated.sln --no-restore` (89 passed)
