### PR TITLE
feat: authorize remote settings administration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       ASPNETCORE_URLS: http://+:18930
       DOTNET_USE_POLLING_FILE_WATCHER: "1"
       Storage__Directory: /data
+      Settings__AdminToken: ${EASYLOTTERY_ADMIN_TOKEN:-change-this-before-production}
     ports:
       - "18930:18930"
     volumes:

--- a/src/EasyLotteryAPI/AdminAccess.cs
+++ b/src/EasyLotteryAPI/AdminAccess.cs
@@ -1,0 +1,19 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace EasyLotteryApi;
+
+public sealed class AdminAccess
+{
+    public const string HeaderName = "X-EasyLottery-Admin-Token";
+    private readonly string _token;
+
+    public AdminAccess(IConfiguration configuration) => _token = configuration["Settings:AdminToken"]?.Trim() ?? "";
+
+    public bool IsAuthorized(HttpRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(_token)) return false;
+        var supplied = request.Headers[HeaderName].ToString();
+        return supplied.Length == _token.Length && CryptographicOperations.FixedTimeEquals(Encoding.UTF8.GetBytes(supplied), Encoding.UTF8.GetBytes(_token));
+    }
+}

--- a/src/EasyLotteryAPI/Program.cs
+++ b/src/EasyLotteryAPI/Program.cs
@@ -11,6 +11,7 @@ builder.Services.AddSingleton<TunnelRuntimeService>();
 builder.Services.AddSingleton<IPaymentProvider, EcpayBroadcasterPaymentProvider>();
 builder.Services.AddSingleton<IPaymentProvider, NewebPayDonationPaymentProvider>();
 builder.Services.AddSingleton<PaymentProviderFactory>();
+builder.Services.AddSingleton<AdminAccess>();
 builder.Services.AddSingleton<PaymentCallbackProcessor>();
 
 var storageDirectory = builder.Configuration["Storage:Directory"]
@@ -64,8 +65,9 @@ if (app.Environment.IsDevelopment())
 app.UseBlazorFrameworkFiles();
 app.UseStaticFiles();
 
-Func<HttpContext, Task<IResult>> readSettings = async context =>
+Func<HttpContext, AdminAccess, Task<IResult>> readSettings = async (context, adminAccess) =>
 {
+    if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
     var content = await ReadFileAsync(configPath, string.Empty, context.RequestAborted);
     return Results.Text(configSecrets.RedactForBrowser(content), "text/yaml", Encoding.UTF8);
 };
@@ -73,15 +75,9 @@ app.MapGet("/settings", readSettings);
 // Compatibility endpoint for browsers still serving a cached pre-settings.yaml build.
 app.MapGet("/easy-lottery-config.yaml", readSettings);
 
-Func<HttpContext, IHubContext<OvertimeHub>, Task<IResult>> writeSettings = async (context, hub) =>
+Func<HttpContext, IHubContext<OvertimeHub>, AdminAccess, Task<IResult>> writeSettings = async (context, hub, adminAccess) =>
 {
-    // Public callback tunnels must never also provide a public settings write API.
-    // Remote administration can be explicitly enabled only by the host operator.
-    var allowRemoteSettingsWrite = builder.Configuration.GetValue<bool>("Settings:AllowRemoteWrite");
-    if (!allowRemoteSettingsWrite && (context.Connection.RemoteIpAddress is null || !IPAddress.IsLoopback(context.Connection.RemoteIpAddress)))
-    {
-        return Results.StatusCode(StatusCodes.Status403Forbidden);
-    }
+    if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
 
     var content = await ReadRequestBodyAsync(context.Request, context.RequestAborted);
     var existingContent = await ReadFileAsync(configPath, string.Empty, context.RequestAborted);
@@ -176,12 +172,9 @@ app.MapPost("/api/payments/{providerId}/notify", async (string providerId, HttpC
     return Results.Text(acknowledgement, "text/plain", Encoding.UTF8);
 });
 
-app.MapPost("/api/payments/orders", async (PaymentOrderRegistrationRequest request, HttpContext context, PaymentCallbackProcessor callbacks) =>
+app.MapPost("/api/payments/orders", async (PaymentOrderRegistrationRequest request, HttpContext context, PaymentCallbackProcessor callbacks, AdminAccess adminAccess) =>
 {
-    if (context.Connection.RemoteIpAddress is null || !IPAddress.IsLoopback(context.Connection.RemoteIpAddress))
-    {
-        return Results.StatusCode(StatusCodes.Status403Forbidden);
-    }
+    if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
     try { return Results.Created($"/api/payments/orders/{request.MerchantOrderNo}", await callbacks.RegisterOrderAsync(request, context.RequestAborted)); }
     catch (ArgumentException exception) { return Results.BadRequest(new { error = exception.Message }); }
     catch (InvalidOperationException exception) { return Results.Conflict(new { error = exception.Message }); }

--- a/src/EasyLotteryWasm/Layout/NavMenu.razor
+++ b/src/EasyLotteryWasm/Layout/NavMenu.razor
@@ -97,6 +97,7 @@
                     審計紀錄
                 </NavLink>
             </div>
+            <div class="nav-item px-3 nav-sub-item"><NavLink class="nav-link" href="system/access">管理存取</NavLink></div>
         }
 
     </nav>

--- a/src/EasyLotteryWasm/Pages/Config/AdminAccess.razor
+++ b/src/EasyLotteryWasm/Pages/Config/AdminAccess.razor
@@ -1,0 +1,11 @@
+@page "/system/access"
+@inject IJSRuntime JSRuntime
+@inject IMessageService MessageService
+
+<PageTitle>管理存取</PageTitle>
+<Card><CardHeader><CardTitle>管理存取權杖</CardTitle></CardHeader><CardBody>
+    <CardText>輸入伺服器以 <code>Settings__AdminToken</code> 設定的權杖。權杖只保存於此瀏覽器工作階段。</CardText>
+    <Field><FieldLabel>管理權杖</FieldLabel><input class="form-control" type="password" @bind="token" autocomplete="current-password" /></Field>
+    <Button Color="Color.Primary" Clicked="SaveAsync">啟用管理存取</Button>
+</CardBody></Card>
+@code { private string token = ""; private async Task SaveAsync() { await JSRuntime.InvokeVoidAsync("easyLotteryConfig.setAdminToken", token); token = ""; await MessageService.Success("管理權杖已保存於此工作階段。"); } }

--- a/src/EasyLotteryWasm/wwwroot/js/configStorage.js
+++ b/src/EasyLotteryWasm/wwwroot/js/configStorage.js
@@ -5,6 +5,7 @@
 
     const storageKey = "easy-lottery.config.yaml";
     const remoteConfigUrl = "/settings";
+    const adminTokenKey = "easy-lottery.admin-token";
     let memoryFallback = "";
     let nextRemoteAttemptAt = 0;
 
@@ -23,13 +24,17 @@
         return memoryFallback;
     }
 
+    function getAdminHeaders() {
+        try { const token = window.sessionStorage.getItem(adminTokenKey); return token ? { "X-EasyLottery-Admin-Token": token } : {}; } catch { return {}; }
+    }
+
     async function read() {
         const now = Date.now();
         try {
             // The web host owns the YAML file. Do not let a stale per-browser
             // localStorage value override shared settings.
             if (now >= nextRemoteAttemptAt) {
-                const response = await fetch(remoteConfigUrl, { cache: "no-store" });
+                const response = await fetch(remoteConfigUrl, { cache: "no-store", headers: getAdminHeaders() });
                 if (response.ok) {
                     nextRemoteAttemptAt = 0;
                     return cacheFallback(await response.text());
@@ -61,9 +66,7 @@
             const response = await fetch(remoteConfigUrl, {
                 method: "PUT",
                 cache: "no-store",
-                headers: {
-                    "Content-Type": "text/yaml; charset=utf-8"
-                },
+                headers: { "Content-Type": "text/yaml; charset=utf-8", ...getAdminHeaders() },
                 body: safeContent
             });
 
@@ -78,5 +81,6 @@
     window.easyLotteryConfig = {
         read,
         write,
+        setAdminToken: (token) => window.sessionStorage.setItem(adminTokenKey, token || ""),
     };
 })();

--- a/tests/EasyLotteryAPITests/AdminAccessTests.cs
+++ b/tests/EasyLotteryAPITests/AdminAccessTests.cs
@@ -1,0 +1,23 @@
+using EasyLotteryApi;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+
+namespace EasyLotteryApiTests;
+
+[TestClass]
+public sealed class AdminAccessTests
+{
+    [TestMethod]
+    public void IsAuthorized_RequiresMatchingConfiguredToken()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?> { ["Settings:AdminToken"] = "test-token" }).Build();
+        var access = new AdminAccess(configuration);
+        var request = new DefaultHttpContext().Request;
+
+        Assert.IsFalse(access.IsAuthorized(request));
+        request.Headers[AdminAccess.HeaderName] = "wrong";
+        Assert.IsFalse(access.IsAuthorized(request));
+        request.Headers[AdminAccess.HeaderName] = "test-token";
+        Assert.IsTrue(access.IsAuthorized(request));
+    }
+}


### PR DESCRIPTION
Closes #105

## Summary

- replace loopback-IP administration checks with a configured, constant-time compared admin token
- require the token for sensitive settings reads/writes and payment-order registration while leaving public payment callbacks unchanged
- add a session-only management access page and attach the token to shared-configuration requests
- document the Docker `EASYLOTTERY_ADMIN_TOKEN` deployment variable

## Validation

- `dotnet test EasyLottery.generated.sln --no-restore` (89 passed)
