### PR TITLE
refactor: split yaml repository storage

### DIFF
--- a/src/EasyLotteryAPI/ConfigSecretRedactor.cs
+++ b/src/EasyLotteryAPI/ConfigSecretRedactor.cs
@@ -1,6 +1,6 @@
 using EasyLotteryDomain.Models.Config;
 using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
+using EasyLotteryDomain.Services;
 
 namespace EasyLotteryApi;
 
@@ -12,14 +12,8 @@ public sealed class ConfigSecretRedactor
 {
     public const string UnchangedSecretMask = "__EASYLOTTERY_SECRET_UNCHANGED__";
 
-    private readonly IDeserializer _deserializer = new DeserializerBuilder()
-        .WithNamingConvention(CamelCaseNamingConvention.Instance)
-        .IgnoreUnmatchedProperties()
-        .Build();
-    private readonly ISerializer _serializer = new SerializerBuilder()
-        .WithNamingConvention(CamelCaseNamingConvention.Instance)
-        .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull | DefaultValuesHandling.OmitDefaults)
-        .Build();
+    private readonly IDeserializer _deserializer = YamlSerialization.CreateDeserializerBuilder().Build();
+    private readonly ISerializer _serializer = YamlSerialization.CreateSerializerBuilder().Build();
 
     public string RedactForBrowser(string yaml)
     {

--- a/src/EasyLotteryAPI/IEasyLotteryConfigRepository.cs
+++ b/src/EasyLotteryAPI/IEasyLotteryConfigRepository.cs
@@ -1,0 +1,14 @@
+using EasyLotteryDomain.Models.Config;
+
+namespace EasyLotteryApi;
+
+public interface IEasyLotteryConfigRepository
+{
+    Task<string> ReadForBrowserAsync(CancellationToken cancellationToken);
+
+    Task SaveBrowserUpdateAsync(string submittedYaml, CancellationToken cancellationToken);
+
+    Task<EasyLotteryConfigDocument> ReadAsync(CancellationToken cancellationToken);
+
+    Task<T> UpdateAsync<T>(Func<EasyLotteryConfigDocument, T> update, CancellationToken cancellationToken);
+}

--- a/src/EasyLotteryAPI/Payments/PaymentCallbackProcessor.cs
+++ b/src/EasyLotteryAPI/Payments/PaymentCallbackProcessor.cs
@@ -14,7 +14,7 @@ public sealed class PaymentCallbackProcessor
     private readonly PaymentProviderFactory _factory;
     private readonly IHubContext<OvertimeHub> _hub;
     private readonly ILogger<PaymentCallbackProcessor> _logger;
-    private readonly SettingsFileStore _settingsStore;
+    private readonly IEasyLotteryConfigRepository _settingsStore;
     private readonly string _paymentEventsPath;
     private readonly string _paymentOrdersPath;
     private readonly string _overtimeFeedPath;
@@ -26,7 +26,7 @@ public sealed class PaymentCallbackProcessor
         ILogger<PaymentCallbackProcessor> logger,
         IConfiguration configuration,
         IWebHostEnvironment environment,
-        SettingsFileStore settingsStore)
+        IEasyLotteryConfigRepository settingsStore)
     {
         _factory = factory;
         _hub = hub;

--- a/src/EasyLotteryAPI/Program.cs
+++ b/src/EasyLotteryAPI/Program.cs
@@ -12,7 +12,7 @@ builder.Services.AddSingleton<IPaymentProvider, EcpayBroadcasterPaymentProvider>
 builder.Services.AddSingleton<IPaymentProvider, NewebPayDonationPaymentProvider>();
 builder.Services.AddSingleton<PaymentProviderFactory>();
 builder.Services.AddSingleton<ConfigSecretRedactor>();
-builder.Services.AddSingleton<SettingsFileStore>();
+builder.Services.AddSingleton<IEasyLotteryConfigRepository, SettingsFileStore>();
 builder.Services.AddSingleton<AdminAccess>();
 builder.Services.AddSingleton<PaymentCallbackProcessor>();
 
@@ -52,7 +52,7 @@ if (app.Environment.IsDevelopment())
 app.UseBlazorFrameworkFiles();
 app.UseStaticFiles();
 
-Func<HttpContext, SettingsFileStore, AdminAccess, Task<IResult>> readSettings = async (context, settingsStore, adminAccess) =>
+Func<HttpContext, IEasyLotteryConfigRepository, AdminAccess, Task<IResult>> readSettings = async (context, settingsStore, adminAccess) =>
 {
     if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
     return Results.Text(await settingsStore.ReadForBrowserAsync(context.RequestAborted), "text/yaml", Encoding.UTF8);
@@ -61,7 +61,7 @@ app.MapGet("/settings", readSettings);
 // Compatibility endpoint for browsers still serving a cached pre-settings.yaml build.
 app.MapGet("/easy-lottery-config.yaml", readSettings);
 
-Func<HttpContext, IHubContext<OvertimeHub>, SettingsFileStore, AdminAccess, Task<IResult>> writeSettings = async (context, hub, settingsStore, adminAccess) =>
+Func<HttpContext, IHubContext<OvertimeHub>, IEasyLotteryConfigRepository, AdminAccess, Task<IResult>> writeSettings = async (context, hub, settingsStore, adminAccess) =>
 {
     if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
 

--- a/src/EasyLotteryAPI/SettingsFileStore.cs
+++ b/src/EasyLotteryAPI/SettingsFileStore.cs
@@ -1,58 +1,77 @@
 using EasyLotteryDomain.Models.Config;
+using EasyLotteryDomain.Services;
 using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
 
 namespace EasyLotteryApi;
 
-/// <summary>Single-writer access to the shared YAML settings file.</summary>
-public sealed class SettingsFileStore
+/// <summary>YAML-backed repository for the EasyLottery configuration.</summary>
+public sealed class SettingsFileStore : IEasyLotteryConfigRepository
 {
     private readonly SemaphoreSlim _gate = new(1, 1);
     private readonly ConfigSecretRedactor _secrets;
-    private readonly IDeserializer _deserializer = new DeserializerBuilder().WithNamingConvention(CamelCaseNamingConvention.Instance).IgnoreUnmatchedProperties().Build();
-    private readonly ISerializer _serializer = new SerializerBuilder().WithNamingConvention(CamelCaseNamingConvention.Instance).ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull | DefaultValuesHandling.OmitDefaults).Build();
+    private readonly IDeserializer _deserializer = YamlSerialization.CreateDeserializerBuilder().Build();
+    private readonly ISerializer _serializer = YamlSerialization.CreateSerializerBuilder().Build();
 
     public string ConfigPath { get; }
+
+    public string ActivitiesPath { get; }
+
+    public string ActivityResultsPath { get; }
 
     public SettingsFileStore(IConfiguration configuration, IWebHostEnvironment environment, ConfigSecretRedactor secrets)
     {
         _secrets = secrets;
         var directory = configuration["Storage:Directory"] ?? Path.Combine(environment.ContentRootPath, "App_Data");
         Directory.CreateDirectory(directory);
+
         ConfigPath = Path.Combine(directory, "settings.yaml");
-        var legacyPath = Path.Combine(directory, "easy-lottery.yaml");
-        if (!File.Exists(ConfigPath) && File.Exists(legacyPath)) File.Move(legacyPath, ConfigPath);
+        ActivitiesPath = Path.Combine(directory, "activities.yaml");
+        ActivityResultsPath = Path.Combine(directory, "activity-results.yaml");
 
-        if (!File.Exists(ConfigPath))
-        {
-            // Always materialize the shared settings file on startup so operators
-            // can locate and manage it even before the first browser write.
-            File.WriteAllText(ConfigPath, string.Empty);
-        }
-
-        if (File.Exists(ConfigPath))
-        {
-            var current = File.ReadAllText(ConfigPath);
-            var normalized = _secrets.NormalizeForPersistence(current);
-            if (!string.Equals(current, normalized, StringComparison.Ordinal)) File.WriteAllText(ConfigPath, normalized);
-        }
+        EnsureRepositoryDocuments();
     }
 
-    public async Task<string> ReadForBrowserAsync(CancellationToken cancellationToken) =>
-        _secrets.RedactForBrowser(await ReadRawAsync(cancellationToken));
+    public async Task<string> ReadForBrowserAsync(CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            var document = await ReadMergedDocumentUnsafeAsync(cancellationToken);
+            return _secrets.RedactForBrowser(_serializer.Serialize(document));
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
 
     public async Task SaveBrowserUpdateAsync(string submittedYaml, CancellationToken cancellationToken)
     {
         await _gate.WaitAsync(cancellationToken);
-        try { await WriteRawAsync(_secrets.MergeBrowserUpdate(await ReadRawUnsafeAsync(cancellationToken), submittedYaml), cancellationToken); }
-        finally { _gate.Release(); }
+        try
+        {
+            var currentYaml = _serializer.Serialize(await ReadMergedDocumentUnsafeAsync(cancellationToken));
+            var mergedYaml = _secrets.MergeBrowserUpdate(currentYaml, submittedYaml);
+            var document = DeserializeConfigDocument(mergedYaml);
+            await WriteSplitDocumentsAsync(document, cancellationToken);
+        }
+        finally
+        {
+            _gate.Release();
+        }
     }
 
     public async Task<EasyLotteryConfigDocument> ReadAsync(CancellationToken cancellationToken)
     {
         await _gate.WaitAsync(cancellationToken);
-        try { return Deserialize(await ReadRawUnsafeAsync(cancellationToken)); }
-        finally { _gate.Release(); }
+        try
+        {
+            return await ReadMergedDocumentUnsafeAsync(cancellationToken);
+        }
+        finally
+        {
+            _gate.Release();
+        }
     }
 
     public async Task<T> UpdateAsync<T>(Func<EasyLotteryConfigDocument, T> update, CancellationToken cancellationToken)
@@ -60,27 +79,118 @@ public sealed class SettingsFileStore
         await _gate.WaitAsync(cancellationToken);
         try
         {
-            var document = Deserialize(await ReadRawUnsafeAsync(cancellationToken));
+            var document = await ReadMergedDocumentUnsafeAsync(cancellationToken);
             var result = update(document);
-            await WriteRawAsync(_serializer.Serialize(document), cancellationToken);
+            await WriteSplitDocumentsAsync(document, cancellationToken);
             return result;
         }
-        finally { _gate.Release(); }
+        finally
+        {
+            _gate.Release();
+        }
     }
 
-    private async Task<string> ReadRawAsync(CancellationToken cancellationToken)
+    private void EnsureRepositoryDocuments()
     {
-        await _gate.WaitAsync(cancellationToken);
-        try { return await ReadRawUnsafeAsync(cancellationToken); }
-        finally { _gate.Release(); }
+        if (File.Exists(ConfigPath) && File.Exists(ActivitiesPath) && File.Exists(ActivityResultsPath))
+        {
+            return;
+        }
+
+        if (File.Exists(ConfigPath))
+        {
+            var legacyDocument = ReadLegacyDocument(ConfigPath);
+            WriteSplitDocuments(legacyDocument);
+            return;
+        }
+
+        var activities = ReadActivitiesDocument(ActivitiesPath);
+        var results = ReadActivityResultsDocument(ActivityResultsPath);
+        WriteSplitDocuments(new EasyLotteryConfigDocument
+        {
+            PokeTemplates = activities.PokeTemplates,
+            RouletteTemplates = activities.RouletteTemplates,
+            DonateLotteryActivities = activities.DonateLotteryActivities,
+            ActivityResults = results.ActivityResults,
+            DonateLotteryDrawRecords = results.DonateLotteryDrawRecords,
+            ProcessedDonatePaymentIds = results.ProcessedDonatePaymentIds
+        });
     }
 
-    private Task<string> ReadRawUnsafeAsync(CancellationToken cancellationToken) => File.Exists(ConfigPath) ? File.ReadAllTextAsync(ConfigPath, cancellationToken) : Task.FromResult(string.Empty);
-    private EasyLotteryConfigDocument Deserialize(string yaml) => string.IsNullOrWhiteSpace(yaml) ? new() : _deserializer.Deserialize<EasyLotteryConfigDocument>(yaml) ?? new();
-    private async Task WriteRawAsync(string content, CancellationToken cancellationToken)
+    private async Task<EasyLotteryConfigDocument> ReadMergedDocumentUnsafeAsync(CancellationToken cancellationToken)
     {
-        var temporaryPath = $"{ConfigPath}.{Guid.NewGuid():N}.tmp";
-        await File.WriteAllTextAsync(temporaryPath, content, cancellationToken);
-        File.Move(temporaryPath, ConfigPath, overwrite: true);
+        var settings = await ReadSettingsDocumentAsync(cancellationToken);
+        var activities = await ReadActivitiesDocumentAsync(cancellationToken);
+        var results = await ReadActivityResultsDocumentAsync(cancellationToken);
+        return YamlRepositoryMapper.Merge(settings, activities, results);
+    }
+
+    private async Task WriteSplitDocumentsAsync(EasyLotteryConfigDocument document, CancellationToken cancellationToken)
+    {
+        var parts = YamlRepositoryMapper.Split(document);
+        await WriteDocumentAsync(ConfigPath, parts.Settings, cancellationToken);
+        await WriteDocumentAsync(ActivitiesPath, parts.Activities, cancellationToken);
+        await WriteDocumentAsync(ActivityResultsPath, parts.Results, cancellationToken);
+    }
+
+    private void WriteSplitDocuments(EasyLotteryConfigDocument document)
+    {
+        var parts = YamlRepositoryMapper.Split(document);
+        WriteDocument(ConfigPath, parts.Settings);
+        WriteDocument(ActivitiesPath, parts.Activities);
+        WriteDocument(ActivityResultsPath, parts.Results);
+    }
+
+    private EasyLotteryConfigDocument ReadLegacyDocument(string path)
+    {
+        var yaml = File.Exists(path) ? File.ReadAllText(path) : string.Empty;
+        yaml = _secrets.NormalizeForPersistence(yaml);
+        return DeserializeConfigDocument(yaml);
+    }
+
+    private async Task<SettingsYamlDocument> ReadSettingsDocumentAsync(CancellationToken cancellationToken) =>
+        await ReadDocumentAsync(ConfigPath, new SettingsYamlDocument(), cancellationToken);
+
+    private async Task<ActivitiesYamlDocument> ReadActivitiesDocumentAsync(CancellationToken cancellationToken) =>
+        await ReadDocumentAsync(ActivitiesPath, new ActivitiesYamlDocument(), cancellationToken);
+
+    private async Task<ActivityResultsYamlDocument> ReadActivityResultsDocumentAsync(CancellationToken cancellationToken) =>
+        await ReadDocumentAsync(ActivityResultsPath, new ActivityResultsYamlDocument(), cancellationToken);
+
+    private ActivitiesYamlDocument ReadActivitiesDocument(string path) =>
+        File.Exists(path) ? DeserializeDocument<ActivitiesYamlDocument>(File.ReadAllText(path)) : new ActivitiesYamlDocument();
+
+    private ActivityResultsYamlDocument ReadActivityResultsDocument(string path) =>
+        File.Exists(path) ? DeserializeDocument<ActivityResultsYamlDocument>(File.ReadAllText(path)) : new ActivityResultsYamlDocument();
+
+    private async Task<T> ReadDocumentAsync<T>(string path, T fallback, CancellationToken cancellationToken) where T : class
+    {
+        if (!File.Exists(path))
+        {
+            return fallback;
+        }
+
+        var yaml = await File.ReadAllTextAsync(path, cancellationToken);
+        return string.IsNullOrWhiteSpace(yaml) ? fallback : DeserializeDocument<T>(yaml) ?? fallback;
+    }
+
+    private EasyLotteryConfigDocument DeserializeConfigDocument(string yaml) =>
+        string.IsNullOrWhiteSpace(yaml) ? new EasyLotteryConfigDocument() : DeserializeDocument<EasyLotteryConfigDocument>(yaml) ?? new EasyLotteryConfigDocument();
+
+    private T DeserializeDocument<T>(string yaml) where T : class =>
+        _deserializer.Deserialize<T>(yaml) ?? throw new InvalidOperationException($"Unable to deserialize YAML document to {typeof(T).Name}.");
+
+    private async Task WriteDocumentAsync<T>(string path, T document, CancellationToken cancellationToken) where T : class
+    {
+        var temporaryPath = $"{path}.{Guid.NewGuid():N}.tmp";
+        await File.WriteAllTextAsync(temporaryPath, _serializer.Serialize(document), cancellationToken);
+        File.Move(temporaryPath, path, overwrite: true);
+    }
+
+    private void WriteDocument<T>(string path, T document) where T : class
+    {
+        var temporaryPath = $"{path}.{Guid.NewGuid():N}.tmp";
+        File.WriteAllText(temporaryPath, _serializer.Serialize(document));
+        File.Move(temporaryPath, path, overwrite: true);
     }
 }

--- a/src/EasyLotteryDomain/Models/Config/YamlRepositoryDocuments.cs
+++ b/src/EasyLotteryDomain/Models/Config/YamlRepositoryDocuments.cs
@@ -18,7 +18,6 @@ public sealed class SettingsYamlDocument
 
 public sealed class ActivitiesYamlDocument
 {
-    public LotteryIdSequence IdSequence { get; set; } = new();
     public List<PokeTemplate> PokeTemplates { get; set; } = [];
     public List<RouletteTemplate> RouletteTemplates { get; set; } = [];
     public List<DonateLotteryActivity> DonateLotteryActivities { get; set; } = [];
@@ -26,7 +25,6 @@ public sealed class ActivitiesYamlDocument
 
 public sealed class ActivityResultsYamlDocument
 {
-    public LotteryIdSequence IdSequence { get; set; } = new();
     public List<ActivityResultRecord> ActivityResults { get; set; } = [];
     public List<DonateLotteryDrawRecord> DonateLotteryDrawRecords { get; set; } = [];
     public List<string> ProcessedDonatePaymentIds { get; set; } = [];

--- a/src/EasyLotteryDomain/Services/YamlRepositoryMapper.cs
+++ b/src/EasyLotteryDomain/Services/YamlRepositoryMapper.cs
@@ -6,8 +6,8 @@ public static class YamlRepositoryMapper
 {
     public static (SettingsYamlDocument Settings, ActivitiesYamlDocument Activities, ActivityResultsYamlDocument Results) Split(EasyLotteryConfigDocument source) =>
         (new SettingsYamlDocument { ConfigVersion = source.ConfigVersion, SystemSettings = source.SystemSettings, IdSequence = source.IdSequence, DrawingRulePresets = source.DrawingRulePresets, DrawingRules = source.DrawingRules, VisualStyle = source.VisualStyle, ObsLayout = source.ObsLayout, SoundCue = source.SoundCue, OvertimeOverlay = source.OvertimeOverlay, AuditRecords = source.AuditRecords },
-         new ActivitiesYamlDocument { IdSequence = source.IdSequence, PokeTemplates = source.PokeTemplates, RouletteTemplates = source.RouletteTemplates, DonateLotteryActivities = source.DonateLotteryActivities },
-         new ActivityResultsYamlDocument { IdSequence = source.IdSequence, ActivityResults = source.ActivityResults, DonateLotteryDrawRecords = source.DonateLotteryDrawRecords, ProcessedDonatePaymentIds = source.ProcessedDonatePaymentIds });
+         new ActivitiesYamlDocument { PokeTemplates = source.PokeTemplates, RouletteTemplates = source.RouletteTemplates, DonateLotteryActivities = source.DonateLotteryActivities },
+         new ActivityResultsYamlDocument { ActivityResults = source.ActivityResults, DonateLotteryDrawRecords = source.DonateLotteryDrawRecords, ProcessedDonatePaymentIds = source.ProcessedDonatePaymentIds });
 
     public static EasyLotteryConfigDocument Merge(SettingsYamlDocument settings, ActivitiesYamlDocument activities, ActivityResultsYamlDocument results) => new()
     {

--- a/src/EasyLotteryDomain/Services/YamlSerialization.cs
+++ b/src/EasyLotteryDomain/Services/YamlSerialization.cs
@@ -1,0 +1,89 @@
+using System.Globalization;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace EasyLotteryDomain.Services;
+
+public static class YamlSerialization
+{
+    public static DeserializerBuilder CreateDeserializerBuilder() =>
+        new DeserializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .IgnoreUnmatchedProperties()
+            .WithTypeConverter(new DateTimeOffsetYamlTypeConverter());
+
+    public static SerializerBuilder CreateSerializerBuilder() =>
+        new SerializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull | DefaultValuesHandling.OmitDefaults)
+            .WithTypeConverter(new DateTimeOffsetYamlTypeConverter());
+
+    private sealed class DateTimeOffsetYamlTypeConverter : IYamlTypeConverter
+    {
+        private const string RoundTripFormat = "O";
+
+        public bool Accepts(Type type) =>
+            type == typeof(DateTimeOffset) ||
+            type == typeof(DateTimeOffset?) ||
+            type == typeof(DateTime) ||
+            type == typeof(DateTime?);
+
+        public object? ReadYaml(IParser parser, Type type, ObjectDeserializer nestedObjectDeserializer)
+        {
+            var scalar = parser.Consume<Scalar>();
+            if (string.IsNullOrWhiteSpace(scalar.Value) || string.Equals(scalar.Value, "null", StringComparison.OrdinalIgnoreCase))
+            {
+                return type == typeof(DateTimeOffset?) || type == typeof(DateTime?)
+                    ? null
+                    : Activator.CreateInstance(type);
+            }
+
+            if (type == typeof(DateTime) || type == typeof(DateTime?))
+            {
+                if (DateTime.TryParseExact(scalar.Value, RoundTripFormat, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var dateTime))
+                {
+                    return dateTime;
+                }
+
+                if (DateTime.TryParse(scalar.Value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out dateTime))
+                {
+                    return dateTime;
+                }
+
+                return type == typeof(DateTime?) ? null : default(DateTime);
+            }
+
+            if (DateTimeOffset.TryParseExact(scalar.Value, RoundTripFormat, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var offset))
+            {
+                return offset;
+            }
+
+            if (DateTimeOffset.TryParse(scalar.Value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out offset))
+            {
+                return offset;
+            }
+
+            return type == typeof(DateTimeOffset?) ? null : default(DateTimeOffset);
+        }
+
+        public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer nestedObjectSerializer)
+        {
+            if (value is null)
+            {
+                emitter.Emit(new Scalar("null"));
+                return;
+            }
+
+            string text = value switch
+            {
+                DateTimeOffset offset => offset.ToUniversalTime().ToString(RoundTripFormat, CultureInfo.InvariantCulture),
+                DateTime dateTime => DateTime.SpecifyKind(dateTime, DateTimeKind.Utc).ToString(RoundTripFormat, CultureInfo.InvariantCulture),
+                _ => Convert.ToString(value, CultureInfo.InvariantCulture) ?? ""
+            };
+
+            emitter.Emit(new Scalar(text));
+        }
+    }
+}

--- a/src/EasyLotteryWasm/Pages/DonateActivities.razor
+++ b/src/EasyLotteryWasm/Pages/DonateActivities.razor
@@ -1,6 +1,7 @@
 @page "/donate-activities"
 @using EasyLotteryDomain.Models.Config
 @using EasyLotteryDomain.Services
+@using System.Globalization
 @using Serilog
 
 @inject DonateLotteryActivityService DonateLotteryActivityService
@@ -137,5 +138,26 @@
     }
     private void OnStartDateChanged(ChangeEventArgs args) => SetDate(args.Value?.ToString(), isStart: true);
     private void OnEndDateChanged(ChangeEventArgs args) => SetDate(args.Value?.ToString(), isStart: false);
-    private void SetDate(string? value, bool isStart) { if (editing is null || !DateTime.TryParse(value, out var date)) return; var instant = new DateTimeOffset(DateTime.SpecifyKind(date, DateTimeKind.Local)).ToUniversalTime(); if (isStart) editing.StartsAtUtc = instant; else editing.EndsAtUtc = instant; }
+    private void SetDate(string? value, bool isStart)
+    {
+        if (editing is null || string.IsNullOrWhiteSpace(value))
+        {
+            return;
+        }
+
+        if (!DateTime.TryParseExact(value, "yyyy-MM-ddTHH:mm", CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
+        {
+            return;
+        }
+
+        var instant = new DateTimeOffset(DateTime.SpecifyKind(date, DateTimeKind.Local)).ToUniversalTime();
+        if (isStart)
+        {
+            editing.StartsAtUtc = instant;
+        }
+        else
+        {
+            editing.EndsAtUtc = instant;
+        }
+    }
 }

--- a/src/EasyLotteryWasm/Services/YamlEasyLotteryConfigStore.cs
+++ b/src/EasyLotteryWasm/Services/YamlEasyLotteryConfigStore.cs
@@ -7,7 +7,6 @@ using EasyLotteryDomain.Services;
 using EasyLotteryWasm.Models;
 using Microsoft.JSInterop;
 using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
 
 namespace EasyLotteryWasm.Services
 {
@@ -32,14 +31,8 @@ namespace EasyLotteryWasm.Services
             _configuration = configuration;
             _jsRuntime = jsRuntime;
             _logger = logger;
-            _deserializer = new DeserializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .IgnoreUnmatchedProperties()
-                .Build();
-            _serializer = new SerializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull | DefaultValuesHandling.OmitDefaults)
-                .Build();
+            _deserializer = YamlSerialization.CreateDeserializerBuilder().Build();
+            _serializer = YamlSerialization.CreateSerializerBuilder().Build();
         }
 
         public async Task<EasyLotteryConfigDocument> LoadAsync(CancellationToken cancellationToken = default)

--- a/tests/EasyLotteryAPITests/SettingsFileStoreTests.cs
+++ b/tests/EasyLotteryAPITests/SettingsFileStoreTests.cs
@@ -1,35 +1,165 @@
 using EasyLotteryApi;
+using EasyLotteryDomain.Models.Config;
+using EasyLotteryDomain.Services;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.FileProviders;
+using YamlDotNet.Serialization;
 
 namespace EasyLotteryApiTests;
 
 [TestClass]
 public sealed class SettingsFileStoreTests
 {
+    private static readonly IDeserializer Deserializer = YamlSerialization.CreateDeserializerBuilder().Build();
+
     [TestMethod]
-    public async Task UpdateAsync_SerializesConcurrentDocumentChanges()
+    public async Task Constructor_CreatesSplitYamlDocuments()
     {
-        var directory = Path.Combine(Path.GetTempPath(), $"easy-lottery-tests-{Guid.NewGuid():N}");
+        var directory = CreateTempDirectory();
         try
         {
-            var configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?> { ["Storage:Directory"] = directory }).Build();
-            var store = new SettingsFileStore(configuration, new TestEnvironment(), new ConfigSecretRedactor());
+            var store = CreateStore(directory);
 
-            await Task.WhenAll(
-                store.UpdateAsync(document => { document.SystemSettings.ResultNotificationEmail = "results@example.test"; return true; }, CancellationToken.None),
-                store.UpdateAsync(document => { document.ProcessedDonatePaymentIds.Add("payment-1"); return true; }, CancellationToken.None));
+            Assert.IsTrue(File.Exists(store.ConfigPath));
+            Assert.IsTrue(File.Exists(store.ActivitiesPath));
+            Assert.IsTrue(File.Exists(store.ActivityResultsPath));
 
-            var saved = await store.ReadAsync(CancellationToken.None);
-            Assert.AreEqual("results@example.test", saved.SystemSettings.ResultNotificationEmail);
-            CollectionAssert.Contains(saved.ProcessedDonatePaymentIds, "payment-1");
+            var settings = Deserialize<SettingsYamlDocument>(await File.ReadAllTextAsync(store.ConfigPath));
+            var activities = Deserialize<ActivitiesYamlDocument>(await File.ReadAllTextAsync(store.ActivitiesPath));
+            var results = Deserialize<ActivityResultsYamlDocument>(await File.ReadAllTextAsync(store.ActivityResultsPath));
+
+            Assert.IsNotNull(settings.SystemSettings);
+            Assert.AreEqual(0, activities.DonateLotteryActivities.Count);
+            Assert.AreEqual(0, results.ActivityResults.Count);
         }
         finally
         {
-            if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true);
+            DeleteTempDirectory(directory);
         }
     }
+
+    [TestMethod]
+    public async Task Constructor_MigratesLegacySettingsYaml_PreservesDatesAndResults()
+    {
+        var directory = CreateTempDirectory();
+        try
+        {
+            var start = new DateTimeOffset(2026, 7, 21, 8, 0, 0, TimeSpan.Zero);
+            var end = new DateTimeOffset(2026, 7, 31, 8, 0, 0, TimeSpan.Zero);
+            var legacyDocument = new EasyLotteryConfigDocument
+            {
+                SystemSettings = { ResultNotificationEmail = "results@example.test" },
+                DonateLotteryActivities =
+                [
+                    new DonateLotteryActivity
+                    {
+                        Id = 4,
+                        Name = "一番賞",
+                        StartsAtUtc = start,
+                        EndsAtUtc = end
+                    }
+                ],
+                ActivityResults =
+                [
+                    new ActivityResultRecord
+                    {
+                        Id = 9,
+                        ActivityName = "一番賞",
+                        ActivityDateUtc = start.UtcDateTime
+                    }
+                ],
+                ProcessedDonatePaymentIds = ["payment-1"]
+            };
+            await File.WriteAllTextAsync(Path.Combine(directory, "settings.yaml"), Serialize(legacyDocument));
+
+            var store = CreateStore(directory);
+            var merged = await store.ReadAsync(CancellationToken.None);
+
+            Assert.AreEqual(start, merged.DonateLotteryActivities[0].StartsAtUtc);
+            Assert.AreEqual(end, merged.DonateLotteryActivities[0].EndsAtUtc);
+            Assert.AreEqual(9, merged.ActivityResults[0].Id);
+            CollectionAssert.Contains(merged.ProcessedDonatePaymentIds, "payment-1");
+
+            var activities = Deserialize<ActivitiesYamlDocument>(await File.ReadAllTextAsync(store.ActivitiesPath));
+            var results = Deserialize<ActivityResultsYamlDocument>(await File.ReadAllTextAsync(store.ActivityResultsPath));
+
+            Assert.AreEqual("一番賞", activities.DonateLotteryActivities[0].Name);
+            Assert.AreEqual(1, results.ProcessedDonatePaymentIds.Count);
+            Assert.AreEqual("payment-1", results.ProcessedDonatePaymentIds[0]);
+        }
+        finally
+        {
+            DeleteTempDirectory(directory);
+        }
+    }
+
+    [TestMethod]
+    public async Task UpdateAsync_WritesChangesToTheSplitFiles()
+    {
+        var directory = CreateTempDirectory();
+        try
+        {
+            var store = CreateStore(directory);
+
+            await store.UpdateAsync(document =>
+            {
+                document.SystemSettings.ResultNotificationEmail = "results@example.test";
+                document.DonateLotteryActivities.Add(new DonateLotteryActivity
+                {
+                    Id = 1,
+                    Name = "測試活動",
+                    StartsAtUtc = new DateTimeOffset(2026, 8, 1, 10, 0, 0, TimeSpan.Zero),
+                    EndsAtUtc = new DateTimeOffset(2026, 8, 2, 10, 0, 0, TimeSpan.Zero)
+                });
+                document.ProcessedDonatePaymentIds.Add("payment-2");
+                return true;
+            }, CancellationToken.None);
+
+            var settings = Deserialize<SettingsYamlDocument>(await File.ReadAllTextAsync(store.ConfigPath));
+            var activities = Deserialize<ActivitiesYamlDocument>(await File.ReadAllTextAsync(store.ActivitiesPath));
+            var results = Deserialize<ActivityResultsYamlDocument>(await File.ReadAllTextAsync(store.ActivityResultsPath));
+
+            Assert.AreEqual("results@example.test", settings.SystemSettings.ResultNotificationEmail);
+            Assert.AreEqual("測試活動", activities.DonateLotteryActivities[0].Name);
+            CollectionAssert.Contains(results.ProcessedDonatePaymentIds, "payment-2");
+        }
+        finally
+        {
+            DeleteTempDirectory(directory);
+        }
+    }
+
+    private static SettingsFileStore CreateStore(string directory)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Storage:Directory"] = directory })
+            .Build();
+        return new SettingsFileStore(configuration, new TestEnvironment(), new ConfigSecretRedactor());
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"easy-lottery-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static void DeleteTempDirectory(string directory)
+    {
+        if (Directory.Exists(directory))
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static string Serialize(EasyLotteryConfigDocument document) =>
+        YamlSerialization.CreateSerializerBuilder()
+            .Build()
+            .Serialize(document);
+
+    private static T Deserialize<T>(string yaml) where T : class =>
+        Deserializer.Deserialize<T>(yaml) ?? throw new InvalidOperationException($"Unable to deserialize {typeof(T).Name}.");
 
     private sealed class TestEnvironment : IWebHostEnvironment
     {


### PR DESCRIPTION
## Summary

- Split the YAML-backed storage into separate `settings.yaml`, `activities.yaml`, and `activity-results.yaml` files.
- Added an `IEasyLotteryConfigRepository` abstraction so the current YAML store can be swapped for a DB-backed repository later.
- Added a shared YAML date converter so `DateTimeOffset` and `DateTime` round-trip cleanly, and fixed Donate activity date parsing from `datetime-local` inputs.

## Migration

- The store auto-creates missing YAML files on startup.
- Existing legacy `settings.yaml` content is migrated into the split documents.
- Browser reads and writes still go through a merged config view, so the UI remains compatible.

## Validation

- `dotnet test EasyLottery.generated.sln --no-restore`