### PR TITLE
feat: enhance OBS donate lottery

### DIFF
--- a/src/EasyLotteryAPI/Payments/PaymentCallbackProcessor.cs
+++ b/src/EasyLotteryAPI/Payments/PaymentCallbackProcessor.cs
@@ -95,7 +95,7 @@ public sealed class PaymentCallbackProcessor
             });
             await WriteJsonAsync(_paymentEventsPath, paymentEvents, cancellationToken);
 
-            var donateWins = await ProcessDonateLotteryAsync(notification, cancellationToken);
+            var donateWins = await ProcessDonateLotteryAsync(notification, provider.Descriptor.DisplayName, cancellationToken);
             var feed = await ReadJsonAsync<List<OvertimeSupportEvent>>(_overtimeFeedPath, cancellationToken) ?? [];
             feed.Add(new OvertimeSupportEvent
             {
@@ -177,9 +177,9 @@ public sealed class PaymentCallbackProcessor
         finally { _gate.Release(); }
     }
 
-    private async Task<IReadOnlyList<DonateLotteryDrawRecord>> ProcessDonateLotteryAsync(PaymentNotification notification, CancellationToken cancellationToken)
+    private async Task<IReadOnlyList<DonateLotteryDrawRecord>> ProcessDonateLotteryAsync(PaymentNotification notification, string paymentMethod, CancellationToken cancellationToken)
     {
-        var result = await _settingsStore.UpdateAsync(document => DonateLotteryEngine.Process(document, notification.ExternalId, notification.DisplayName, notification.Amount, notification.OccurredAtUtc), cancellationToken);
+        var result = await _settingsStore.UpdateAsync(document => DonateLotteryEngine.Process(document, notification.ExternalId, notification.DisplayName, notification.Amount, notification.OccurredAtUtc, donationMessage: notification.Message, paymentMethod: paymentMethod), cancellationToken);
         return result.Processed ? result.Wins : [];
     }
 

--- a/src/EasyLotteryDomain/Models/Config/DonateLotteryActivity.cs
+++ b/src/EasyLotteryDomain/Models/Config/DonateLotteryActivity.cs
@@ -6,6 +6,14 @@ public enum DonateLotteryActivityType
     Polaroid
 }
 
+public enum DonateLotteryAnimation
+{
+    IchibanKuji,
+    Gacha,
+    Garagara,
+    MoneyBox
+}
+
 public sealed class DonateLotteryActivity
 {
     public int Id { get; set; }
@@ -15,6 +23,7 @@ public sealed class DonateLotteryActivity
     public DateTimeOffset StartsAtUtc { get; set; } = DateTimeOffset.UtcNow;
     public DateTimeOffset EndsAtUtc { get; set; } = DateTimeOffset.UtcNow.AddDays(1);
     public decimal WinProbability { get; set; } = 1m;
+    public DonateLotteryAnimation Animation { get; set; } = DonateLotteryAnimation.IchibanKuji;
     public bool IsEnabled { get; set; }
     public List<DonateLotteryPrize> Prizes { get; set; } = [];
 }
@@ -26,6 +35,9 @@ public sealed class DonateLotteryPrize
     public string ImageUrl { get; set; } = "";
     public int Quantity { get; set; } = 1;
     public int RemainingQuantity { get; set; } = 1;
+    /// <summary>此獎項在單次抽獎中所佔百分比（0 至 100）。未配置的餘額為銘謝惠顧。</summary>
+    public decimal Probability { get; set; }
+    public bool IsGrandPrize { get; set; }
 }
 
 public sealed class DonateLotteryDrawRecord
@@ -38,5 +50,8 @@ public sealed class DonateLotteryDrawRecord
     public int DrawCount { get; set; }
     public string PrizeName { get; set; } = "";
     public string PrizeImageUrl { get; set; } = "";
+    public bool IsWinning { get; set; }
+    public string DonationMessage { get; set; } = "";
+    public string PaymentMethod { get; set; } = "";
     public DateTimeOffset DrawnAtUtc { get; set; } = DateTimeOffset.UtcNow;
 }

--- a/src/EasyLotteryDomain/Services/DonateLotteryActivityService.cs
+++ b/src/EasyLotteryDomain/Services/DonateLotteryActivityService.cs
@@ -21,8 +21,8 @@ public sealed class DonateLotteryActivityService
         if (string.IsNullOrWhiteSpace(activity.Name)) throw new InvalidOperationException("請輸入活動名稱。");
         if (activity.MinimumDonationAmount <= 0m) throw new InvalidOperationException("最低贊助金額必須大於 0。");
         if (activity.EndsAtUtc <= activity.StartsAtUtc) throw new InvalidOperationException("活動結束時間必須晚於開始時間。");
-        activity.WinProbability = Math.Clamp(activity.WinProbability, 0m, 1m);
         activity.Prizes ??= [];
+        var probabilityTotal = 0m;
         foreach (var prize in activity.Prizes)
         {
             prize.Id = prize.Id <= 0 ? document.IdSequence.NextDonateLotteryPrizeId++ : prize.Id;
@@ -30,7 +30,10 @@ public sealed class DonateLotteryActivityService
             prize.ImageUrl = prize.ImageUrl?.Trim() ?? "";
             prize.Quantity = Math.Max(0, prize.Quantity);
             prize.RemainingQuantity = Math.Clamp(prize.RemainingQuantity, 0, prize.Quantity);
+            prize.Probability = Math.Clamp(prize.Probability, 0m, 100m);
+            probabilityTotal += prize.Probability;
         }
+        if (probabilityTotal > 100m) throw new InvalidOperationException("獎項機率合計不可超過 100%。");
 
         if (activity.Id <= 0)
         {

--- a/src/EasyLotteryDomain/Services/DonateLotteryEngine.cs
+++ b/src/EasyLotteryDomain/Services/DonateLotteryEngine.cs
@@ -10,7 +10,9 @@ public static class DonateLotteryEngine
         string donorName,
         decimal amount,
         DateTimeOffset occurredAtUtc,
-        Func<double>? nextRandom = null)
+        Func<double>? nextRandom = null,
+        string? donationMessage = null,
+        string? paymentMethod = null)
     {
         if (string.IsNullOrWhiteSpace(paymentExternalId))
         {
@@ -31,19 +33,9 @@ public static class DonateLotteryEngine
             var drawCount = activity.MinimumDonationAmount <= 0m ? 0 : (int)(amount / activity.MinimumDonationAmount);
             for (var draw = 0; draw < drawCount; draw++)
             {
-                if (random() >= (double)Math.Clamp(activity.WinProbability, 0m, 1m))
-                {
-                    continue;
-                }
-
-                var available = activity.Prizes.Where(prize => prize.RemainingQuantity > 0).ToList();
-                if (available.Count == 0)
-                {
-                    break;
-                }
-
-                var prize = available[Math.Min((int)(random() * available.Count), available.Count - 1)];
-                prize.RemainingQuantity--;
+                var prize = SelectPrize(activity, random);
+                var isWinning = prize is not null;
+                if (prize is not null) prize.RemainingQuantity--;
                 var record = new DonateLotteryDrawRecord
                 {
                     Id = document.IdSequence.NextDonateLotteryDrawRecordId++,
@@ -52,16 +44,40 @@ public static class DonateLotteryEngine
                     DonorName = string.IsNullOrWhiteSpace(donorName) ? "匿名贊助者" : donorName.Trim(),
                     Amount = amount,
                     DrawCount = drawCount,
-                    PrizeName = prize.Name,
-                    PrizeImageUrl = prize.ImageUrl,
+                    PrizeName = prize?.Name ?? "銘謝惠顧",
+                    PrizeImageUrl = prize?.ImageUrl ?? "",
+                    IsWinning = isWinning,
+                    DonationMessage = donationMessage?.Trim() ?? "",
+                    PaymentMethod = paymentMethod?.Trim() ?? "",
                     DrawnAtUtc = occurredAtUtc
                 };
                 document.DonateLotteryDrawRecords.Add(record);
-                results.Add(record);
+                if (isWinning) results.Add(record);
             }
         }
 
         return new DonateLotteryProcessResult(true, "", results);
+    }
+    private static DonateLotteryPrize? SelectPrize(DonateLotteryActivity activity, Func<double> random)
+    {
+        var prizes = activity.Prizes.Where(item => item.RemainingQuantity > 0).ToList();
+        // Existing configurations predate per-prize probabilities. Keep them working until
+        // they are saved through the new editor, then use the explicit percentages below.
+        if (prizes.All(item => item.Probability <= 0m))
+        {
+            if (random() >= (double)Math.Clamp(activity.WinProbability, 0m, 1m)) return null;
+            return prizes.Count == 0 ? null : prizes[Math.Min((int)(random() * prizes.Count), prizes.Count - 1)];
+        }
+
+        var roll = (decimal)random() * 100m;
+        var cursor = 0m;
+        foreach (var prize in prizes)
+        {
+            cursor += Math.Clamp(prize.Probability, 0m, 100m);
+            if (roll < cursor) return prize;
+        }
+
+        return null;
     }
 }
 

--- a/src/EasyLotteryWasm/Pages/DonateActivities.razor
+++ b/src/EasyLotteryWasm/Pages/DonateActivities.razor
@@ -24,21 +24,26 @@
                 <div class="col-md-6"><Field><FieldLabel>活動名稱</FieldLabel><TextInput @bind-Value="editing.Name" /></Field></div>
                 <div class="col-md-3"><Field><FieldLabel>類型</FieldLabel><Select TValue="DonateLotteryActivityType" @bind-SelectedValue="editing.Type"><SelectItem Value="DonateLotteryActivityType.Postcard">明信片</SelectItem><SelectItem Value="DonateLotteryActivityType.Polaroid">拍立得</SelectItem></Select></Field></div>
                 <div class="col-md-3"><Field><FieldLabel>最低贊助金額</FieldLabel><NumericInput TValue="decimal" @bind-Value="editing.MinimumDonationAmount" Min="1" /></Field></div>
+                <div class="col-md-3"><Field><FieldLabel>抽獎動畫</FieldLabel><Select TValue="DonateLotteryAnimation" @bind-SelectedValue="editing.Animation"><SelectItem Value="DonateLotteryAnimation.IchibanKuji">一番賞</SelectItem><SelectItem Value="DonateLotteryAnimation.Gacha">扭蛋</SelectItem><SelectItem Value="DonateLotteryAnimation.Garagara">日式滾筒</SelectItem><SelectItem Value="DonateLotteryAnimation.MoneyBox">塞錢箱／詩籤</SelectItem></Select></Field></div>
                 <div class="col-md-4"><Field><FieldLabel>開始時間（本地時區）</FieldLabel><input class="form-control" type="datetime-local" value="@StartDateText" @onchange="OnStartDateChanged" /></Field></div>
                 <div class="col-md-4"><Field><FieldLabel>結束時間（本地時區）</FieldLabel><input class="form-control" type="datetime-local" value="@EndDateText" @onchange="OnEndDateChanged" /></Field></div>
                 <div class="col-md-2"><Field><FieldLabel>中獎機率</FieldLabel><NumericInput TValue="decimal" @bind-Value="editing.WinProbability" /></Field></div>
                 <div class="col-md-2"><Field><FieldLabel>啟用</FieldLabel><Switch TValue="bool" @bind-Value="editing.IsEnabled" /></Field></div>
             </div>
             <h5 class="mt-4">獎項</h5>
+            <p class="text-muted">每個獎項設定 0–100% 的中獎率；未配置的剩餘機率固定為「銘謝惠顧」。合計不可超過 100%。</p>
             @foreach (var prize in editing.Prizes)
             {
                 <div class="row g-2 mb-2" @key="prize">
-                    <div class="col-md-4"><TextInput @bind-Value="prize.Name" Placeholder="獎項名稱" /></div>
-                    <div class="col-md-4"><TextInput @bind-Value="prize.ImageUrl" Placeholder="圖片 URL" /></div>
-                    <div class="col-md-2"><NumericInput TValue="int" @bind-Value="prize.Quantity" Min="0" /></div>
+                    <div class="col-md-3"><TextInput @bind-Value="prize.Name" Placeholder="獎項名稱" /></div>
+                    <div class="col-md-2"><NumericInput TValue="decimal" @bind-Value="prize.Probability" Min="0" Max="100" Placeholder="機率 (%)" /></div>
+                    <div class="col-md-2"><TextInput @bind-Value="prize.ImageUrl" Placeholder="圖片 URL" /></div>
+                    <div class="col-md-1"><NumericInput TValue="int" @bind-Value="prize.Quantity" Min="0" /></div>
+                    <div class="col-md-2"><Switch TValue="bool" @bind-Value="prize.IsGrandPrize" /> <small>最大獎</small></div>
                     <div class="col-md-2"><Button Color="Color.Danger" Size="Size.Small" Clicked="() => editing.Prizes.Remove(prize)">移除</Button></div>
                 </div>
             }
+            <div class="small text-muted">目前合計：@PrizeProbabilityTotal.ToString("0.##")%　／　銘謝惠顧：@Math.Max(0m, 100m - PrizeProbabilityTotal).ToString("0.##")%</div>
             <Button Color="Color.Secondary" Size="Size.Small" Clicked="AddPrize">新增獎項</Button>
             <div class="d-flex gap-2 mt-4"><Button Color="Color.Primary" Clicked="SaveAsync">儲存</Button><Button Color="Color.Secondary" Clicked="() => editing = null">取消</Button></div>
         </CardBody>
@@ -64,8 +69,9 @@
     protected override async Task OnInitializedAsync() => await ReloadAsync();
 
     private async Task ReloadAsync() => activities = await DonateLotteryActivityService.ListAsync();
-    private Task CreateAsync() { editing = new DonateLotteryActivity { StartsAtUtc = DateTimeOffset.UtcNow, EndsAtUtc = DateTimeOffset.UtcNow.AddDays(7), WinProbability = 1m, Prizes = [new()] }; return Task.CompletedTask; }
-    private void Edit(DonateLotteryActivity activity) => editing = new DonateLotteryActivity { Id = activity.Id, Name = activity.Name, Type = activity.Type, MinimumDonationAmount = activity.MinimumDonationAmount, StartsAtUtc = activity.StartsAtUtc, EndsAtUtc = activity.EndsAtUtc, WinProbability = activity.WinProbability, IsEnabled = activity.IsEnabled, Prizes = activity.Prizes.Select(prize => new DonateLotteryPrize { Id = prize.Id, Name = prize.Name, ImageUrl = prize.ImageUrl, Quantity = prize.Quantity, RemainingQuantity = prize.RemainingQuantity }).ToList() };
+    private decimal PrizeProbabilityTotal => editing?.Prizes.Sum(prize => prize.Probability) ?? 0m;
+    private Task CreateAsync() { editing = new DonateLotteryActivity { StartsAtUtc = DateTimeOffset.UtcNow, EndsAtUtc = DateTimeOffset.UtcNow.AddDays(7), WinProbability = 1m, Prizes = [new DonateLotteryPrize { Probability = 100m }] }; return Task.CompletedTask; }
+    private void Edit(DonateLotteryActivity activity) => editing = new DonateLotteryActivity { Id = activity.Id, Name = activity.Name, Type = activity.Type, Animation = activity.Animation, MinimumDonationAmount = activity.MinimumDonationAmount, StartsAtUtc = activity.StartsAtUtc, EndsAtUtc = activity.EndsAtUtc, WinProbability = activity.WinProbability, IsEnabled = activity.IsEnabled, Prizes = activity.Prizes.Select(prize => new DonateLotteryPrize { Id = prize.Id, Name = prize.Name, ImageUrl = prize.ImageUrl, Quantity = prize.Quantity, RemainingQuantity = prize.RemainingQuantity, Probability = prize.Probability, IsGrandPrize = prize.IsGrandPrize }).ToList() };
     private void AddPrize() => editing?.Prizes.Add(new DonateLotteryPrize());
     private async Task SaveAsync() { if (editing is null) return; try { await DonateLotteryActivityService.SaveAsync(editing); editing = null; await ReloadAsync(); await MessageService.Success("Donate 活動已儲存。"); } catch (Exception exception) { await MessageService.Error(exception.Message); } }
     private void OnStartDateChanged(ChangeEventArgs args) => SetDate(args.Value?.ToString(), isStart: true);

--- a/src/EasyLotteryWasm/Pages/DonateObs.razor
+++ b/src/EasyLotteryWasm/Pages/DonateObs.razor
@@ -1,4 +1,5 @@
 @page "/obs/donate/{ActivityId:int}"
+@layout EasyLotteryWasm.Layout.ObsLayout
 @using EasyLotteryDomain.Models.Config
 @using EasyLotteryDomain.Services
 @inject IEasyLotteryConfigStore ConfigStore
@@ -8,7 +9,11 @@
 <PageTitle>Donate 抽獎 OBS</PageTitle>
 
 <div class="donate-obs-shell">
-    @if (activity is null)
+    @if (isLoading)
+    {
+        <div class="donate-obs-empty">載入 Donate 活動中…</div>
+    }
+    else if (activity is null)
     {
         <div class="donate-obs-empty">找不到 Donate 活動</div>
     }
@@ -18,15 +23,24 @@
     }
     else
     {
-        <div class="donate-reveal" @key="latestWin.Id">
-            <div class="donate-reveal-label">DONATE WINNER</div>
+        <div class="donate-reveal @AnimationClass @(IsGrandPrize ? "grand-prize" : "")" @key="latestWin.Id">
+            <div class="donate-reveal-label">@(latestWin.IsWinning ? "DONATE RESULT" : "DONATE THANK YOU")</div>
+            <div class="draw-prop" aria-hidden="true">
+                @if (activity.Animation == DonateLotteryAnimation.Gacha) { <span class="chibi">🧒</span><span class="gacha-machine">◉</span> }
+                else if (activity.Animation == DonateLotteryAnimation.Garagara) { <span class="chibi">🧒</span><span class="garagara-drum">✦</span> }
+                else if (activity.Animation == DonateLotteryAnimation.MoneyBox) { <span class="coin">●</span><span class="money-box">▣</span><span class="fortune-slip">@latestWin.PrizeName</span> }
+                else { <span class="ichiban-ticket">一番賞</span> }
+            </div>
             @if (!string.IsNullOrWhiteSpace(latestWin.PrizeImageUrl) && !prizeImageFailed)
             {
                 <img class="donate-reveal-image" src="@latestWin.PrizeImageUrl" alt="@latestWin.PrizeName" @onerror="() => prizeImageFailed = true" />
             }
             else { <div class="donate-reveal-fallback">@latestWin.PrizeName</div> }
             <div class="donate-reveal-prize">@latestWin.PrizeName</div>
+            @if (IsGrandPrize) { <div class="grand-prize-banner">★ 最大獎 ★</div> }
             <div class="donate-reveal-donor">@latestWin.DonorName · NT$@latestWin.Amount:N0</div>
+            @if (!string.IsNullOrWhiteSpace(latestWin.DonationMessage)) { <div class="donate-reveal-message">「@latestWin.DonationMessage」</div> }
+            @if (!string.IsNullOrWhiteSpace(latestWin.PaymentMethod)) { <small>@latestWin.PaymentMethod</small> }
         </div>
     }
 </div>
@@ -35,10 +49,12 @@
 {
     <details class="donate-test-panel" open>
         <summary>Donate 測試模式</summary>
-        <p>只會建立測試抽獎紀錄，不會送出金流請求。</p>
+        <p>會以正式 Donate 相同的抽獎與 OBS 通知資料流建立測試紀錄，不會送出金流請求。</p>
         <input @bind="testDonorName" placeholder="贊助者名稱" aria-label="測試贊助者名稱" />
         <input type="number" min="1" @bind="testAmount" aria-label="測試贊助金額" />
-        <button @onclick="RunTestAsync">模擬 Donate 並抽獎</button>
+        <input @bind="testMessage" placeholder="留言" aria-label="測試留言" />
+        <input @bind="testPaymentMethod" placeholder="支付方式" aria-label="測試支付方式" />
+        <button @onclick="RunTestAsync">送出測試 Donate</button>
         @if (!string.IsNullOrWhiteSpace(testResult)) { <div role="status">@testResult</div> }
     </details>
 }
@@ -47,27 +63,56 @@
     .donate-obs-shell { min-height: 100vh; display:grid; place-items:center; background:transparent; color:white; font-family:system-ui,sans-serif; }
     .donate-obs-empty { text-align:center; padding:2rem 3rem; border-radius:1.5rem; background:rgba(8,10,26,.72); font-size:2rem; }
     .donate-reveal { text-align:center; padding:2rem; animation:donate-reveal .65s cubic-bezier(.16,1,.3,1); text-shadow:0 3px 18px #000; }
+    .draw-prop { min-height:7rem; display:flex; align-items:center; justify-content:center; gap:1rem; font-size:5rem; }
+    .chibi { display:inline-block; animation:chibi-crank .7s ease-in-out infinite alternate; transform-origin:bottom center; }
+    .gacha-machine { width:5rem; height:5rem; display:grid; place-items:center; border:10px solid #ff6b9d; border-radius:50% 50% 28% 28%; background:#7c3aed; box-shadow:inset 0 0 0 12px #fef3c7,0 10px 0 #4c1d95; animation:gacha-shake .25s linear infinite; }
+    .garagara-drum { width:6rem; height:6rem; display:grid; place-items:center; border:12px solid #b7791f; border-radius:50%; background:repeating-conic-gradient(#f7d794 0 12deg,#d69e2e 12deg 24deg); box-shadow:0 9px 0 #78350f; animation:drum-turn .45s linear infinite; }
+    .ichiban-ticket { display:inline-grid; place-items:center; width:12rem; height:5rem; color:#fff7d6; background:linear-gradient(135deg,#d90429,#7f1d1d); border:5px solid #fbbf24; font-size:2rem; font-weight:900; transform:rotate(-6deg); animation:ticket-reveal .8s ease-out; }
+    .money-box { color:#fbbf24; font-size:6rem; }
+    .coin { color:#fde047; animation:coin-drop 1s ease-in infinite; }
+    .fortune-slip { align-self:flex-end; padding:.6rem 1rem; color:#5b1d12; background:#fff7ed; font-size:1rem; font-weight:900; writing-mode:vertical-rl; animation:slip-pop .8s .45s both; }
+    .grand-prize { animation:grand-flash .8s ease-in-out infinite alternate; }
+    .grand-prize-banner { color:#fff7d6; font-size:clamp(1.2rem,3vw,2.3rem); font-weight:950; letter-spacing:.2em; }
     .donate-reveal-label { color:#ffd166; font-weight:900; letter-spacing:.22em; margin-bottom:1rem; }
     .donate-reveal-image { max-width:min(68vw,640px); max-height:62vh; object-fit:contain; border:6px solid #ffd166; border-radius:1.25rem; box-shadow:0 0 45px rgba(255,209,102,.8); }
     .donate-reveal-fallback { width:min(68vw,640px); aspect-ratio:1; display:grid; place-items:center; border:6px solid #ffd166; border-radius:1.25rem; background:linear-gradient(135deg,#6d28d9,#f59e0b); font-size:clamp(2rem,7vw,5rem); font-weight:900; }
     .donate-reveal-prize { font-size:clamp(2rem,6vw,4.5rem); font-weight:900; margin-top:1rem; }
     .donate-reveal-donor { font-size:clamp(1.15rem,3vw,2rem); }
+    .donate-reveal-message { margin-top:.5rem; font-size:clamp(1rem,2.4vw,1.6rem); }
     .donate-test-panel { position:fixed; right:1rem; bottom:1rem; z-index:10; max-width:24rem; padding:1rem; border-radius:.75rem; background:#fff; color:#172033; box-shadow:0 8px 30px rgba(0,0,0,.35); }
     .donate-test-panel input { display:block; width:100%; margin:.5rem 0; padding:.45rem; }
     .donate-test-panel button { padding:.45rem .75rem; border:0; border-radius:.35rem; background:#2563eb; color:#fff; }
     @@keyframes donate-reveal { from { opacity:0; transform:scale(.45) rotate(-4deg); } to { opacity:1; transform:scale(1) rotate(0); } }
+    @@keyframes chibi-crank { to { transform:rotate(-16deg) translateY(5px); } }
+    @@keyframes gacha-shake { 50% { transform:translateX(5px) rotate(4deg); } }
+    @@keyframes drum-turn { to { transform:rotate(360deg); } }
+    @@keyframes ticket-reveal { from { transform:scale(.2) rotate(25deg); } to { transform:scale(1) rotate(-6deg); } }
+    @@keyframes coin-drop { from { transform:translateY(-4rem); opacity:0; } 30%,80% { opacity:1; } to { transform:translateY(1rem); opacity:0; } }
+    @@keyframes slip-pop { from { transform:translateY(4rem) scale(.4); opacity:0; } to { transform:translateY(0) scale(1); opacity:1; } }
+    @@keyframes grand-flash { from { filter:drop-shadow(0 0 8px #fbbf24); } to { filter:drop-shadow(0 0 35px #fef08a); transform:scale(1.04); } }
 </style>
 
 @code {
     [Parameter] public int ActivityId { get; set; }
     private DonateLotteryActivity? activity;
     private DonateLotteryDrawRecord? latestWin;
+    private bool isLoading = true;
     private int? displayedWinId;
     private bool prizeImageFailed;
     private bool testMode;
     private string testDonorName = "測試贊助者";
     private decimal testAmount = 100m;
+    private string testMessage = "這是一則 OBS Donate 測試通知";
+    private string testPaymentMethod = "測試付款";
     private string testResult = "";
+    private string AnimationClass => activity?.Animation switch
+    {
+        DonateLotteryAnimation.Gacha => "animation-gacha",
+        DonateLotteryAnimation.Garagara => "animation-garagara",
+        DonateLotteryAnimation.MoneyBox => "animation-money-box",
+        _ => "animation-ichiban"
+    };
+    private bool IsGrandPrize => latestWin is not null && activity?.Prizes.Any(prize => prize.IsGrandPrize && string.Equals(prize.Name, latestWin.PrizeName, StringComparison.Ordinal)) == true;
     private readonly CancellationTokenSource cancellation = new();
 
     protected override async Task OnInitializedAsync()
@@ -81,9 +126,9 @@
     {
         var document = await ConfigStore.LoadAsync(cancellation.Token);
         var testId = $"obs-test:{ActivityId}:{Guid.NewGuid():N}";
-        var result = DonateLotteryEngine.Process(document, testId, testDonorName, testAmount, DateTimeOffset.UtcNow);
+        var result = DonateLotteryEngine.Process(document, testId, testDonorName, testAmount, DateTimeOffset.UtcNow, donationMessage: testMessage, paymentMethod: testPaymentMethod);
         await ConfigStore.SaveAsync(document, cancellation.Token);
-        testResult = result.Wins.Count == 0 ? "測試完成：未中獎（請確認活動是否啟用、期間、門檻與庫存）。" : $"測試完成：抽中 {string.Join("、", result.Wins.Select(win => win.PrizeName))}";
+        testResult = result.Wins.Count == 0 ? "測試完成：沒有符合條件的活動。" : $"測試通知已送出（{testPaymentMethod}）：{testDonorName} NT${testAmount:N0}，結果 {string.Join("、", result.Wins.Select(win => win.PrizeName))}。留言：{testMessage}";
         await RefreshAsync();
     }
 
@@ -104,6 +149,7 @@
             displayedWinId = latestWin?.Id;
             prizeImageFailed = false;
         }
+        isLoading = false;
     }
 
     public ValueTask DisposeAsync() { cancellation.Cancel(); cancellation.Dispose(); return ValueTask.CompletedTask; }

--- a/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
+++ b/src/EasyLotteryWasm/Pages/Overtime/OvertimeOverlay.razor
@@ -23,6 +23,9 @@ else
 {
     <div class="overtime-overlay">
         <div class="overtime-shell">
+            <div class="overtime-obs-controls mb-2">
+                <Button Color="Color.Secondary" Clicked="SendOvertimeTestAsync">測試贊助通知</Button>
+            </div>
             @if (IsIdle)
             {
                 <div class="overtime-standby-panel">
@@ -1261,6 +1264,22 @@ else
             SessionEndAtUtc = SessionEndAtUtc
         });
 
+        await ReloadEventsAsync();
+        StateHasChanged();
+    }
+
+    private async Task SendOvertimeTestAsync()
+    {
+        await OvertimeFeedClient.PostEcpayDonateAsync(new OvertimeSupportEvent
+        {
+            DisplayName = "測試贊助者",
+            Message = "加班台 OBS 測試通知",
+            Amount = settings.DemoEcpayAmount > 0 ? settings.DemoEcpayAmount : 100m,
+            AmountDisplay = "NT$100",
+            Currency = "TWD",
+            ExternalId = $"obs-overtime-test:{Guid.NewGuid():N}",
+            OccurredAtUtc = DateTimeOffset.UtcNow
+        });
         await ReloadEventsAsync();
         StateHasChanged();
     }

--- a/src/EasyLotteryWasm/Services/YamlEasyLotteryConfigStore.cs
+++ b/src/EasyLotteryWasm/Services/YamlEasyLotteryConfigStore.cs
@@ -226,6 +226,28 @@ namespace EasyLotteryWasm.Services
                 NormalizeActivityResult(activityResult);
             }
 
+            foreach (var activity in document.DonateLotteryActivities)
+            {
+                activity.Name ??= "";
+                activity.Prizes ??= [];
+                foreach (var prize in activity.Prizes)
+                {
+                    prize.Name ??= "";
+                    prize.ImageUrl ??= "";
+                    prize.Probability = Math.Clamp(prize.Probability, 0m, 100m);
+                }
+            }
+
+            foreach (var draw in document.DonateLotteryDrawRecords)
+            {
+                draw.PaymentExternalId ??= "";
+                draw.DonorName = string.IsNullOrWhiteSpace(draw.DonorName) ? "匿名贊助者" : draw.DonorName.Trim();
+                draw.PrizeName ??= "";
+                draw.PrizeImageUrl ??= "";
+                draw.DonationMessage ??= "";
+                draw.PaymentMethod ??= "";
+            }
+
             foreach (var preset in document.DrawingRulePresets)
             {
                 NormalizeDrawingRulePreset(preset);

--- a/tests/EasyLotteryDomainTests/Services/DonateLotteryActivityServiceTests.cs
+++ b/tests/EasyLotteryDomainTests/Services/DonateLotteryActivityServiceTests.cs
@@ -1,0 +1,30 @@
+using EasyLotteryDomain.Models.Config;
+using EasyLotteryDomain.Services;
+using EasyLotteryDomainTests.Helpers;
+
+namespace EasyLotteryDomainTests.Services;
+
+[TestClass]
+public sealed class DonateLotteryActivityServiceTests
+{
+    [TestMethod]
+    public void SaveAsync_RejectsPrizeProbabilitiesOverOneHundredPercent()
+    {
+        var service = new DonateLotteryActivityService(new InMemoryEasyLotteryConfigStore());
+        var activity = new DonateLotteryActivity
+        {
+            Name = "測試活動",
+            StartsAtUtc = DateTimeOffset.UtcNow,
+            EndsAtUtc = DateTimeOffset.UtcNow.AddDays(1),
+            Prizes =
+            [
+                new DonateLotteryPrize { Name = "A", Probability = 60m },
+                new DonateLotteryPrize { Name = "B", Probability = 41m }
+            ]
+        };
+
+        var exception = Assert.ThrowsExactly<InvalidOperationException>(() => service.SaveAsync(activity).GetAwaiter().GetResult());
+
+        StringAssert.Contains(exception.Message, "不可超過 100%");
+    }
+}

--- a/tests/EasyLotteryDomainTests/Services/DonateLotteryEngineTests.cs
+++ b/tests/EasyLotteryDomainTests/Services/DonateLotteryEngineTests.cs
@@ -45,6 +45,32 @@ public sealed class DonateLotteryEngineTests
         Assert.AreEqual(0, result.Wins.Count);
     }
 
+    [TestMethod]
+    public void Process_UsesPrizeProbabilityAndStoresThankYouForTheRemainingChance()
+    {
+        var document = ActiveDocument();
+        document.DonateLotteryActivities[0].Prizes[0].Probability = 35m;
+
+        var miss = DonateLotteryEngine.Process(document, "payment-miss", "Alice", 100m, DateTimeOffset.UtcNow, () => .5d);
+        var win = DonateLotteryEngine.Process(document, "payment-win", "Alice", 100m, DateTimeOffset.UtcNow, () => .2d);
+
+        Assert.AreEqual(0, miss.Wins.Count);
+        Assert.AreEqual("銘謝惠顧", document.DonateLotteryDrawRecords[0].PrizeName);
+        Assert.IsFalse(document.DonateLotteryDrawRecords[0].IsWinning);
+        Assert.AreEqual(1, win.Wins.Count);
+        Assert.AreEqual("獎項", win.Wins[0].PrizeName);
+    }
+
+    [TestMethod]
+    public void Process_PersistsDonateNotificationDetails()
+    {
+        var document = ActiveDocument();
+        var result = DonateLotteryEngine.Process(document, "payment-details", "Alice", 100m, DateTimeOffset.UtcNow, () => 0d, "加油！", "測試付款");
+
+        Assert.AreEqual("加油！", result.Wins[0].DonationMessage);
+        Assert.AreEqual("測試付款", result.Wins[0].PaymentMethod);
+    }
+
     private static EasyLotteryConfigDocument ActiveDocument() => new()
     {
         DonateLotteryActivities =


### PR DESCRIPTION
## 摘要

完成 #112 的 OBS Donate 活動體驗與機率抽獎基礎：修正 Donate OBS 路由／載入狀態，新增 Donate 與加班台的 OBS 測試入口，並導入可設定的獎項機率、最大獎與動畫效果。

Closes #112

## 變更內容

- Donate OBS 改用 OBS 專用版型，初載顯示載入狀態，不再先顯示找不到活動。
- Donate 測試可輸入名稱、金額、留言與支付方式；這些內容會寫入抽獎通知紀錄並呈現在 OBS。
- 加班台 OBS 新增測試贊助通知按鈕。
- 活動獎項可設定個別機率、最大獎與抽獎動畫；機率總和不可超過 100%，餘額固定為銘謝惠顧。
- 抽獎引擎記錄所有抽取結果，包含銘謝惠顧；既有未設定機率的活動保留舊版抽獎邏輯。
- 實作一番賞、扭蛋、日式滾筒、塞錢箱／詩籤四種純前端動畫，以及最大獎閃耀效果。

## 驗證

- `dotnet test EasyLottery.generated.sln --no-restore`
- 通過：87 Domain tests、6 API tests。

## 風險與後續

- 動畫為不依賴外部素材的 CSS／Unicode 初版，後續可替換為正式美術資產。
- Draft PR 保留給 OBS 實機驗證與視覺調整。