### PR TITLE
refactor: define split yaml repository documents

### DIFF
--- a/src/EasyLotteryDomain/Models/Config/YamlRepositoryDocuments.cs
+++ b/src/EasyLotteryDomain/Models/Config/YamlRepositoryDocuments.cs
@@ -1,0 +1,33 @@
+using EasyLotteryDomain.Models.Entities;
+
+namespace EasyLotteryDomain.Models.Config;
+
+public sealed class SettingsYamlDocument
+{
+    public int ConfigVersion { get; set; } = 1;
+    public LotterySystemSettings SystemSettings { get; set; } = new();
+    public LotteryIdSequence IdSequence { get; set; } = new();
+    public List<DrawingRulePreset> DrawingRulePresets { get; set; } = [];
+    public DrawingRuleSettings DrawingRules { get; set; } = new();
+    public VisualStyleSettings VisualStyle { get; set; } = new();
+    public ObsLayoutSettings ObsLayout { get; set; } = new();
+    public SoundCueSettings SoundCue { get; set; } = new();
+    public OvertimeOverlaySettings OvertimeOverlay { get; set; } = new();
+    public List<ChangeAuditRecord> AuditRecords { get; set; } = [];
+}
+
+public sealed class ActivitiesYamlDocument
+{
+    public LotteryIdSequence IdSequence { get; set; } = new();
+    public List<PokeTemplate> PokeTemplates { get; set; } = [];
+    public List<RouletteTemplate> RouletteTemplates { get; set; } = [];
+    public List<DonateLotteryActivity> DonateLotteryActivities { get; set; } = [];
+}
+
+public sealed class ActivityResultsYamlDocument
+{
+    public LotteryIdSequence IdSequence { get; set; } = new();
+    public List<ActivityResultRecord> ActivityResults { get; set; } = [];
+    public List<DonateLotteryDrawRecord> DonateLotteryDrawRecords { get; set; } = [];
+    public List<string> ProcessedDonatePaymentIds { get; set; } = [];
+}

--- a/src/EasyLotteryDomain/Services/YamlRepositoryMapper.cs
+++ b/src/EasyLotteryDomain/Services/YamlRepositoryMapper.cs
@@ -1,0 +1,31 @@
+using EasyLotteryDomain.Models.Config;
+
+namespace EasyLotteryDomain.Services;
+
+public static class YamlRepositoryMapper
+{
+    public static (SettingsYamlDocument Settings, ActivitiesYamlDocument Activities, ActivityResultsYamlDocument Results) Split(EasyLotteryConfigDocument source) =>
+        (new SettingsYamlDocument { ConfigVersion = source.ConfigVersion, SystemSettings = source.SystemSettings, IdSequence = source.IdSequence, DrawingRulePresets = source.DrawingRulePresets, DrawingRules = source.DrawingRules, VisualStyle = source.VisualStyle, ObsLayout = source.ObsLayout, SoundCue = source.SoundCue, OvertimeOverlay = source.OvertimeOverlay, AuditRecords = source.AuditRecords },
+         new ActivitiesYamlDocument { IdSequence = source.IdSequence, PokeTemplates = source.PokeTemplates, RouletteTemplates = source.RouletteTemplates, DonateLotteryActivities = source.DonateLotteryActivities },
+         new ActivityResultsYamlDocument { IdSequence = source.IdSequence, ActivityResults = source.ActivityResults, DonateLotteryDrawRecords = source.DonateLotteryDrawRecords, ProcessedDonatePaymentIds = source.ProcessedDonatePaymentIds });
+
+    public static EasyLotteryConfigDocument Merge(SettingsYamlDocument settings, ActivitiesYamlDocument activities, ActivityResultsYamlDocument results) => new()
+    {
+        ConfigVersion = settings.ConfigVersion,
+        SystemSettings = settings.SystemSettings,
+        IdSequence = settings.IdSequence,
+        DrawingRulePresets = settings.DrawingRulePresets,
+        DrawingRules = settings.DrawingRules,
+        VisualStyle = settings.VisualStyle,
+        ObsLayout = settings.ObsLayout,
+        SoundCue = settings.SoundCue,
+        OvertimeOverlay = settings.OvertimeOverlay,
+        AuditRecords = settings.AuditRecords,
+        PokeTemplates = activities.PokeTemplates,
+        RouletteTemplates = activities.RouletteTemplates,
+        DonateLotteryActivities = activities.DonateLotteryActivities,
+        ActivityResults = results.ActivityResults,
+        DonateLotteryDrawRecords = results.DonateLotteryDrawRecords,
+        ProcessedDonatePaymentIds = results.ProcessedDonatePaymentIds
+    };
+}

--- a/tests/EasyLotteryDomainTests/Services/YamlRepositoryMapperTests.cs
+++ b/tests/EasyLotteryDomainTests/Services/YamlRepositoryMapperTests.cs
@@ -1,0 +1,27 @@
+using EasyLotteryDomain.Models.Config;
+using EasyLotteryDomain.Services;
+
+namespace EasyLotteryDomainTests.Services;
+
+[TestClass]
+public sealed class YamlRepositoryMapperTests
+{
+    [TestMethod]
+    public void SplitAndMerge_PreservesActivityDatesAndResults()
+    {
+        var start = new DateTimeOffset(2026, 7, 21, 8, 0, 0, TimeSpan.Zero);
+        var end = new DateTimeOffset(2026, 7, 31, 8, 0, 0, TimeSpan.Zero);
+        var source = new EasyLotteryConfigDocument
+        {
+            DonateLotteryActivities = [new DonateLotteryActivity { Id = 4, StartsAtUtc = start, EndsAtUtc = end, Name = "一番賞" }],
+            ActivityResults = [new ActivityResultRecord { Id = 9, ActivityName = "一番賞", ActivityDateUtc = start.UtcDateTime }]
+        };
+
+        var parts = YamlRepositoryMapper.Split(source);
+        var merged = YamlRepositoryMapper.Merge(parts.Settings, parts.Activities, parts.Results);
+
+        Assert.AreEqual(start, merged.DonateLotteryActivities[0].StartsAtUtc);
+        Assert.AreEqual(end, merged.DonateLotteryActivities[0].EndsAtUtc);
+        Assert.AreEqual(9, merged.ActivityResults[0].Id);
+    }
+}


### PR DESCRIPTION
## 摘要

開始 #123 的正確 repository migration：建立三個專屬 YAML document 與 split/merge mapper，先鎖定活動日期與結果的 round-trip 行為。

## 變更

- 新增 `SettingsYamlDocument`、`ActivitiesYamlDocument`、`ActivityResultsYamlDocument`。
- 新增 `YamlRepositoryMapper`，不再以整份設定模型輸出到每個 YAML。
- 新增活動日期與結果 round-trip 測試。

## 驗證

- `dotnet test EasyLottery.generated.sln --no-restore`
- 89 Domain tests、6 API tests 通過。