### PR TITLE
feat: allow deleting donate activities

### DIFF
--- a/src/EasyLotteryDomain/Services/DonateLotteryActivityService.cs
+++ b/src/EasyLotteryDomain/Services/DonateLotteryActivityService.cs
@@ -50,4 +50,15 @@ public sealed class DonateLotteryActivityService
         await _configStore.SaveAsync(document, cancellationToken);
         return activity;
     }
+
+    public async Task DeleteAsync(int activityId, CancellationToken cancellationToken = default)
+    {
+        var document = await _configStore.LoadAsync(cancellationToken);
+        var removed = document.DonateLotteryActivities.RemoveAll(activity => activity.Id == activityId);
+        if (removed == 0) throw new InvalidOperationException("找不到 Donate 活動。");
+
+        // Keep historical draw records for reports and audit trails. They retain
+        // the activity ID even after the editable activity definition is gone.
+        await _configStore.SaveAsync(document, cancellationToken);
+    }
 }

--- a/src/EasyLotteryWasm/Pages/DonateActivities.razor
+++ b/src/EasyLotteryWasm/Pages/DonateActivities.razor
@@ -71,7 +71,7 @@
     <tbody>
     @foreach (var activity in activities)
     {
-        <tr><td>@activity.Name <small class="text-muted">@activity.Type</small></td><td>@activity.StartsAtUtc.LocalDateTime:g — @activity.EndsAtUtc.LocalDateTime:g</td><td>NT$@activity.MinimumDonationAmount</td><td>@activity.Prizes.Sum(prize => prize.RemainingQuantity) / @activity.Prizes.Sum(prize => prize.Quantity)</td><td>@(activity.IsEnabled ? "啟用" : "停用")</td><td class="d-flex gap-2"><Button Color="Color.Secondary" Size="Size.Small" Clicked="() => Edit(activity)">編輯</Button>@if (activity.IsEnabled) { <a class="btn btn-outline-primary btn-sm" href="@($"/obs/donate/{activity.Id}")" target="_blank" rel="noopener noreferrer">開啟 OBS URL</a> } else { <Button Color="Color.Secondary" Size="Size.Small" Disabled>開啟 OBS URL</Button> }</td></tr>
+        <tr><td>@activity.Name <small class="text-muted">@activity.Type</small></td><td>@activity.StartsAtUtc.LocalDateTime:g — @activity.EndsAtUtc.LocalDateTime:g</td><td>NT$@activity.MinimumDonationAmount</td><td>@activity.Prizes.Sum(prize => prize.RemainingQuantity) / @activity.Prizes.Sum(prize => prize.Quantity)</td><td>@(activity.IsEnabled ? "啟用" : "停用")</td><td class="d-flex gap-2"><Button Color="Color.Secondary" Size="Size.Small" Clicked="() => Edit(activity)">編輯</Button>@if (activity.IsEnabled) { <a class="btn btn-outline-primary btn-sm" href="@($"/obs/donate/{activity.Id}")" target="_blank" rel="noopener noreferrer">開啟 OBS URL</a> } else { <Button Color="Color.Secondary" Size="Size.Small" Disabled>開啟 OBS URL</Button> }<Button Color="Color.Danger" Size="Size.Small" Clicked="() => DeleteAsync(activity)">刪除</Button></td></tr>
     }
     </tbody>
 </table>
@@ -98,6 +98,19 @@
     private void Edit(DonateLotteryActivity activity) => editing = new DonateLotteryActivity { Id = activity.Id, Name = activity.Name, Type = activity.Type, Animation = activity.Animation, MinimumDonationAmount = activity.MinimumDonationAmount, StartsAtUtc = activity.StartsAtUtc, EndsAtUtc = activity.EndsAtUtc, IsEnabled = activity.IsEnabled, Prizes = activity.Prizes.Select(prize => new DonateLotteryPrize { Id = prize.Id, Name = prize.Name, ImageUrl = prize.ImageUrl, Quantity = prize.Quantity, RemainingQuantity = prize.RemainingQuantity, Probability = prize.Probability, IsGrandPrize = prize.IsGrandPrize }).ToList() };
     private void AddPrize() => editing?.Prizes.Add(new DonateLotteryPrize());
     private async Task SaveAsync() { if (editing is null) return; try { await DonateLotteryActivityService.SaveAsync(editing); editing = null; await ReloadAsync(); await MessageService.Success("Donate 活動已儲存。"); } catch (Exception exception) { await MessageService.Error(exception.Message); } }
+    private async Task DeleteAsync(DonateLotteryActivity activity)
+    {
+        var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"確定要刪除「{activity.Name}」嗎？活動設定與獎項會被移除，但既有抽獎紀錄會保留。");
+        if (!confirmed) return;
+        try
+        {
+            await DonateLotteryActivityService.DeleteAsync(activity.Id);
+            if (editing?.Id == activity.Id) editing = null;
+            await ReloadAsync();
+            await MessageService.Success("Donate 活動已刪除，既有抽獎紀錄已保留。");
+        }
+        catch (Exception exception) { await MessageService.Error(exception.Message); }
+    }
     private void OnStartDateChanged(ChangeEventArgs args) => SetDate(args.Value?.ToString(), isStart: true);
     private void OnEndDateChanged(ChangeEventArgs args) => SetDate(args.Value?.ToString(), isStart: false);
     private void SetDate(string? value, bool isStart) { if (editing is null || !DateTime.TryParse(value, out var date)) return; var instant = new DateTimeOffset(DateTime.SpecifyKind(date, DateTimeKind.Local)).ToUniversalTime(); if (isStart) editing.StartsAtUtc = instant; else editing.EndsAtUtc = instant; }

--- a/tests/EasyLotteryDomainTests/Services/DonateLotteryActivityServiceTests.cs
+++ b/tests/EasyLotteryDomainTests/Services/DonateLotteryActivityServiceTests.cs
@@ -27,4 +27,21 @@ public sealed class DonateLotteryActivityServiceTests
 
         StringAssert.Contains(exception.Message, "不可超過 100%");
     }
+
+    [TestMethod]
+    public async Task DeleteAsync_RemovesActivityButPreservesDrawHistory()
+    {
+        var store = new InMemoryEasyLotteryConfigStore();
+        var document = await store.LoadAsync();
+        document.DonateLotteryActivities.Add(new DonateLotteryActivity { Id = 7, Name = "待刪除活動" });
+        document.DonateLotteryDrawRecords.Add(new DonateLotteryDrawRecord { Id = 3, ActivityId = 7, PrizeName = "歷史獎項" });
+        await store.SaveAsync(document);
+        var service = new DonateLotteryActivityService(store);
+
+        await service.DeleteAsync(7);
+
+        var saved = await store.LoadAsync();
+        Assert.IsFalse(saved.DonateLotteryActivities.Any(activity => activity.Id == 7));
+        Assert.IsTrue(saved.DonateLotteryDrawRecords.Any(record => record.ActivityId == 7));
+    }
 }


### PR DESCRIPTION
## 摘要

新增 Donate 活動的刪除操作。

Closes #121

## 變更

- 活動列表新增刪除按鈕與確認提示。
- 刪除活動與獎項設定。
- 保留既有 Donate 抽獎紀錄，維持報表與稽核可追溯性。

## 驗證

- `dotnet test EasyLottery.generated.sln --no-restore`
- 通過：88 Domain tests、6 API tests。