### PR TITLE
fix: guide unauthorized settings access

### DIFF
--- a/src/EasyLotteryWasm/Pages/DonateActivities.razor
+++ b/src/EasyLotteryWasm/Pages/DonateActivities.razor
@@ -4,6 +4,7 @@
 
 @inject DonateLotteryActivityService DonateLotteryActivityService
 @inject IMessageService MessageService
+@inject IJSRuntime JSRuntime
 
 <PageTitle>Donate 活動</PageTitle>
 
@@ -11,11 +12,19 @@
     <CardHeader><CardTitle>Donate 抽獎活動</CardTitle></CardHeader>
     <CardBody>
         <CardText>贊助金額每達到最低門檻即可獲得一次抽獎機會。獎項用盡後不會重複抽出。</CardText>
-        <Button Color="Color.Primary" Clicked="CreateAsync">新增活動</Button>
+        <Button Color="Color.Primary" Clicked="CreateAsync" Disabled="requiresAdminToken">新增活動</Button>
     </CardBody>
 </Card>
 
-@if (editing is not null)
+@if (requiresAdminToken)
+{
+    <div class="alert alert-warning" role="alert">
+        無法讀取共享活動設定：此瀏覽器尚未取得管理存取權杖。
+        請前往 <a href="system/access">管理存取</a> 輸入伺服器設定的 <code>Settings__AdminToken</code> 後重新整理。
+    </div>
+}
+
+@if (editing is not null && !requiresAdminToken)
 {
     <Card class="mb-4">
         <CardHeader><CardTitle>@(editing.Id == 0 ? "新增" : "編輯") Donate 活動</CardTitle></CardHeader>
@@ -55,6 +64,8 @@
     </Card>
 }
 
+@if (!requiresAdminToken)
+{
 <table class="table align-middle">
     <thead><tr><th>活動</th><th>期間</th><th>最低贊助</th><th>獎項庫存</th><th>狀態</th><th></th></tr></thead>
     <tbody>
@@ -64,14 +75,21 @@
     }
     </tbody>
 </table>
+}
 
 @code {
     private IReadOnlyList<DonateLotteryActivity> activities = [];
     private DonateLotteryActivity? editing;
+    private bool requiresAdminToken;
     private string StartDateText => editing?.StartsAtUtc.LocalDateTime.ToString("yyyy-MM-ddTHH:mm") ?? "";
     private string EndDateText => editing?.EndsAtUtc.LocalDateTime.ToString("yyyy-MM-ddTHH:mm") ?? "";
 
-    protected override async Task OnInitializedAsync() => await ReloadAsync();
+    protected override async Task OnInitializedAsync()
+    {
+        await ReloadAsync();
+        requiresAdminToken = await JSRuntime.InvokeAsync<bool>("easyLotteryConfig.requiresAdminToken");
+        if (requiresAdminToken) activities = [];
+    }
 
     private async Task ReloadAsync() => activities = await DonateLotteryActivityService.ListAsync();
     private decimal PrizeProbabilityTotal => editing?.Prizes.Sum(prize => prize.Probability) ?? 0m;

--- a/src/EasyLotteryWasm/wwwroot/js/configStorage.js
+++ b/src/EasyLotteryWasm/wwwroot/js/configStorage.js
@@ -8,6 +8,7 @@
     const adminTokenKey = "easy-lottery.admin-token";
     let memoryFallback = "";
     let nextRemoteAttemptAt = 0;
+    let authorizationRequired = false;
 
     function getSafeContent(content) {
         return content == null ? "" : content;
@@ -37,14 +38,21 @@
                 const response = await fetch(remoteConfigUrl, { cache: "no-store", headers: getAdminHeaders() });
                 if (response.ok) {
                     nextRemoteAttemptAt = 0;
+                    authorizationRequired = false;
                     return cacheFallback(await response.text());
                 }
+
+                // A reachable web host explicitly rejected the request. Preserve this
+                // distinction from an offline standalone WASM server so the UI can
+                // guide the user instead of displaying an empty fallback as settings.
+                authorizationRequired = response.status === 401;
 
                 // The standalone WASM dev server has no YAML API. Avoid generating
                 // a 404 every overlay refresh while retaining the local fallback.
                 nextRemoteAttemptAt = now + 30_000;
             }
         } catch {
+            authorizationRequired = false;
             nextRemoteAttemptAt = now + 30_000;
         }
 
@@ -71,8 +79,10 @@
             });
 
             if (!response.ok) {
+                authorizationRequired = response.status === 401;
                 throw new Error(`Unable to save shared YAML configuration (${response.status}).`);
             }
+            authorizationRequired = false;
         } catch {
             // The browser cache above is the offline fallback.
         }
@@ -83,5 +93,6 @@
         write,
         setAdminToken: (token) => window.sessionStorage.setItem(adminTokenKey, token || ""),
         getAdminToken: () => window.sessionStorage.getItem(adminTokenKey) || "",
+        requiresAdminToken: () => authorizationRequired,
     };
 })();


### PR DESCRIPTION
## 摘要

修正設定 API 回傳 401 時，Donate 活動頁靜默顯示 local fallback／預設資料的問題。

Closes #119

## 變更

- 設定橋接層明確區分 401 與離線／404 fallback。
- 收到 401 時，Donate 活動頁顯示管理權杖設定導引。
- 未授權時隱藏不可信的 fallback 活動資料並停用新增活動。

## 驗證

- `dotnet test EasyLottery.generated.sln --no-restore`
- 通過：87 Domain tests、6 API tests。