### PR TITLE
feat: split donate activity api

### DIFF
--- a/src/EasyLotteryAPI/Program.cs
+++ b/src/EasyLotteryAPI/Program.cs
@@ -4,6 +4,8 @@ using System.Net.Mail;
 using Microsoft.AspNetCore.SignalR;
 using EasyLotteryApi;
 using EasyLotteryApi.Payments;
+using EasyLotteryDomain.Models.Config;
+using EasyLotteryDomain.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddSignalR();
@@ -12,7 +14,10 @@ builder.Services.AddSingleton<IPaymentProvider, EcpayBroadcasterPaymentProvider>
 builder.Services.AddSingleton<IPaymentProvider, NewebPayDonationPaymentProvider>();
 builder.Services.AddSingleton<PaymentProviderFactory>();
 builder.Services.AddSingleton<ConfigSecretRedactor>();
-builder.Services.AddSingleton<IEasyLotteryConfigRepository, SettingsFileStore>();
+builder.Services.AddSingleton<SettingsFileStore>();
+builder.Services.AddSingleton<IEasyLotteryConfigRepository>(sp => sp.GetRequiredService<SettingsFileStore>());
+builder.Services.AddSingleton<IEasyLotteryConfigStore>(sp => sp.GetRequiredService<SettingsFileStore>());
+builder.Services.AddSingleton<DonateLotteryActivityService>();
 builder.Services.AddSingleton<AdminAccess>();
 builder.Services.AddSingleton<PaymentCallbackProcessor>();
 
@@ -72,6 +77,64 @@ Func<HttpContext, IHubContext<OvertimeHub>, IEasyLotteryConfigRepository, AdminA
 };
 app.MapPut("/settings", writeSettings);
 app.MapPut("/easy-lottery-config.yaml", writeSettings);
+
+Func<HttpContext, DonateLotteryActivityService, AdminAccess, Task<IResult>> listDonateActivities = async (context, donateActivities, adminAccess) =>
+{
+    if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
+    return Results.Ok(await donateActivities.ListAsync(context.RequestAborted));
+};
+app.MapGet("/api/donate-activities", listDonateActivities);
+
+Func<DonateLotteryActivity, HttpContext, DonateLotteryActivityService, AdminAccess, Task<IResult>> createDonateActivity = async (activity, context, donateActivities, adminAccess) =>
+{
+    if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
+    try
+    {
+        var saved = await donateActivities.SaveAsync(activity, context.RequestAborted);
+        return Results.Created($"/api/donate-activities/{saved.Id}", saved);
+    }
+    catch (InvalidOperationException exception)
+    {
+        return Results.BadRequest(new { error = exception.Message });
+    }
+};
+app.MapPost("/api/donate-activities", createDonateActivity);
+
+Func<int, DonateLotteryActivity, HttpContext, DonateLotteryActivityService, AdminAccess, Task<IResult>> updateDonateActivity = async (id, activity, context, donateActivities, adminAccess) =>
+{
+    if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
+    if (activity.Id != 0 && activity.Id != id)
+    {
+        return Results.BadRequest(new { error = "路由 ID 與活動 ID 不一致。" });
+    }
+
+    try
+    {
+        activity.Id = id;
+        var saved = await donateActivities.SaveAsync(activity, context.RequestAborted);
+        return Results.Ok(saved);
+    }
+    catch (InvalidOperationException exception)
+    {
+        return Results.BadRequest(new { error = exception.Message });
+    }
+};
+app.MapPut("/api/donate-activities/{id:int}", updateDonateActivity);
+
+Func<int, HttpContext, DonateLotteryActivityService, AdminAccess, Task<IResult>> deleteDonateActivity = async (id, context, donateActivities, adminAccess) =>
+{
+    if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
+    try
+    {
+        await donateActivities.DeleteAsync(id, context.RequestAborted);
+        return Results.NoContent();
+    }
+    catch (InvalidOperationException exception)
+    {
+        return Results.NotFound(new { error = exception.Message });
+    }
+};
+app.MapDelete("/api/donate-activities/{id:int}", deleteDonateActivity);
 
 app.MapGet("/easy-lottery-overtime-feed.json", async (HttpContext context) =>
 {

--- a/src/EasyLotteryAPI/SettingsFileStore.cs
+++ b/src/EasyLotteryAPI/SettingsFileStore.cs
@@ -5,7 +5,7 @@ using YamlDotNet.Serialization;
 namespace EasyLotteryApi;
 
 /// <summary>YAML-backed repository for the EasyLottery configuration.</summary>
-public sealed class SettingsFileStore : IEasyLotteryConfigRepository
+public sealed class SettingsFileStore : IEasyLotteryConfigRepository, IEasyLotteryConfigStore
 {
     private readonly SemaphoreSlim _gate = new(1, 1);
     private readonly ConfigSecretRedactor _secrets;
@@ -83,6 +83,22 @@ public sealed class SettingsFileStore : IEasyLotteryConfigRepository
             var result = update(document);
             await WriteSplitDocumentsAsync(document, cancellationToken);
             return result;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public Task<EasyLotteryConfigDocument> LoadAsync(CancellationToken cancellationToken = default) =>
+        ReadAsync(cancellationToken);
+
+    public async Task SaveAsync(EasyLotteryConfigDocument document, CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            await WriteSplitDocumentsAsync(document, cancellationToken);
         }
         finally
         {

--- a/src/EasyLotteryWasm/Pages/DonateActivities.razor
+++ b/src/EasyLotteryWasm/Pages/DonateActivities.razor
@@ -1,10 +1,10 @@
 @page "/donate-activities"
 @using EasyLotteryDomain.Models.Config
-@using EasyLotteryDomain.Services
+@using EasyLotteryWasm.Services
 @using System.Globalization
 @using Serilog
 
-@inject DonateLotteryActivityService DonateLotteryActivityService
+@inject DonateLotteryActivityApiClient DonateLotteryActivityApiClient
 @inject IMessageService MessageService
 @inject IJSRuntime JSRuntime
 
@@ -96,12 +96,17 @@
 
     protected override async Task OnInitializedAsync()
     {
-        await ReloadAsync();
         requiresAdminToken = await JSRuntime.InvokeAsync<bool>("easyLotteryConfig.requiresAdminToken");
-        if (requiresAdminToken) activities = [];
+        if (requiresAdminToken)
+        {
+            activities = [];
+            return;
+        }
+
+        await ReloadAsync();
     }
 
-    private async Task ReloadAsync() => activities = await DonateLotteryActivityService.ListAsync();
+    private async Task ReloadAsync() => activities = await DonateLotteryActivityApiClient.ListAsync();
     private decimal PrizeProbabilityTotal => editing?.Prizes.Sum(prize => prize.Probability) ?? 0m;
     private bool ProbabilityTotalExceeded => PrizeProbabilityTotal > 100m;
     private Task CreateAsync() { editing = new DonateLotteryActivity { StartsAtUtc = DateTimeOffset.UtcNow, EndsAtUtc = DateTimeOffset.UtcNow.AddDays(7), Prizes = [new DonateLotteryPrize { Probability = 100m }] }; return Task.CompletedTask; }
@@ -112,7 +117,7 @@
         if (editing is null) return;
         try
         {
-            await DonateLotteryActivityService.SaveAsync(editing);
+            await DonateLotteryActivityApiClient.SaveAsync(editing);
             editing = null;
             await ReloadAsync();
             await MessageService.Success("Donate 活動已儲存。");
@@ -129,7 +134,7 @@
         if (!confirmed) return;
         try
         {
-            await DonateLotteryActivityService.DeleteAsync(activity.Id);
+            await DonateLotteryActivityApiClient.DeleteAsync(activity.Id);
             if (editing?.Id == activity.Id) editing = null;
             await ReloadAsync();
             await MessageService.Success("Donate 活動已刪除，既有抽獎紀錄會保留。");

--- a/src/EasyLotteryWasm/Program.cs
+++ b/src/EasyLotteryWasm/Program.cs
@@ -35,7 +35,7 @@ builder.Services.AddScoped<SystemSettingsService>();
 builder.Services.AddScoped<ObsLayoutService>();
 builder.Services.AddScoped<SoundCueService>();
 builder.Services.AddScoped<ActivityResultService>();
-builder.Services.AddScoped<DonateLotteryActivityService>();
+builder.Services.AddScoped<DonateLotteryActivityApiClient>();
 builder.Services.AddScoped<ResultNotificationService>();
 builder.Services.AddScoped<VisualStyleService>();
 builder.Services.AddScoped<OvertimeFeedClient>();

--- a/src/EasyLotteryWasm/Services/DonateLotteryActivityApiClient.cs
+++ b/src/EasyLotteryWasm/Services/DonateLotteryActivityApiClient.cs
@@ -1,0 +1,57 @@
+using System.Net.Http.Json;
+using EasyLotteryDomain.Models.Config;
+using Microsoft.JSInterop;
+
+namespace EasyLotteryWasm.Services;
+
+public sealed class DonateLotteryActivityApiClient
+{
+    private const string AdminHeaderName = "X-EasyLottery-Admin-Token";
+
+    private readonly HttpClient _httpClient;
+    private readonly IJSRuntime _jsRuntime;
+
+    public DonateLotteryActivityApiClient(HttpClient httpClient, IJSRuntime jsRuntime)
+    {
+        _httpClient = httpClient;
+        _jsRuntime = jsRuntime;
+    }
+
+    public async Task<IReadOnlyList<DonateLotteryActivity>> ListAsync(CancellationToken cancellationToken = default)
+    {
+        using var request = await CreateRequestAsync(HttpMethod.Get, "api/donate-activities", cancellationToken);
+        using var response = await _httpClient.SendAsync(request, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<List<DonateLotteryActivity>>(cancellationToken: cancellationToken) ?? [];
+    }
+
+    public async Task<DonateLotteryActivity> SaveAsync(DonateLotteryActivity activity, CancellationToken cancellationToken = default)
+    {
+        var method = activity.Id <= 0 ? HttpMethod.Post : HttpMethod.Put;
+        var path = activity.Id <= 0 ? "api/donate-activities" : $"api/donate-activities/{activity.Id}";
+        using var request = await CreateRequestAsync(method, path, cancellationToken);
+        request.Content = JsonContent.Create(activity);
+        using var response = await _httpClient.SendAsync(request, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<DonateLotteryActivity>(cancellationToken: cancellationToken) ?? activity;
+    }
+
+    public async Task DeleteAsync(int activityId, CancellationToken cancellationToken = default)
+    {
+        using var request = await CreateRequestAsync(HttpMethod.Delete, $"api/donate-activities/{activityId}", cancellationToken);
+        using var response = await _httpClient.SendAsync(request, cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
+
+    private async Task<HttpRequestMessage> CreateRequestAsync(HttpMethod method, string path, CancellationToken cancellationToken)
+    {
+        var request = new HttpRequestMessage(method, path);
+        var token = await _jsRuntime.InvokeAsync<string>("easyLotteryConfig.getAdminToken", cancellationToken);
+        if (!string.IsNullOrWhiteSpace(token))
+        {
+            request.Headers.Add(AdminHeaderName, token);
+        }
+
+        return request;
+    }
+}


### PR DESCRIPTION
## Summary

- Added a dedicated `/api/donate-activities` REST resource for listing, creating, updating, and deleting Donate activities.
- Updated the Donate Activities page to call the new API client instead of saving through the shared settings YAML endpoint.
- Kept server-side validation and persistence in the existing donate activity service, but moved the browser flow off the settings API so activity changes no longer rewrite the whole settings document.

## Validation

- `dotnet test EasyLottery.generated.sln --no-restore`