### PR TITLE
fix: simplify donate prize probability

### DIFF
--- a/src/EasyLotteryDomain/Models/Config/DonateLotteryActivity.cs
+++ b/src/EasyLotteryDomain/Models/Config/DonateLotteryActivity.cs
@@ -22,7 +22,6 @@ public sealed class DonateLotteryActivity
     public decimal MinimumDonationAmount { get; set; } = 100m;
     public DateTimeOffset StartsAtUtc { get; set; } = DateTimeOffset.UtcNow;
     public DateTimeOffset EndsAtUtc { get; set; } = DateTimeOffset.UtcNow.AddDays(1);
-    public decimal WinProbability { get; set; } = 1m;
     public DonateLotteryAnimation Animation { get; set; } = DonateLotteryAnimation.IchibanKuji;
     public bool IsEnabled { get; set; }
     public List<DonateLotteryPrize> Prizes { get; set; } = [];

--- a/src/EasyLotteryDomain/Services/DonateLotteryEngine.cs
+++ b/src/EasyLotteryDomain/Services/DonateLotteryEngine.cs
@@ -61,14 +61,6 @@ public static class DonateLotteryEngine
     private static DonateLotteryPrize? SelectPrize(DonateLotteryActivity activity, Func<double> random)
     {
         var prizes = activity.Prizes.Where(item => item.RemainingQuantity > 0).ToList();
-        // Existing configurations predate per-prize probabilities. Keep them working until
-        // they are saved through the new editor, then use the explicit percentages below.
-        if (prizes.All(item => item.Probability <= 0m))
-        {
-            if (random() >= (double)Math.Clamp(activity.WinProbability, 0m, 1m)) return null;
-            return prizes.Count == 0 ? null : prizes[Math.Min((int)(random() * prizes.Count), prizes.Count - 1)];
-        }
-
         var roll = (decimal)random() * 100m;
         var cursor = 0m;
         foreach (var prize in prizes)

--- a/src/EasyLotteryWasm/Pages/DonateActivities.razor
+++ b/src/EasyLotteryWasm/Pages/DonateActivities.razor
@@ -27,7 +27,6 @@
                 <div class="col-md-3"><Field><FieldLabel>抽獎動畫</FieldLabel><Select TValue="DonateLotteryAnimation" @bind-SelectedValue="editing.Animation"><SelectItem Value="DonateLotteryAnimation.IchibanKuji">一番賞</SelectItem><SelectItem Value="DonateLotteryAnimation.Gacha">扭蛋</SelectItem><SelectItem Value="DonateLotteryAnimation.Garagara">日式滾筒</SelectItem><SelectItem Value="DonateLotteryAnimation.MoneyBox">塞錢箱／詩籤</SelectItem></Select></Field></div>
                 <div class="col-md-4"><Field><FieldLabel>開始時間（本地時區）</FieldLabel><input class="form-control" type="datetime-local" value="@StartDateText" @onchange="OnStartDateChanged" /></Field></div>
                 <div class="col-md-4"><Field><FieldLabel>結束時間（本地時區）</FieldLabel><input class="form-control" type="datetime-local" value="@EndDateText" @onchange="OnEndDateChanged" /></Field></div>
-                <div class="col-md-2"><Field><FieldLabel>中獎機率</FieldLabel><NumericInput TValue="decimal" @bind-Value="editing.WinProbability" /></Field></div>
                 <div class="col-md-2"><Field><FieldLabel>啟用</FieldLabel><Switch TValue="bool" @bind-Value="editing.IsEnabled" /></Field></div>
             </div>
             <h5 class="mt-4">獎項</h5>
@@ -43,9 +42,15 @@
                     <div class="col-md-2"><Button Color="Color.Danger" Size="Size.Small" Clicked="() => editing.Prizes.Remove(prize)">移除</Button></div>
                 </div>
             }
-            <div class="small text-muted">目前合計：@PrizeProbabilityTotal.ToString("0.##")%　／　銘謝惠顧：@Math.Max(0m, 100m - PrizeProbabilityTotal).ToString("0.##")%</div>
+            <div class="alert @(ProbabilityTotalExceeded ? "alert-danger" : "alert-info") py-2 mb-2" role="status">
+                目前獎項機率合計：@PrizeProbabilityTotal.ToString("0.##")%　／　銘謝惠顧：@Math.Max(0m, 100m - PrizeProbabilityTotal).ToString("0.##")%
+                @if (ProbabilityTotalExceeded)
+                {
+                    <strong class="ms-2">機率總和不可超過 100%，請調整獎項機率後再儲存。</strong>
+                }
+            </div>
             <Button Color="Color.Secondary" Size="Size.Small" Clicked="AddPrize">新增獎項</Button>
-            <div class="d-flex gap-2 mt-4"><Button Color="Color.Primary" Clicked="SaveAsync">儲存</Button><Button Color="Color.Secondary" Clicked="() => editing = null">取消</Button></div>
+            <div class="d-flex gap-2 mt-4"><Button Color="Color.Primary" Clicked="SaveAsync" Disabled="ProbabilityTotalExceeded">儲存</Button><Button Color="Color.Secondary" Clicked="() => editing = null">取消</Button></div>
         </CardBody>
     </Card>
 }
@@ -70,8 +75,9 @@
 
     private async Task ReloadAsync() => activities = await DonateLotteryActivityService.ListAsync();
     private decimal PrizeProbabilityTotal => editing?.Prizes.Sum(prize => prize.Probability) ?? 0m;
-    private Task CreateAsync() { editing = new DonateLotteryActivity { StartsAtUtc = DateTimeOffset.UtcNow, EndsAtUtc = DateTimeOffset.UtcNow.AddDays(7), WinProbability = 1m, Prizes = [new DonateLotteryPrize { Probability = 100m }] }; return Task.CompletedTask; }
-    private void Edit(DonateLotteryActivity activity) => editing = new DonateLotteryActivity { Id = activity.Id, Name = activity.Name, Type = activity.Type, Animation = activity.Animation, MinimumDonationAmount = activity.MinimumDonationAmount, StartsAtUtc = activity.StartsAtUtc, EndsAtUtc = activity.EndsAtUtc, WinProbability = activity.WinProbability, IsEnabled = activity.IsEnabled, Prizes = activity.Prizes.Select(prize => new DonateLotteryPrize { Id = prize.Id, Name = prize.Name, ImageUrl = prize.ImageUrl, Quantity = prize.Quantity, RemainingQuantity = prize.RemainingQuantity, Probability = prize.Probability, IsGrandPrize = prize.IsGrandPrize }).ToList() };
+    private bool ProbabilityTotalExceeded => PrizeProbabilityTotal > 100m;
+    private Task CreateAsync() { editing = new DonateLotteryActivity { StartsAtUtc = DateTimeOffset.UtcNow, EndsAtUtc = DateTimeOffset.UtcNow.AddDays(7), Prizes = [new DonateLotteryPrize { Probability = 100m }] }; return Task.CompletedTask; }
+    private void Edit(DonateLotteryActivity activity) => editing = new DonateLotteryActivity { Id = activity.Id, Name = activity.Name, Type = activity.Type, Animation = activity.Animation, MinimumDonationAmount = activity.MinimumDonationAmount, StartsAtUtc = activity.StartsAtUtc, EndsAtUtc = activity.EndsAtUtc, IsEnabled = activity.IsEnabled, Prizes = activity.Prizes.Select(prize => new DonateLotteryPrize { Id = prize.Id, Name = prize.Name, ImageUrl = prize.ImageUrl, Quantity = prize.Quantity, RemainingQuantity = prize.RemainingQuantity, Probability = prize.Probability, IsGrandPrize = prize.IsGrandPrize }).ToList() };
     private void AddPrize() => editing?.Prizes.Add(new DonateLotteryPrize());
     private async Task SaveAsync() { if (editing is null) return; try { await DonateLotteryActivityService.SaveAsync(editing); editing = null; await ReloadAsync(); await MessageService.Success("Donate 活動已儲存。"); } catch (Exception exception) { await MessageService.Error(exception.Message); } }
     private void OnStartDateChanged(ChangeEventArgs args) => SetDate(args.Value?.ToString(), isStart: true);

--- a/tests/EasyLotteryDomainTests/Services/DonateLotteryEngineTests.cs
+++ b/tests/EasyLotteryDomainTests/Services/DonateLotteryEngineTests.cs
@@ -84,8 +84,7 @@ public sealed class DonateLotteryEngineTests
                 StartsAtUtc = DateTimeOffset.UtcNow.AddHours(-1),
                 EndsAtUtc = DateTimeOffset.UtcNow.AddHours(1),
                 IsEnabled = true,
-                WinProbability = 1m,
-                Prizes = [new DonateLotteryPrize { Id = 1, Name = "獎項", RemainingQuantity = 2, Quantity = 2 }]
+                Prizes = [new DonateLotteryPrize { Id = 1, Name = "獎項", RemainingQuantity = 2, Quantity = 2, Probability = 100m }]
             }
         ]
     };


### PR DESCRIPTION
## 摘要

修正 #114 的 Donate 活動機率設定：只有獎項可設定機率，並在設定頁即時顯示總和與銘謝惠顧餘額。

Closes #114

## 變更內容

- 移除活動層級 `WinProbability` 欄位與抽獎引擎中的舊版判定。
- 抽獎僅依有庫存的獎項機率決定；未分配的機率為銘謝惠顧。
- 機率總和超過 100% 時顯示錯誤提示並停用儲存。
- 保留服務層驗證，防止繞過 UI 儲存超額機率。
- YAML 讀取器會忽略舊版未對應欄位，因此舊設定可安全載入。

## 驗證

- `dotnet test EasyLottery.generated.sln --no-restore`
- 通過：87 Domain tests、6 API tests。