### PR TITLE
docs: add agent PR instructions

### DIFF
--- a/.agent/INSTRUCTIONS.md
+++ b/.agent/INSTRUCTIONS.md
@@ -1,0 +1,6 @@
+# EasyLottery agent instructions
+
+## Pull requests
+
+- Create pull requests as **Ready for review** by default.
+- Create a Draft pull request only when the user explicitly asks for a draft.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent instructions
+
+Read [`.agent/INSTRUCTIONS.md`](.agent/INSTRUCTIONS.md) before starting repository work.


### PR DESCRIPTION
## 摘要

新增專案 agent 指引入口，明確規定 PR 預設為 Ready for review，僅在使用者明確要求時才建立 Draft。

## 變更

- 根目錄 `AGENTS.md` 指向 `.agent/INSTRUCTIONS.md`。
- `.agent/INSTRUCTIONS.md` 記錄 PR 建立規則。

## 驗證

- `git diff --check`