### PR TITLE
feat: enrich donate obs animations

### DIFF
--- a/src/EasyLotteryWasm/Pages/DonateObs.razor
+++ b/src/EasyLotteryWasm/Pages/DonateObs.razor
@@ -25,11 +25,56 @@
     {
         <div class="donate-reveal @AnimationClass @(IsGrandPrize ? "grand-prize" : "")" @key="latestWin.Id">
             <div class="donate-reveal-label">@(latestWin.IsWinning ? "DONATE RESULT" : "DONATE THANK YOU")</div>
-            <div class="draw-prop" aria-hidden="true">
-                @if (activity.Animation == DonateLotteryAnimation.Gacha) { <span class="chibi">🧒</span><span class="gacha-machine">◉</span> }
-                else if (activity.Animation == DonateLotteryAnimation.Garagara) { <span class="chibi">🧒</span><span class="garagara-drum">✦</span> }
-                else if (activity.Animation == DonateLotteryAnimation.MoneyBox) { <span class="coin">●</span><span class="money-box">▣</span><span class="fortune-slip">@latestWin.PrizeName</span> }
-                else { <span class="ichiban-ticket">一番賞</span> }
+            <div class="draw-prop animation-@AnimationKey" aria-hidden="true">
+                @if (activity.Animation == DonateLotteryAnimation.IchibanKuji)
+                {
+                    <div class="ichiban-stage">
+                        <div class="ichiban-curtain ichiban-curtain-left"></div>
+                        <div class="ichiban-curtain ichiban-curtain-right"></div>
+                        <div class="ichiban-ribbon"></div>
+                        <div class="ichiban-ticket">一番賞</div>
+                        <div class="ichiban-chibi">◉</div>
+                    </div>
+                }
+                else if (activity.Animation == DonateLotteryAnimation.Gacha)
+                {
+                    <div class="gacha-stage">
+                        <div class="gacha-halo"></div>
+                        <div class="gacha-machine">
+                            <div class="gacha-glass"></div>
+                            <div class="gacha-slot"></div>
+                            <div class="gacha-crank"></div>
+                            <div class="gacha-capsule"></div>
+                        </div>
+                        <div class="chibi gacha-chibi">◉</div>
+                    </div>
+                }
+                else if (activity.Animation == DonateLotteryAnimation.Garagara)
+                {
+                    <div class="garagara-stage">
+                        <div class="garagara-chibi">◉</div>
+                        <div class="garagara-arm"></div>
+                        <div class="garagara-drum">
+                            <span></span><span></span><span></span><span></span>
+                        </div>
+                        <div class="garagara-rain">
+                            <span></span><span></span><span></span>
+                        </div>
+                    </div>
+                }
+                else if (activity.Animation == DonateLotteryAnimation.MoneyBox)
+                {
+                    <div class="moneybox-stage">
+                        <div class="coin coin-1">●</div>
+                        <div class="coin coin-2">●</div>
+                        <div class="coin coin-3">●</div>
+                        <div class="money-box">
+                            <div class="money-box-slot"></div>
+                            <div class="money-box-face"></div>
+                        </div>
+                        <div class="fortune-slip">@latestWin.PrizeName</div>
+                    </div>
+                }
             </div>
             @if (!string.IsNullOrWhiteSpace(latestWin.PrizeImageUrl) && !prizeImageFailed)
             {
@@ -66,17 +111,51 @@ else
 <style>
     .donate-obs-shell { min-height: 100vh; display:grid; place-items:center; background:transparent; color:white; font-family:system-ui,sans-serif; }
     .donate-obs-empty { text-align:center; padding:2rem 3rem; border-radius:1.5rem; background:rgba(8,10,26,.72); font-size:2rem; }
-    .donate-reveal { text-align:center; padding:2rem; animation:donate-reveal .65s cubic-bezier(.16,1,.3,1); text-shadow:0 3px 18px #000; }
-    .draw-prop { min-height:7rem; display:flex; align-items:center; justify-content:center; gap:1rem; font-size:5rem; }
-    .chibi { display:inline-block; animation:chibi-crank .7s ease-in-out infinite alternate; transform-origin:bottom center; }
-    .gacha-machine { width:5rem; height:5rem; display:grid; place-items:center; border:10px solid #ff6b9d; border-radius:50% 50% 28% 28%; background:#7c3aed; box-shadow:inset 0 0 0 12px #fef3c7,0 10px 0 #4c1d95; animation:gacha-shake .25s linear infinite; }
-    .garagara-drum { width:6rem; height:6rem; display:grid; place-items:center; border:12px solid #b7791f; border-radius:50%; background:repeating-conic-gradient(#f7d794 0 12deg,#d69e2e 12deg 24deg); box-shadow:0 9px 0 #78350f; animation:drum-turn .45s linear infinite; }
-    .ichiban-ticket { display:inline-grid; place-items:center; width:12rem; height:5rem; color:#fff7d6; background:linear-gradient(135deg,#d90429,#7f1d1d); border:5px solid #fbbf24; font-size:2rem; font-weight:900; transform:rotate(-6deg); animation:ticket-reveal .8s ease-out; }
-    .money-box { color:#fbbf24; font-size:6rem; }
-    .coin { color:#fde047; animation:coin-drop 1s ease-in infinite; }
-    .fortune-slip { align-self:flex-end; padding:.6rem 1rem; color:#5b1d12; background:#fff7ed; font-size:1rem; font-weight:900; writing-mode:vertical-rl; animation:slip-pop .8s .45s both; }
-    .grand-prize { animation:grand-flash .8s ease-in-out infinite alternate; }
-    .grand-prize-banner { color:#fff7d6; font-size:clamp(1.2rem,3vw,2.3rem); font-weight:950; letter-spacing:.2em; }
+    .donate-reveal { text-align:center; padding:2rem; animation:donate-reveal .65s cubic-bezier(.16,1,.3,1); text-shadow:0 3px 18px #000; position:relative; }
+    .donate-reveal::before { content:""; position:absolute; inset:-2.5rem; pointer-events:none; background:radial-gradient(circle at center, rgba(255,255,255,.16), transparent 60%); opacity:.7; filter:blur(14px); }
+    .draw-prop { min-height:12rem; display:grid; place-items:center; margin:.25rem auto 1rem; perspective:1200px; position:relative; }
+    .draw-prop > * { position:relative; }
+    .animation-ichiban .ichiban-stage { width:min(22rem, 72vw); height:10rem; display:grid; place-items:center; position:relative; }
+    .ichiban-curtain { position:absolute; top:0; bottom:0; width:40%; background:linear-gradient(180deg, rgba(190,24,93,.95), rgba(127,29,29,.95)); border:4px solid #fbbf24; box-shadow:inset 0 0 28px rgba(255,255,255,.2); }
+    .ichiban-curtain-left { left:0; transform-origin:left center; border-radius:1rem 0 0 1rem; animation:curtain-open-left 1.2s ease-in-out infinite alternate; }
+    .ichiban-curtain-right { right:0; transform-origin:right center; border-radius:0 1rem 1rem 0; animation:curtain-open-right 1.2s ease-in-out infinite alternate; }
+    .ichiban-ribbon { position:absolute; inset:1.2rem 22%; border-radius:999px; background:linear-gradient(90deg,#f59e0b,#fef08a,#f59e0b); filter:blur(1px); animation:shine-sweep 2s linear infinite; }
+    .ichiban-ticket { display:grid; place-items:center; width:13rem; height:5.5rem; color:#fff7d6; background:linear-gradient(135deg,#d90429,#7f1d1d); border:5px solid #fbbf24; border-radius:.75rem; font-size:2rem; font-weight:900; transform:rotate(-6deg); animation:ticket-reveal .8s ease-out, ticket-bob 1.8s ease-in-out infinite alternate; z-index:1; }
+    .ichiban-chibi { position:absolute; left:1rem; bottom:-.75rem; font-size:2rem; animation:chibi-pull 1.1s ease-in-out infinite alternate; }
+    .animation-gacha .gacha-stage { width:min(25rem, 76vw); height:12rem; display:grid; place-items:center; position:relative; }
+    .gacha-halo { position:absolute; width:8rem; height:8rem; border-radius:50%; background:radial-gradient(circle, rgba(253,224,71,.9), rgba(253,224,71,.12) 55%, transparent 70%); animation:halo-pulse 1.2s ease-in-out infinite alternate; }
+    .gacha-machine { width:7rem; height:8rem; display:grid; place-items:center; border:10px solid #ff6b9d; border-radius:46% 46% 30% 30%; background:linear-gradient(180deg,#7c3aed,#4c1d95); box-shadow:inset 0 0 0 12px #fef3c7,0 10px 0 #312e81; animation:gacha-shake .25s linear infinite; position:relative; }
+    .gacha-glass { position:absolute; inset:1.15rem .65rem 2rem; border-radius:50%; background:radial-gradient(circle at 35% 28%, rgba(255,255,255,.8), rgba(255,255,255,.1) 48%, rgba(255,255,255,.04) 70%); border:3px solid rgba(255,255,255,.6); }
+    .gacha-slot { position:absolute; bottom:.8rem; left:50%; width:3rem; height:.5rem; transform:translateX(-50%); border-radius:999px; background:#fef08a; box-shadow:0 0 12px rgba(254,240,138,.95); }
+    .gacha-crank { position:absolute; right:-1.9rem; bottom:1.5rem; width:2.5rem; height:2.5rem; border:.55rem solid #fde68a; border-radius:50%; box-shadow:0 0 0 .25rem #92400e; animation:crank-turn .9s linear infinite; }
+    .gacha-capsule { position:absolute; top:-1.5rem; left:50%; width:2.15rem; height:3rem; transform:translateX(-50%); border-radius:999px; background:linear-gradient(180deg,#fde047 0 50%, #fb7185 50% 100%); box-shadow:0 .5rem 1rem rgba(0,0,0,.35); animation:capsule-drop 1.1s ease-in-out infinite; }
+    .gacha-chibi { position:absolute; left:1rem; bottom:0; font-size:2rem; animation:chibi-turn-crank .9s ease-in-out infinite alternate; }
+    .animation-garagara .garagara-stage { width:min(28rem, 82vw); height:12rem; display:grid; place-items:center; position:relative; }
+    .garagara-arm { position:absolute; left:2.5rem; bottom:2.1rem; width:5rem; height:.65rem; background:linear-gradient(90deg,#b45309,#fbbf24); border-radius:999px; transform-origin:right center; transform:rotate(-24deg); animation:arm-turn .9s ease-in-out infinite alternate; }
+    .garagara-chibi { position:absolute; left:0; bottom:1.25rem; font-size:2rem; animation:chibi-push 1s ease-in-out infinite alternate; }
+    .garagara-drum { width:8.75rem; height:8.75rem; display:grid; place-items:center; border:12px solid #b7791f; border-radius:50%; background:repeating-conic-gradient(#f7d794 0 12deg,#d69e2e 12deg 24deg); box-shadow:0 9px 0 #78350f, inset 0 0 0 8px rgba(255,255,255,.08); animation:drum-turn 1.2s linear infinite; position:relative; }
+    .garagara-drum span { position:absolute; width:.9rem; height:1.7rem; background:#fffaf0; border-radius:.35rem; box-shadow:0 0 0 .15rem rgba(120,53,15,.18); }
+    .garagara-drum span:nth-child(1) { transform:rotate(15deg) translateY(-2.8rem); }
+    .garagara-drum span:nth-child(2) { transform:rotate(105deg) translateY(-2.8rem); }
+    .garagara-drum span:nth-child(3) { transform:rotate(195deg) translateY(-2.8rem); }
+    .garagara-drum span:nth-child(4) { transform:rotate(285deg) translateY(-2.8rem); }
+    .garagara-rain { position:absolute; inset:-.5rem 0 auto; display:flex; justify-content:center; gap:1rem; pointer-events:none; }
+    .garagara-rain span { width:.65rem; height:1.8rem; background:linear-gradient(180deg, rgba(255,255,255,.9), rgba(255,247,237,.15)); border-radius:999px; animation:rain-fall 1.1s linear infinite; }
+    .garagara-rain span:nth-child(2) { animation-delay:.18s; }
+    .garagara-rain span:nth-child(3) { animation-delay:.36s; }
+    .animation-money-box .moneybox-stage { width:min(24rem, 76vw); height:12rem; display:grid; place-items:center; position:relative; }
+    .money-box { width:8rem; height:7.5rem; display:grid; place-items:center; color:#fbbf24; font-size:6rem; position:relative; animation:money-box-bounce 1s ease-in-out infinite alternate; }
+    .money-box::before { content:""; position:absolute; inset:1.15rem 1rem 0.75rem; border-radius:1rem 1rem .85rem .85rem; background:linear-gradient(180deg,#5b21b6,#312e81); box-shadow:0 8px 0 #111827, inset 0 0 0 4px rgba(251,191,36,.4); }
+    .money-box-slot { position:absolute; top:1.1rem; width:2.2rem; height:.5rem; border-radius:999px; background:#fef3c7; z-index:1; box-shadow:0 0 .7rem rgba(254,243,199,.95); }
+    .money-box-face { position:absolute; bottom:1.05rem; width:3.5rem; height:.75rem; border-radius:999px; background:linear-gradient(90deg,#fef3c7,#fbbf24,#fef3c7); z-index:1; }
+    .coin { position:absolute; color:#fde047; font-size:2.8rem; text-shadow:0 0 16px rgba(253,224,71,.8); }
+    .coin-1 { left:2rem; top:1rem; animation:coin-drop-left 1.2s ease-in infinite; }
+    .coin-2 { left:50%; top:-.2rem; transform:translateX(-50%); animation:coin-drop-center 1.2s ease-in .15s infinite; }
+    .coin-3 { right:2rem; top:1.1rem; animation:coin-drop-right 1.2s ease-in .3s infinite; }
+    .fortune-slip { position:absolute; right:0; bottom:-.25rem; padding:.6rem 1rem; color:#5b1d12; background:#fff7ed; font-size:1rem; font-weight:900; border-radius:.4rem; box-shadow:0 0 18px rgba(255,247,237,.75); writing-mode:vertical-rl; animation:slip-pop .85s .35s both; }
+    .grand-prize { animation:grand-flash .8s ease-in-out infinite alternate, grand-scale 1.4s ease-in-out infinite alternate; }
+    .grand-prize::after { content:""; position:absolute; inset:-4rem; pointer-events:none; background:conic-gradient(from 0deg, transparent 0 15%, rgba(255,255,255,.55) 20%, transparent 25% 40%, rgba(251,191,36,.55) 45%, transparent 50% 65%, rgba(255,255,255,.45) 70%, transparent 75% 100%); mask:radial-gradient(circle, transparent 0 38%, #000 52%); animation:grand-spin 3.5s linear infinite; }
+    .grand-prize-banner { color:#fff7d6; font-size:clamp(1.2rem,3vw,2.3rem); font-weight:950; letter-spacing:.2em; text-shadow:0 0 24px rgba(255,240,140,.9); }
     .donate-reveal-label { color:#ffd166; font-weight:900; letter-spacing:.22em; margin-bottom:1rem; }
     .donate-reveal-image { max-width:min(68vw,640px); max-height:62vh; object-fit:contain; border:6px solid #ffd166; border-radius:1.25rem; box-shadow:0 0 45px rgba(255,209,102,.8); }
     .donate-reveal-fallback { width:min(68vw,640px); aspect-ratio:1; display:grid; place-items:center; border:6px solid #ffd166; border-radius:1.25rem; background:linear-gradient(135deg,#6d28d9,#f59e0b); font-size:clamp(2rem,7vw,5rem); font-weight:900; }
@@ -90,13 +169,29 @@ else
     .donate-test-close { font-size:1.25rem; line-height:1; }
     .donate-test-launch { position:fixed; right:1rem; bottom:1rem; z-index:10; padding:.75rem 1rem; border:0; border-radius:.5rem; background:#2563eb; color:#fff; font-weight:800; box-shadow:0 6px 20px rgba(0,0,0,.35); }
     @@keyframes donate-reveal { from { opacity:0; transform:scale(.45) rotate(-4deg); } to { opacity:1; transform:scale(1) rotate(0); } }
-    @@keyframes chibi-crank { to { transform:rotate(-16deg) translateY(5px); } }
+    @@keyframes curtain-open-left { from { transform:scaleX(1); } to { transform:scaleX(.82) rotate(-1.5deg); } }
+    @@keyframes curtain-open-right { from { transform:scaleX(1); } to { transform:scaleX(.82) rotate(1.5deg); } }
+    @@keyframes shine-sweep { from { filter:brightness(1); transform:translateX(-10%); } to { filter:brightness(1.45); transform:translateX(10%); } }
+    @@keyframes ticket-reveal { from { transform:scale(.2) rotate(25deg) translateY(1.5rem); } to { transform:scale(1) rotate(-6deg) translateY(0); } }
+    @@keyframes ticket-bob { from { transform:rotate(-7deg) translateY(-.15rem); } to { transform:rotate(-5deg) translateY(.25rem); } }
+    @@keyframes chibi-pull { from { transform:translateX(0) translateY(0) rotate(0deg); } to { transform:translateX(1rem) translateY(.3rem) rotate(-10deg); } }
+    @@keyframes halo-pulse { from { transform:scale(.85); opacity:.7; } to { transform:scale(1.15); opacity:1; } }
     @@keyframes gacha-shake { 50% { transform:translateX(5px) rotate(4deg); } }
+    @@keyframes crank-turn { from { transform:rotate(0deg); } to { transform:rotate(360deg); } }
+    @@keyframes capsule-drop { from { transform:translateX(-50%) translateY(-1.4rem); opacity:0; } 35%,80% { opacity:1; } to { transform:translateX(-50%) translateY(4.25rem); opacity:0; } }
+    @@keyframes chibi-turn-crank { from { transform:translateY(0) rotate(-8deg); } to { transform:translateY(.3rem) rotate(10deg); } }
+    @@keyframes arm-turn { from { transform:rotate(-18deg); } to { transform:rotate(28deg); } }
+    @@keyframes chibi-push { from { transform:translateX(0) translateY(0) rotate(0deg); } to { transform:translateX(1rem) translateY(.35rem) rotate(10deg); } }
+    @@keyframes rain-fall { from { transform:translateY(-1.6rem); opacity:0; } 20%,80% { opacity:1; } to { transform:translateY(6rem); opacity:0; } }
     @@keyframes drum-turn { to { transform:rotate(360deg); } }
-    @@keyframes ticket-reveal { from { transform:scale(.2) rotate(25deg); } to { transform:scale(1) rotate(-6deg); } }
-    @@keyframes coin-drop { from { transform:translateY(-4rem); opacity:0; } 30%,80% { opacity:1; } to { transform:translateY(1rem); opacity:0; } }
+    @@keyframes money-box-bounce { from { transform:translateY(.2rem) rotate(-1deg); } to { transform:translateY(-.35rem) rotate(1deg); } }
+    @@keyframes coin-drop-left { from { transform:translateY(-3rem) rotate(-15deg); opacity:0; } 25%,80% { opacity:1; } to { transform:translateY(3rem) rotate(18deg); opacity:0; } }
+    @@keyframes coin-drop-center { from { transform:translateX(-50%) translateY(-3.2rem); opacity:0; } 25%,80% { opacity:1; } to { transform:translateX(-50%) translateY(3rem); opacity:0; } }
+    @@keyframes coin-drop-right { from { transform:translateY(-3rem) rotate(15deg); opacity:0; } 25%,80% { opacity:1; } to { transform:translateY(3rem) rotate(-18deg); opacity:0; } }
     @@keyframes slip-pop { from { transform:translateY(4rem) scale(.4); opacity:0; } to { transform:translateY(0) scale(1); opacity:1; } }
     @@keyframes grand-flash { from { filter:drop-shadow(0 0 8px #fbbf24); } to { filter:drop-shadow(0 0 35px #fef08a); transform:scale(1.04); } }
+    @@keyframes grand-scale { from { transform:scale(1); } to { transform:scale(1.06); } }
+    @@keyframes grand-spin { to { transform:rotate(360deg); } }
 </style>
 
 @code {
@@ -118,6 +213,13 @@ else
         DonateLotteryAnimation.Garagara => "animation-garagara",
         DonateLotteryAnimation.MoneyBox => "animation-money-box",
         _ => "animation-ichiban"
+    };
+    private string AnimationKey => activity?.Animation switch
+    {
+        DonateLotteryAnimation.Gacha => "gacha",
+        DonateLotteryAnimation.Garagara => "garagara",
+        DonateLotteryAnimation.MoneyBox => "moneybox",
+        _ => "ichiban"
     };
     private bool IsGrandPrize => latestWin is not null && activity?.Prizes.Any(prize => prize.IsGrandPrize && string.Equals(prize.Name, latestWin.PrizeName, StringComparison.Ordinal)) == true;
     private readonly CancellationTokenSource cancellation = new();


### PR DESCRIPTION
## Summary

- Reworked the Donate OBS result screen into four distinct animation styles: Ichiban Kuji, Gacha, Garagara, and Money Box.
- Added clearer chibi / machine / drum / coin motion so the reveal feels like a real animated effect instead of a static placeholder.
- Expanded the grand prize treatment with a stronger glow / flare treatment.

## Validation

- `dotnet test EasyLottery.generated.sln --no-restore`