### PR TITLE
fix: require explicit admin token

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ EasyLottery 是一套以 **Blazor WebAssembly + Domain Service** 組成的直播
 
 ### 執行 Web Host
 
+Docker 部署前必須設定一組隨機管理權杖；它用於保護系統設定與付款訂單管理 API，請勿使用可預測值或提交至版本控制：
+
+```bash
+export EASYLOTTERY_ADMIN_TOKEN="$(openssl rand -hex 32)"
+```
+
 ```bash
 dotnet run --project src/EasyLotteryAPI/EasyLotteryApi.csproj --launch-profile EasyLotteryAPI
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       ASPNETCORE_URLS: http://+:18930
       DOTNET_USE_POLLING_FILE_WATCHER: "1"
       Storage__Directory: /data
-      Settings__AdminToken: ${EASYLOTTERY_ADMIN_TOKEN:-change-this-before-production}
+      Settings__AdminToken: ${EASYLOTTERY_ADMIN_TOKEN:?Set EASYLOTTERY_ADMIN_TOKEN before starting EasyLottery}
     ports:
       - "18930:18930"
     volumes:

--- a/src/EasyLotteryAPI/AdminAccess.cs
+++ b/src/EasyLotteryAPI/AdminAccess.cs
@@ -10,6 +10,8 @@ public sealed class AdminAccess
 
     public AdminAccess(IConfiguration configuration) => _token = configuration["Settings:AdminToken"]?.Trim() ?? "";
 
+    public bool IsConfigured => !string.IsNullOrWhiteSpace(_token);
+
     public bool IsAuthorized(HttpRequest request)
     {
         if (string.IsNullOrWhiteSpace(_token)) return false;

--- a/src/EasyLotteryAPI/Program.cs
+++ b/src/EasyLotteryAPI/Program.cs
@@ -25,6 +25,11 @@ var storageGate = new SemaphoreSlim(1, 1);
 
 var app = builder.Build();
 
+if (!app.Services.GetRequiredService<AdminAccess>().IsConfigured)
+{
+    app.Logger.LogWarning("Settings administration is disabled because Settings:AdminToken is not configured.");
+}
+
 if (app.Environment.IsDevelopment())
 {
     // Debug builds generate hash-named WASM assets. Prevent a browser that was


### PR DESCRIPTION
Closes #110

## Summary

- require `EASYLOTTERY_ADMIN_TOKEN` when starting the Docker Compose stack
- log an explicit warning and keep management APIs unavailable when no server token is configured
- document generation of a random deployment token

## Validation

- `dotnet test EasyLottery.generated.sln --no-restore` (90 passed)
