### PR TITLE
Refactor payment and overtime storage

### DIFF
--- a/src/EasyLotteryAPI/Payments/PaymentCallbackProcessor.cs
+++ b/src/EasyLotteryAPI/Payments/PaymentCallbackProcessor.cs
@@ -1,10 +1,10 @@
-using System.Text.Json;
 using System.Net;
 using System.Net.Mail;
+using EasyLotteryApplication.Payments;
 using EasyLotteryApi;
 using EasyLotteryDomain.Models.Config;
-using EasyLotteryDomain.Services;
 using EasyLotteryDomain.Models.Overtime;
+using EasyLotteryDomain.Services;
 using Microsoft.AspNetCore.SignalR;
 
 namespace EasyLotteryApi.Payments;
@@ -15,28 +15,26 @@ public sealed class PaymentCallbackProcessor
     private readonly IHubContext<OvertimeHub> _hub;
     private readonly ILogger<PaymentCallbackProcessor> _logger;
     private readonly IEasyLotteryConfigRepository _settingsStore;
-    private readonly string _paymentEventsPath;
-    private readonly string _paymentOrdersPath;
-    private readonly string _overtimeFeedPath;
-    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly IPaymentEventRepository _paymentEventRepository;
+    private readonly IPaymentOrderRepository _paymentOrderRepository;
+    private readonly IOvertimeFeedRepository _overtimeFeedRepository;
 
     public PaymentCallbackProcessor(
         PaymentProviderFactory factory,
         IHubContext<OvertimeHub> hub,
         ILogger<PaymentCallbackProcessor> logger,
-        IConfiguration configuration,
-        IWebHostEnvironment environment,
-        IEasyLotteryConfigRepository settingsStore)
+        IEasyLotteryConfigRepository settingsStore,
+        IPaymentEventRepository paymentEventRepository,
+        IPaymentOrderRepository paymentOrderRepository,
+        IOvertimeFeedRepository overtimeFeedRepository)
     {
         _factory = factory;
         _hub = hub;
         _logger = logger;
-        var storageDirectory = configuration["Storage:Directory"] ?? Path.Combine(environment.ContentRootPath, "App_Data");
-        Directory.CreateDirectory(storageDirectory);
         _settingsStore = settingsStore;
-        _paymentEventsPath = Path.Combine(storageDirectory, "easy-lottery-payment-events.json");
-        _paymentOrdersPath = Path.Combine(storageDirectory, "easy-lottery-payment-orders.json");
-        _overtimeFeedPath = Path.Combine(storageDirectory, "easy-lottery-overtime-feed.json");
+        _paymentEventRepository = paymentEventRepository;
+        _paymentOrderRepository = paymentOrderRepository;
+        _overtimeFeedRepository = overtimeFeedRepository;
     }
 
     public async Task<PaymentCallbackProcessResult> ProcessAsync(string providerId, PaymentNotificationRequest request, CancellationToken cancellationToken)
@@ -60,79 +58,70 @@ public sealed class PaymentCallbackProcessor
             return PaymentCallbackProcessResult.Rejected(notification.FailureReason);
         }
 
-        await _gate.WaitAsync(cancellationToken);
-        try
+        var paymentEvents = await _paymentEventRepository.ListAsync(cancellationToken);
+        if (paymentEvents.Any(item => string.Equals(item.ProviderId, providerId, StringComparison.OrdinalIgnoreCase) &&
+                                      string.Equals(item.ExternalId, notification.ExternalId, StringComparison.Ordinal)))
         {
-            var paymentEvents = await ReadJsonAsync<List<ProcessedPaymentEvent>>(_paymentEventsPath, cancellationToken) ?? [];
-            if (paymentEvents.Any(item => string.Equals(item.ProviderId, providerId, StringComparison.OrdinalIgnoreCase) &&
-                                          string.Equals(item.ExternalId, notification.ExternalId, StringComparison.Ordinal)))
-            {
-                return PaymentCallbackProcessResult.Duplicate();
-            }
+            return PaymentCallbackProcessResult.Duplicate();
+        }
 
-            var orders = await ReadJsonAsync<List<RegisteredPaymentOrder>>(_paymentOrdersPath, cancellationToken) ?? [];
-            var order = orders.FirstOrDefault(item => string.Equals(item.ProviderId, providerId, StringComparison.OrdinalIgnoreCase) &&
-                                                      string.Equals(item.MerchantOrderNo, notification.MerchantOrderNo, StringComparison.Ordinal));
-            if (order is not null)
-            {
-                order.Status = "paid";
-                order.PaidAtUtc = notification.OccurredAtUtc;
-                await WriteJsonAsync(_paymentOrdersPath, orders, cancellationToken);
-            }
+        var orders = (await _paymentOrderRepository.ListAsync(cancellationToken)).ToList();
+        var order = orders.FirstOrDefault(item => string.Equals(item.ProviderId, providerId, StringComparison.OrdinalIgnoreCase) &&
+                                                  string.Equals(item.MerchantOrderNo, notification.MerchantOrderNo, StringComparison.Ordinal));
+        if (order is not null)
+        {
+            order.Status = "paid";
+            order.PaidAtUtc = notification.OccurredAtUtc;
+            await _paymentOrderRepository.SaveAsync(orders, cancellationToken);
+        }
 
-            paymentEvents.Add(new ProcessedPaymentEvent
-            {
-                ProviderId = providerId,
-                ExternalId = notification.ExternalId,
-                MerchantOrderNo = notification.MerchantOrderNo,
-                Amount = notification.Amount,
-                Currency = notification.Currency,
-                Status = "paid",
-                DisplayName = order?.DisplayName ?? notification.DisplayName,
-                Message = order?.Message ?? "",
-                PaidAtUtc = notification.OccurredAtUtc,
-                ProcessedAtUtc = DateTimeOffset.UtcNow
-            });
-            await WriteJsonAsync(_paymentEventsPath, paymentEvents, cancellationToken);
+        await _paymentEventRepository.AppendAsync(new ProcessedPaymentEvent
+        {
+            ProviderId = providerId,
+            ExternalId = notification.ExternalId,
+            MerchantOrderNo = notification.MerchantOrderNo,
+            Amount = notification.Amount,
+            Currency = notification.Currency,
+            Status = "paid",
+            DisplayName = order?.DisplayName ?? notification.DisplayName,
+            Message = order?.Message ?? "",
+            PaidAtUtc = notification.OccurredAtUtc,
+            ProcessedAtUtc = DateTimeOffset.UtcNow
+        }, cancellationToken);
 
-            var donateWins = await ProcessDonateLotteryAsync(notification, provider.Descriptor.DisplayName, cancellationToken);
-            var feed = await ReadJsonAsync<List<OvertimeSupportEvent>>(_overtimeFeedPath, cancellationToken) ?? [];
+        var donateWins = await ProcessDonateLotteryAsync(notification, provider.Descriptor.DisplayName, cancellationToken);
+        var feed = (await _overtimeFeedRepository.ListAsync(cancellationToken)).ToList();
+        feed.Add(new OvertimeSupportEvent
+        {
+            Source = OvertimeSupportSource.ThirdPartyPayment,
+            SourceLabel = provider.Descriptor.DisplayName,
+            DisplayName = order?.DisplayName ?? notification.DisplayName,
+            Message = order?.Message ?? "",
+            Amount = notification.Amount,
+            AmountDisplay = $"NT${notification.Amount:N0}",
+            Currency = notification.Currency,
+            OccurredAtUtc = notification.OccurredAtUtc,
+            ExternalId = notification.ExternalId
+        });
+        foreach (var win in donateWins)
+        {
             feed.Add(new OvertimeSupportEvent
             {
                 Source = OvertimeSupportSource.ThirdPartyPayment,
-                SourceLabel = provider.Descriptor.DisplayName,
-                DisplayName = order?.DisplayName ?? notification.DisplayName,
-                Message = order?.Message ?? "",
-                Amount = notification.Amount,
-                AmountDisplay = $"NT${notification.Amount:N0}",
+                SourceLabel = "Donate 抽獎中獎",
+                DisplayName = win.DonorName,
+                Message = $"抽中 {win.PrizeName}",
+                Amount = win.Amount,
+                AmountDisplay = $"NT${win.Amount:N0}",
                 Currency = notification.Currency,
-                OccurredAtUtc = notification.OccurredAtUtc,
-                ExternalId = notification.ExternalId
+                AvatarUrl = win.PrizeImageUrl,
+                Color = "#ffd166",
+                OccurredAtUtc = win.DrawnAtUtc,
+                ExternalId = $"{win.PaymentExternalId}:{win.Id}"
             });
-            foreach (var win in donateWins)
-            {
-                feed.Add(new OvertimeSupportEvent
-                {
-                    Source = OvertimeSupportSource.ThirdPartyPayment,
-                    SourceLabel = "Donate 抽獎中獎",
-                    DisplayName = win.DonorName,
-                    Message = $"抽中 {win.PrizeName}",
-                    Amount = win.Amount,
-                    AmountDisplay = $"NT${win.Amount:N0}",
-                    Currency = notification.Currency,
-                    AvatarUrl = win.PrizeImageUrl,
-                    Color = "#ffd166",
-                    OccurredAtUtc = win.DrawnAtUtc,
-                    ExternalId = $"{win.PaymentExternalId}:{win.Id}"
-                });
-            }
-            await WriteJsonAsync(_overtimeFeedPath, feed, cancellationToken);
-            await SendResultNotificationAsync(donateWins, cancellationToken);
         }
-        finally
-        {
-            _gate.Release();
-        }
+        await _overtimeFeedRepository.SaveAsync(feed, cancellationToken);
+        await SendResultNotificationAsync(donateWins, cancellationToken);
 
         await _hub.Clients.All.SendAsync("OvertimeFeedChanged", cancellationToken);
         return PaymentCallbackProcessResult.Success();
@@ -146,35 +135,32 @@ public sealed class PaymentCallbackProcessor
             throw new ArgumentException("請提供支援的金流商與商店訂單編號。");
         }
 
-        await _gate.WaitAsync(cancellationToken);
-        try
+        var orders = (await _paymentOrderRepository.ListAsync(cancellationToken)).ToList();
+        if (orders.Any(order => string.Equals(order.ProviderId, providerId, StringComparison.OrdinalIgnoreCase) &&
+                                string.Equals(order.MerchantOrderNo, request.MerchantOrderNo.Trim(), StringComparison.Ordinal)))
         {
-            var orders = await ReadJsonAsync<List<RegisteredPaymentOrder>>(_paymentOrdersPath, cancellationToken) ?? [];
-            if (orders.Any(order => string.Equals(order.ProviderId, providerId, StringComparison.OrdinalIgnoreCase) && string.Equals(order.MerchantOrderNo, request.MerchantOrderNo.Trim(), StringComparison.Ordinal)))
-            {
-                throw new InvalidOperationException("此商店訂單編號已登記。");
-            }
-            var order = new RegisteredPaymentOrder
-            {
-                ProviderId = providerId,
-                MerchantOrderNo = request.MerchantOrderNo.Trim(),
-                DisplayName = request.DisplayName?.Trim() ?? "匿名贊助者",
-                Message = request.Message?.Trim() ?? "",
-                CreatedAtUtc = DateTimeOffset.UtcNow,
-                Status = "pending"
-            };
-            orders.Add(order);
-            await WriteJsonAsync(_paymentOrdersPath, orders, cancellationToken);
-            return order;
+            throw new InvalidOperationException("此商店訂單編號已登記。");
         }
-        finally { _gate.Release(); }
+
+        var order = new RegisteredPaymentOrder
+        {
+            ProviderId = providerId,
+            MerchantOrderNo = request.MerchantOrderNo.Trim(),
+            DisplayName = request.DisplayName?.Trim() ?? "匿名贊助者",
+            Message = request.Message?.Trim() ?? "",
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+            Status = "pending"
+        };
+        orders.Add(order);
+        await _paymentOrderRepository.SaveAsync(orders, cancellationToken);
+        return order;
     }
 
     public async Task<IReadOnlyList<ProcessedPaymentEvent>> ListProcessedEventsAsync(CancellationToken cancellationToken)
     {
-        await _gate.WaitAsync(cancellationToken);
-        try { return (await ReadJsonAsync<List<ProcessedPaymentEvent>>(_paymentEventsPath, cancellationToken) ?? []).OrderByDescending(item => item.PaidAtUtc).ToList(); }
-        finally { _gate.Release(); }
+        return (await _paymentEventRepository.ListAsync(cancellationToken))
+            .OrderByDescending(item => item.PaidAtUtc)
+            .ToList();
     }
 
     private async Task<IReadOnlyList<DonateLotteryDrawRecord>> ProcessDonateLotteryAsync(PaymentNotification notification, string paymentMethod, CancellationToken cancellationToken)
@@ -231,65 +217,4 @@ public sealed class PaymentCallbackProcessor
         "newebpay" => PaymentProviderIds.NewebPayDonation,
         _ => providerId
     };
-
-    private static async Task<T?> ReadJsonAsync<T>(string path, CancellationToken cancellationToken)
-    {
-        if (!File.Exists(path))
-        {
-            return default;
-        }
-
-        await using var stream = File.OpenRead(path);
-        return await JsonSerializer.DeserializeAsync<T>(stream, cancellationToken: cancellationToken);
-    }
-
-    private static async Task WriteJsonAsync<T>(string path, T value, CancellationToken cancellationToken)
-    {
-        var temporaryPath = $"{path}.{Guid.NewGuid():N}.tmp";
-        await using (var stream = File.Create(temporaryPath))
-        {
-            await JsonSerializer.SerializeAsync(stream, value, cancellationToken: cancellationToken);
-        }
-        File.Move(temporaryPath, path, overwrite: true);
-    }
-}
-
-public sealed class ProcessedPaymentEvent
-{
-    public string ProviderId { get; set; } = "";
-    public string ExternalId { get; set; } = "";
-    public string MerchantOrderNo { get; set; } = "";
-    public decimal Amount { get; set; }
-    public string Currency { get; set; } = "TWD";
-    public string Status { get; set; } = "paid";
-    public string DisplayName { get; set; } = "";
-    public string Message { get; set; } = "";
-    public DateTimeOffset PaidAtUtc { get; set; }
-    public DateTimeOffset ProcessedAtUtc { get; set; }
-}
-
-public sealed class PaymentOrderRegistrationRequest
-{
-    public string ProviderId { get; set; } = "";
-    public string MerchantOrderNo { get; set; } = "";
-    public string DisplayName { get; set; } = "";
-    public string Message { get; set; } = "";
-}
-
-public sealed class RegisteredPaymentOrder
-{
-    public string ProviderId { get; set; } = "";
-    public string MerchantOrderNo { get; set; } = "";
-    public string DisplayName { get; set; } = "";
-    public string Message { get; set; } = "";
-    public string Status { get; set; } = "pending";
-    public DateTimeOffset CreatedAtUtc { get; set; }
-    public DateTimeOffset? PaidAtUtc { get; set; }
-}
-
-public sealed record PaymentCallbackProcessResult(bool Accepted, bool IsDuplicate, string Error)
-{
-    public static PaymentCallbackProcessResult Success() => new(true, false, "");
-    public static PaymentCallbackProcessResult Duplicate() => new(true, true, "");
-    public static PaymentCallbackProcessResult Rejected(string error) => new(false, false, error);
 }

--- a/src/EasyLotteryAPI/Program.cs
+++ b/src/EasyLotteryAPI/Program.cs
@@ -1,8 +1,11 @@
 using System.Text;
 using System.Net;
 using System.Net.Mail;
+using System.Text.Json;
 using EasyLotteryApplication.DonateActivities;
+using EasyLotteryApplication.Payments;
 using EasyLotteryInfrastructure;
+using EasyLotteryDomain.Models.Overtime;
 using MediatR;
 using Microsoft.AspNetCore.SignalR;
 using EasyLotteryApi;
@@ -28,9 +31,6 @@ builder.Services.AddSingleton<PaymentCallbackProcessor>();
 var storageDirectory = builder.Configuration["Storage:Directory"]
     ?? Path.Combine(builder.Environment.ContentRootPath, "App_Data");
 Directory.CreateDirectory(storageDirectory);
-
-var overtimeFeedPath = Path.Combine(storageDirectory, "easy-lottery-overtime-feed.json");
-var storageGate = new SemaphoreSlim(1, 1);
 
 var app = builder.Build();
 
@@ -148,26 +148,37 @@ Func<int, HttpContext, IMediator, AdminAccess, Task<IResult>> deleteDonateActivi
 };
 app.MapDelete("/api/donate-activities/{id:int}", deleteDonateActivity);
 
-app.MapGet("/easy-lottery-overtime-feed.json", async (HttpContext context) =>
+Func<HttpContext, IOvertimeFeedRepository, AdminAccess, Task<IResult>> readOvertimeFeed = async (context, feedRepository, adminAccess) =>
 {
-    var content = await ReadFileAsync(overtimeFeedPath, "[]", context.RequestAborted);
-    return Results.Text(content, "application/json", Encoding.UTF8);
-});
+    if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
+    return Results.Text(JsonSerializer.Serialize(await feedRepository.ListAsync(context.RequestAborted)), "application/json", Encoding.UTF8);
+};
+app.MapGet("/api/overtime-feed", readOvertimeFeed);
+app.MapGet("/easy-lottery-overtime-feed.json", readOvertimeFeed);
 
-app.MapPut("/easy-lottery-overtime-feed.json", async (HttpContext context, IHubContext<OvertimeHub> hub) =>
+Func<HttpContext, IOvertimeFeedRepository, IHubContext<OvertimeHub>, AdminAccess, Task<IResult>> writeOvertimeFeed = async (context, feedRepository, hub, adminAccess) =>
 {
-    var content = await ReadRequestBodyAsync(context.Request, context.RequestAborted);
-    await WriteFileAsync(overtimeFeedPath, content, storageGate, context.RequestAborted);
+    if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
+    var body = await ReadRequestBodyAsync(context.Request, context.RequestAborted);
+    var events = string.IsNullOrWhiteSpace(body)
+        ? []
+        : JsonSerializer.Deserialize<List<OvertimeSupportEvent>>(body, new JsonSerializerOptions(JsonSerializerDefaults.Web)) ?? [];
+    await feedRepository.SaveAsync(events, context.RequestAborted);
     await hub.Clients.All.SendAsync("OvertimeFeedChanged", context.RequestAborted);
     return Results.NoContent();
-});
+};
+app.MapPut("/api/overtime-feed", writeOvertimeFeed);
+app.MapPut("/easy-lottery-overtime-feed.json", writeOvertimeFeed);
 
-app.MapDelete("/easy-lottery-overtime-feed.json", async (HttpContext context, IHubContext<OvertimeHub> hub) =>
+Func<HttpContext, IOvertimeFeedRepository, IHubContext<OvertimeHub>, AdminAccess, Task<IResult>> clearOvertimeFeed = async (context, feedRepository, hub, adminAccess) =>
 {
-    await WriteFileAsync(overtimeFeedPath, "[]", storageGate, context.RequestAborted);
+    if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
+    await feedRepository.SaveAsync([], context.RequestAborted);
     await hub.Clients.All.SendAsync("OvertimeFeedChanged", context.RequestAborted);
     return Results.NoContent();
-});
+};
+app.MapDelete("/api/overtime-feed", clearOvertimeFeed);
+app.MapDelete("/easy-lottery-overtime-feed.json", clearOvertimeFeed);
 
 app.MapPost("/api/result-notification", async (ResultNotificationRequest request) =>
 {
@@ -254,32 +265,10 @@ app.MapFallbackToFile("index.html");
 
 await app.RunAsync();
 
-static async Task<string> ReadFileAsync(string path, string fallback, CancellationToken cancellationToken)
-{
-    return File.Exists(path)
-        ? await File.ReadAllTextAsync(path, cancellationToken)
-        : fallback;
-}
-
 static async Task<string> ReadRequestBodyAsync(HttpRequest request, CancellationToken cancellationToken)
 {
     using var reader = new StreamReader(request.Body, Encoding.UTF8);
     return await reader.ReadToEndAsync(cancellationToken);
-}
-
-static async Task WriteFileAsync(string path, string content, SemaphoreSlim gate, CancellationToken cancellationToken)
-{
-    await gate.WaitAsync(cancellationToken);
-    try
-    {
-        var temporaryPath = $"{path}.{Guid.NewGuid():N}.tmp";
-        await File.WriteAllTextAsync(temporaryPath, content, Encoding.UTF8, cancellationToken);
-        File.Move(temporaryPath, path, overwrite: true);
-    }
-    finally
-    {
-        gate.Release();
-    }
 }
 
 sealed class ResultNotificationRequest

--- a/src/EasyLotteryAPI/SettingsFileStore.cs
+++ b/src/EasyLotteryAPI/SettingsFileStore.cs
@@ -37,32 +37,32 @@ public sealed class SettingsFileStore : IEasyLotteryConfigRepository, IEasyLotte
     public async Task<string> ReadForBrowserAsync(CancellationToken cancellationToken)
     {
         await using var gate = await _storageGates.AcquireAsync(cancellationToken, ConfigPath, ActivitiesPath, ActivityResultsPath);
-            var document = await ReadMergedDocumentUnsafeAsync(cancellationToken);
-            return _secrets.RedactForBrowser(_serializer.Serialize(document));
+        var document = await ReadMergedDocumentUnsafeAsync(cancellationToken);
+        return _secrets.RedactForBrowser(_serializer.Serialize(document));
     }
 
     public async Task SaveBrowserUpdateAsync(string submittedYaml, CancellationToken cancellationToken)
     {
         await using var gate = await _storageGates.AcquireAsync(cancellationToken, ConfigPath, ActivitiesPath, ActivityResultsPath);
-            var currentYaml = _serializer.Serialize(await ReadMergedDocumentUnsafeAsync(cancellationToken));
-            var mergedYaml = _secrets.MergeBrowserUpdate(currentYaml, submittedYaml);
-            var document = DeserializeConfigDocument(mergedYaml);
-            await WriteSplitDocumentsAsync(document, cancellationToken);
+        var currentYaml = _serializer.Serialize(await ReadMergedDocumentUnsafeAsync(cancellationToken));
+        var mergedYaml = _secrets.MergeBrowserUpdate(currentYaml, submittedYaml);
+        var document = DeserializeConfigDocument(mergedYaml);
+        await WriteSplitDocumentsAsync(document, cancellationToken);
     }
 
     public async Task<EasyLotteryConfigDocument> ReadAsync(CancellationToken cancellationToken)
     {
         await using var gate = await _storageGates.AcquireAsync(cancellationToken, ConfigPath, ActivitiesPath, ActivityResultsPath);
-            return await ReadMergedDocumentUnsafeAsync(cancellationToken);
+        return await ReadMergedDocumentUnsafeAsync(cancellationToken);
     }
 
     public async Task<T> UpdateAsync<T>(Func<EasyLotteryConfigDocument, T> update, CancellationToken cancellationToken)
     {
         await using var gate = await _storageGates.AcquireAsync(cancellationToken, ConfigPath, ActivitiesPath, ActivityResultsPath);
-            var document = await ReadMergedDocumentUnsafeAsync(cancellationToken);
-            var result = update(document);
-            await WriteSplitDocumentsAsync(document, cancellationToken);
-            return result;
+        var document = await ReadMergedDocumentUnsafeAsync(cancellationToken);
+        var result = update(document);
+        await WriteSplitDocumentsAsync(document, cancellationToken);
+        return result;
     }
 
     public Task<EasyLotteryConfigDocument> LoadAsync(CancellationToken cancellationToken = default) =>
@@ -71,7 +71,7 @@ public sealed class SettingsFileStore : IEasyLotteryConfigRepository, IEasyLotte
     public async Task SaveAsync(EasyLotteryConfigDocument document, CancellationToken cancellationToken = default)
     {
         await using var gate = await _storageGates.AcquireAsync(cancellationToken, ConfigPath, ActivitiesPath, ActivityResultsPath);
-            await WriteSplitDocumentsAsync(document, cancellationToken);
+        await WriteSplitDocumentsAsync(document, cancellationToken);
     }
 
     private void EnsureRepositoryDocuments()
@@ -108,14 +108,6 @@ public sealed class SettingsFileStore : IEasyLotteryConfigRepository, IEasyLotte
         await WriteDocumentAsync(ActivityResultsPath, parts.Results, cancellationToken);
     }
 
-    private void WriteSplitDocuments(EasyLotteryConfigDocument document)
-    {
-        var parts = YamlRepositoryMapper.Split(document);
-        WriteDocument(ConfigPath, parts.Settings);
-        WriteDocument(ActivitiesPath, parts.Activities);
-        WriteDocument(ActivityResultsPath, parts.Results);
-    }
-
     private async Task<SettingsYamlDocument> ReadSettingsDocumentAsync(CancellationToken cancellationToken) =>
         await ReadDocumentAsync(ConfigPath, new SettingsYamlDocument(), cancellationToken);
 
@@ -124,12 +116,6 @@ public sealed class SettingsFileStore : IEasyLotteryConfigRepository, IEasyLotte
 
     private async Task<ActivityResultsYamlDocument> ReadActivityResultsDocumentAsync(CancellationToken cancellationToken) =>
         await ReadDocumentAsync(ActivityResultsPath, new ActivityResultsYamlDocument(), cancellationToken);
-
-    private ActivitiesYamlDocument ReadActivitiesDocument(string path) =>
-        File.Exists(path) ? DeserializeDocument<ActivitiesYamlDocument>(File.ReadAllText(path)) : new ActivitiesYamlDocument();
-
-    private ActivityResultsYamlDocument ReadActivityResultsDocument(string path) =>
-        File.Exists(path) ? DeserializeDocument<ActivityResultsYamlDocument>(File.ReadAllText(path)) : new ActivityResultsYamlDocument();
 
     private async Task<T> ReadDocumentAsync<T>(string path, T fallback, CancellationToken cancellationToken) where T : class
     {

--- a/src/EasyLotteryApplication/Payments/PaymentCallbackModels.cs
+++ b/src/EasyLotteryApplication/Payments/PaymentCallbackModels.cs
@@ -1,0 +1,59 @@
+namespace EasyLotteryApplication.Payments;
+
+public sealed class ProcessedPaymentEvent
+{
+    public string ProviderId { get; set; } = "";
+    public string ExternalId { get; set; } = "";
+    public string MerchantOrderNo { get; set; } = "";
+    public decimal Amount { get; set; }
+    public string Currency { get; set; } = "TWD";
+    public string Status { get; set; } = "paid";
+    public string DisplayName { get; set; } = "";
+    public string Message { get; set; } = "";
+    public DateTimeOffset PaidAtUtc { get; set; }
+    public DateTimeOffset ProcessedAtUtc { get; set; }
+}
+
+public sealed class PaymentOrderRegistrationRequest
+{
+    public string ProviderId { get; set; } = "";
+    public string MerchantOrderNo { get; set; } = "";
+    public string DisplayName { get; set; } = "";
+    public string Message { get; set; } = "";
+}
+
+public sealed class RegisteredPaymentOrder
+{
+    public string ProviderId { get; set; } = "";
+    public string MerchantOrderNo { get; set; } = "";
+    public string DisplayName { get; set; } = "";
+    public string Message { get; set; } = "";
+    public string Status { get; set; } = "pending";
+    public DateTimeOffset CreatedAtUtc { get; set; }
+    public DateTimeOffset? PaidAtUtc { get; set; }
+}
+
+public sealed record PaymentCallbackProcessResult(bool Accepted, bool IsDuplicate, string Error)
+{
+    public static PaymentCallbackProcessResult Success() => new(true, false, "");
+    public static PaymentCallbackProcessResult Duplicate() => new(true, true, "");
+    public static PaymentCallbackProcessResult Rejected(string error) => new(false, false, error);
+}
+
+public interface IPaymentEventRepository
+{
+    Task<IReadOnlyList<ProcessedPaymentEvent>> ListAsync(CancellationToken cancellationToken = default);
+    Task AppendAsync(ProcessedPaymentEvent paymentEvent, CancellationToken cancellationToken = default);
+}
+
+public interface IPaymentOrderRepository
+{
+    Task<IReadOnlyList<RegisteredPaymentOrder>> ListAsync(CancellationToken cancellationToken = default);
+    Task SaveAsync(IReadOnlyList<RegisteredPaymentOrder> orders, CancellationToken cancellationToken = default);
+}
+
+public interface IOvertimeFeedRepository
+{
+    Task<IReadOnlyList<EasyLotteryDomain.Models.Overtime.OvertimeSupportEvent>> ListAsync(CancellationToken cancellationToken = default);
+    Task SaveAsync(IReadOnlyList<EasyLotteryDomain.Models.Overtime.OvertimeSupportEvent> events, CancellationToken cancellationToken = default);
+}

--- a/src/EasyLotteryInfrastructure/DependencyInjection.cs
+++ b/src/EasyLotteryInfrastructure/DependencyInjection.cs
@@ -1,5 +1,7 @@
 using EasyLotteryApplication.DonateActivities;
+using EasyLotteryApplication.Payments;
 using EasyLotteryInfrastructure.DonateActivities;
+using EasyLotteryInfrastructure.Payments;
 using EasyLotteryInfrastructure.Storage;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -14,6 +16,12 @@ public static class DependencyInjection
         services.AddSingleton<IDonateActivityEventStore>(sp => sp.GetRequiredService<YamlDonateActivityEventStore>());
         services.AddSingleton<YamlDonateActivityRepository>();
         services.AddSingleton<IDonateLotteryActivityRepository>(sp => sp.GetRequiredService<YamlDonateActivityRepository>());
+        services.AddSingleton<JsonPaymentEventRepository>();
+        services.AddSingleton<IPaymentEventRepository>(sp => sp.GetRequiredService<JsonPaymentEventRepository>());
+        services.AddSingleton<JsonPaymentOrderRepository>();
+        services.AddSingleton<IPaymentOrderRepository>(sp => sp.GetRequiredService<JsonPaymentOrderRepository>());
+        services.AddSingleton<JsonOvertimeFeedRepository>();
+        services.AddSingleton<IOvertimeFeedRepository>(sp => sp.GetRequiredService<JsonOvertimeFeedRepository>());
         return services;
     }
 }

--- a/src/EasyLotteryInfrastructure/Payments/JsonOvertimeFeedRepository.cs
+++ b/src/EasyLotteryInfrastructure/Payments/JsonOvertimeFeedRepository.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using EasyLotteryApplication.Payments;
+using EasyLotteryDomain.Models.Overtime;
+using EasyLotteryInfrastructure.Storage;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace EasyLotteryInfrastructure.Payments;
+
+public sealed class JsonOvertimeFeedRepository : IOvertimeFeedRepository
+{
+    private readonly IStorageGateProvider _storageGates;
+    public string StoragePath { get; }
+
+    public JsonOvertimeFeedRepository(IConfiguration configuration, IHostEnvironment environment, IStorageGateProvider storageGates)
+    {
+        _storageGates = storageGates;
+        var storageDirectory = configuration["Storage:Directory"] ?? Path.Combine(environment.ContentRootPath, "App_Data");
+        Directory.CreateDirectory(storageDirectory);
+        StoragePath = Path.Combine(storageDirectory, "easy-lottery-overtime-feed.json");
+    }
+
+    public async Task<IReadOnlyList<OvertimeSupportEvent>> ListAsync(CancellationToken cancellationToken = default)
+    {
+        await using var gate = await _storageGates.AcquireAsync(cancellationToken, StoragePath);
+        return await ReadUnsafeAsync(cancellationToken);
+    }
+
+    public async Task SaveAsync(IReadOnlyList<OvertimeSupportEvent> events, CancellationToken cancellationToken = default)
+    {
+        await using var gate = await _storageGates.AcquireAsync(cancellationToken, StoragePath);
+        await WriteUnsafeAsync(events, cancellationToken);
+    }
+
+    internal async Task<IReadOnlyList<OvertimeSupportEvent>> ReadUnsafeAsync(CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(StoragePath))
+        {
+            return [];
+        }
+
+        await using var stream = File.OpenRead(StoragePath);
+        return (await JsonSerializer.DeserializeAsync<List<OvertimeSupportEvent>>(stream, cancellationToken: cancellationToken)) ?? [];
+    }
+
+    internal async Task WriteUnsafeAsync(IReadOnlyList<OvertimeSupportEvent> events, CancellationToken cancellationToken = default)
+    {
+        var temporaryPath = $"{StoragePath}.{Guid.NewGuid():N}.tmp";
+        await using (var stream = File.Create(temporaryPath))
+        {
+            await JsonSerializer.SerializeAsync(stream, events, cancellationToken: cancellationToken);
+        }
+        File.Move(temporaryPath, StoragePath, overwrite: true);
+    }
+}

--- a/src/EasyLotteryInfrastructure/Payments/JsonPaymentRepositories.cs
+++ b/src/EasyLotteryInfrastructure/Payments/JsonPaymentRepositories.cs
@@ -1,0 +1,103 @@
+using System.Text.Json;
+using EasyLotteryApplication.Payments;
+using EasyLotteryInfrastructure.Storage;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace EasyLotteryInfrastructure.Payments;
+
+public sealed class JsonPaymentEventRepository : IPaymentEventRepository
+{
+    private readonly IStorageGateProvider _storageGates;
+    public string StoragePath { get; }
+
+    public JsonPaymentEventRepository(IConfiguration configuration, IHostEnvironment environment, IStorageGateProvider storageGates)
+    {
+        _storageGates = storageGates;
+        var storageDirectory = configuration["Storage:Directory"] ?? Path.Combine(environment.ContentRootPath, "App_Data");
+        Directory.CreateDirectory(storageDirectory);
+        StoragePath = System.IO.Path.Combine(storageDirectory, "easy-lottery-payment-events.json");
+    }
+
+    public async Task<IReadOnlyList<ProcessedPaymentEvent>> ListAsync(CancellationToken cancellationToken = default)
+    {
+        await using var gate = await _storageGates.AcquireAsync(cancellationToken, StoragePath);
+        return await ReadUnsafeAsync(cancellationToken);
+    }
+
+    public async Task AppendAsync(ProcessedPaymentEvent paymentEvent, CancellationToken cancellationToken = default)
+    {
+        await using var gate = await _storageGates.AcquireAsync(cancellationToken, StoragePath);
+        var items = (await ReadUnsafeAsync(cancellationToken)).ToList();
+        items.Add(paymentEvent);
+        await WriteUnsafeAsync(items, cancellationToken);
+    }
+
+    internal async Task<IReadOnlyList<ProcessedPaymentEvent>> ReadUnsafeAsync(CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(StoragePath))
+        {
+            return [];
+        }
+
+        await using var stream = File.OpenRead(StoragePath);
+        return (await JsonSerializer.DeserializeAsync<List<ProcessedPaymentEvent>>(stream, cancellationToken: cancellationToken)) ?? [];
+    }
+
+    internal async Task WriteUnsafeAsync(IReadOnlyList<ProcessedPaymentEvent> items, CancellationToken cancellationToken = default)
+    {
+        var temporaryPath = $"{StoragePath}.{Guid.NewGuid():N}.tmp";
+        await using (var stream = File.Create(temporaryPath))
+        {
+            await JsonSerializer.SerializeAsync(stream, items, cancellationToken: cancellationToken);
+        }
+        File.Move(temporaryPath, StoragePath, overwrite: true);
+    }
+}
+
+public sealed class JsonPaymentOrderRepository : IPaymentOrderRepository
+{
+    private readonly IStorageGateProvider _storageGates;
+    public string StoragePath { get; }
+
+    public JsonPaymentOrderRepository(IConfiguration configuration, IHostEnvironment environment, IStorageGateProvider storageGates)
+    {
+        _storageGates = storageGates;
+        var storageDirectory = configuration["Storage:Directory"] ?? Path.Combine(environment.ContentRootPath, "App_Data");
+        Directory.CreateDirectory(storageDirectory);
+        StoragePath = System.IO.Path.Combine(storageDirectory, "easy-lottery-payment-orders.json");
+    }
+
+    public async Task<IReadOnlyList<RegisteredPaymentOrder>> ListAsync(CancellationToken cancellationToken = default)
+    {
+        await using var gate = await _storageGates.AcquireAsync(cancellationToken, StoragePath);
+        return await ReadUnsafeAsync(cancellationToken);
+    }
+
+    public async Task SaveAsync(IReadOnlyList<RegisteredPaymentOrder> orders, CancellationToken cancellationToken = default)
+    {
+        await using var gate = await _storageGates.AcquireAsync(cancellationToken, StoragePath);
+        await WriteUnsafeAsync(orders, cancellationToken);
+    }
+
+    internal async Task<IReadOnlyList<RegisteredPaymentOrder>> ReadUnsafeAsync(CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(StoragePath))
+        {
+            return [];
+        }
+
+        await using var stream = File.OpenRead(StoragePath);
+        return (await JsonSerializer.DeserializeAsync<List<RegisteredPaymentOrder>>(stream, cancellationToken: cancellationToken)) ?? [];
+    }
+
+    internal async Task WriteUnsafeAsync(IReadOnlyList<RegisteredPaymentOrder> orders, CancellationToken cancellationToken = default)
+    {
+        var temporaryPath = $"{StoragePath}.{Guid.NewGuid():N}.tmp";
+        await using (var stream = File.Create(temporaryPath))
+        {
+            await JsonSerializer.SerializeAsync(stream, orders, cancellationToken: cancellationToken);
+        }
+        File.Move(temporaryPath, StoragePath, overwrite: true);
+    }
+}

--- a/src/EasyLotteryWasm/Pages/DonateActivities.razor
+++ b/src/EasyLotteryWasm/Pages/DonateActivities.razor
@@ -26,53 +26,67 @@
     </div>
 }
 
-@if (editing is not null && !requiresAdminToken)
-{
-    <Card class="mb-4">
-        <CardHeader><CardTitle>@(editing.Id == 0 ? "新增" : "編輯") Donate 活動</CardTitle></CardHeader>
-        <CardBody>
-            <div class="row g-3">
-                <div class="col-md-6"><Field><FieldLabel>活動名稱</FieldLabel><TextInput @bind-Value="editing.Name" /></Field></div>
-                <div class="col-md-3"><Field><FieldLabel>類型</FieldLabel><Select TValue="DonateLotteryActivityType" @bind-SelectedValue="editing.Type"><SelectItem Value="DonateLotteryActivityType.Postcard">明信片</SelectItem><SelectItem Value="DonateLotteryActivityType.Polaroid">拍立得</SelectItem></Select></Field></div>
-                <div class="col-md-3"><Field><FieldLabel>最低贊助金額</FieldLabel><NumericInput TValue="decimal" @bind-Value="editing.MinimumDonationAmount" Min="1" /></Field></div>
-                <div class="col-md-3"><Field><FieldLabel>抽獎動畫</FieldLabel><Select TValue="DonateLotteryAnimation" @bind-SelectedValue="editing.Animation"><SelectItem Value="DonateLotteryAnimation.IchibanKuji">一番賞</SelectItem><SelectItem Value="DonateLotteryAnimation.Gacha">扭蛋</SelectItem><SelectItem Value="DonateLotteryAnimation.Garagara">日式滾筒</SelectItem><SelectItem Value="DonateLotteryAnimation.MoneyBox">塞錢箱／詩籤</SelectItem></Select></Field></div>
-                <div class="col-md-4"><Field><FieldLabel>開始時間（本地時區）</FieldLabel><input class="form-control" type="datetime-local" value="@StartDateText" @onchange="OnStartDateChanged" /></Field></div>
-                <div class="col-md-4"><Field><FieldLabel>結束時間（本地時區）</FieldLabel><input class="form-control" type="datetime-local" value="@EndDateText" @onchange="OnEndDateChanged" /></Field></div>
-                <div class="col-md-2"><Field><FieldLabel>啟用</FieldLabel><Switch TValue="bool" @bind-Value="editing.IsEnabled" /></Field></div>
-            </div>
-            <h5 class="mt-4">獎項</h5>
-            <p class="text-muted">每個獎項設定 0–100% 的中獎率；未配置的剩餘機率固定為「銘謝惠顧」。合計不可超過 100%。</p>
-            <div class="row g-2 mb-1 d-none d-md-flex small fw-bold text-muted" aria-hidden="true">
-                <div class="col-md-3">獎項名稱</div>
-                <div class="col-md-2">中獎機率 (%)</div>
-                <div class="col-md-2">圖片 URL</div>
-                <div class="col-md-1">數量</div>
-                <div class="col-md-2">最大獎</div>
-                <div class="col-md-2">操作</div>
-            </div>
-            @foreach (var prize in editing.Prizes)
+<Modal Visible="@editorVisible"
+       VisibleChanged="@OnEditorVisibleChanged"
+       Centered
+       Scrollable
+       ShowBackdrop>
+    <ModalContent>
+        <ModalHeader>
+            <ModalTitle>@EditorTitle</ModalTitle>
+            <CloseButton Clicked="@CloseEditorAsync" />
+        </ModalHeader>
+        <ModalBody>
+            @if (editing is not null)
             {
-                <div class="row g-2 mb-2" @key="prize">
-                    <div class="col-md-3"><TextInput @bind-Value="prize.Name" Placeholder="獎項名稱" /></div>
-                    <div class="col-md-2"><NumericInput TValue="decimal" @bind-Value="prize.Probability" Min="0" Max="100" Placeholder="機率 (%)" /></div>
-                    <div class="col-md-2"><TextInput @bind-Value="prize.ImageUrl" Placeholder="圖片 URL" /></div>
-                    <div class="col-md-1"><NumericInput TValue="int" @bind-Value="prize.Quantity" Min="0" /></div>
-                    <div class="col-md-2"><Switch TValue="bool" @bind-Value="prize.IsGrandPrize" /> <small>最大獎</small></div>
-                    <div class="col-md-2"><Button Color="Color.Danger" Size="Size.Small" Clicked="() => editing.Prizes.Remove(prize)">移除</Button></div>
+                <div class="row g-3">
+                    <div class="col-md-6"><Field><FieldLabel>活動名稱</FieldLabel><TextInput @bind-Value="editing.Name" /></Field></div>
+                    <div class="col-md-3"><Field><FieldLabel>類型</FieldLabel><Select TValue="DonateLotteryActivityType" @bind-SelectedValue="editing.Type"><SelectItem Value="DonateLotteryActivityType.Postcard">明信片</SelectItem><SelectItem Value="DonateLotteryActivityType.Polaroid">拍立得</SelectItem></Select></Field></div>
+                    <div class="col-md-3"><Field><FieldLabel>最低贊助金額</FieldLabel><NumericInput TValue="decimal" @bind-Value="editing.MinimumDonationAmount" Min="1" /></Field></div>
+                    <div class="col-md-3"><Field><FieldLabel>抽獎動畫</FieldLabel><Select TValue="DonateLotteryAnimation" @bind-SelectedValue="editing.Animation"><SelectItem Value="DonateLotteryAnimation.IchibanKuji">一番賞</SelectItem><SelectItem Value="DonateLotteryAnimation.Gacha">扭蛋</SelectItem><SelectItem Value="DonateLotteryAnimation.Garagara">日式滾筒</SelectItem><SelectItem Value="DonateLotteryAnimation.MoneyBox">塞錢箱／詩籤</SelectItem></Select></Field></div>
+                    <div class="col-md-4"><Field><FieldLabel>開始時間（本地時區）</FieldLabel><input class="form-control" type="datetime-local" value="@StartDateText" @onchange="OnStartDateChanged" /></Field></div>
+                    <div class="col-md-4"><Field><FieldLabel>結束時間（本地時區）</FieldLabel><input class="form-control" type="datetime-local" value="@EndDateText" @onchange="OnEndDateChanged" /></Field></div>
+                    <div class="col-md-2"><Field><FieldLabel>啟用</FieldLabel><Switch TValue="bool" @bind-Value="editing.IsEnabled" /></Field></div>
                 </div>
-            }
-            <div class="alert @(ProbabilityTotalExceeded ? "alert-danger" : "alert-info") py-2 mb-2" role="status">
-                目前獎項機率合計：@PrizeProbabilityTotal.ToString("0.##")%　／　銘謝惠顧：@Math.Max(0m, 100m - PrizeProbabilityTotal).ToString("0.##")%
-                @if (ProbabilityTotalExceeded)
+                <h5 class="mt-4">獎項</h5>
+                <p class="text-muted">每個獎項設定 0–100% 的中獎率；未配置的剩餘機率固定為「銘謝惠顧」。合計不可超過 100%。</p>
+                <div class="row g-2 mb-1 d-none d-md-flex small fw-bold text-muted" aria-hidden="true">
+                    <div class="col-md-3">獎項名稱</div>
+                    <div class="col-md-2">中獎機率 (%)</div>
+                    <div class="col-md-2">圖片 URL</div>
+                    <div class="col-md-1">數量</div>
+                    <div class="col-md-2">最大獎</div>
+                    <div class="col-md-2">操作</div>
+                </div>
+                @foreach (var prize in editing.Prizes)
                 {
-                    <strong class="ms-2">機率總和不可超過 100%，請調整獎項機率後再儲存。</strong>
+                    <div class="row g-2 mb-2" @key="prize">
+                        <div class="col-md-3"><TextInput @bind-Value="prize.Name" Placeholder="獎項名稱" /></div>
+                        <div class="col-md-2"><NumericInput TValue="decimal" @bind-Value="prize.Probability" Min="0" Max="100" Placeholder="機率 (%)" /></div>
+                        <div class="col-md-2"><TextInput @bind-Value="prize.ImageUrl" Placeholder="圖片 URL" /></div>
+                        <div class="col-md-1"><NumericInput TValue="int" @bind-Value="prize.Quantity" Min="0" /></div>
+                        <div class="col-md-2"><Switch TValue="bool" @bind-Value="prize.IsGrandPrize" /> <small>最大獎</small></div>
+                        <div class="col-md-2"><Button Color="Color.Danger" Size="Size.Small" Clicked="() => editing.Prizes.Remove(prize)">移除</Button></div>
+                    </div>
                 }
+                <div class="alert @(ProbabilityTotalExceeded ? "alert-danger" : "alert-info") py-2 mb-2" role="status">
+                    目前獎項機率合計：@PrizeProbabilityTotal.ToString("0.##")%　／　銘謝惠顧：@Math.Max(0m, 100m - PrizeProbabilityTotal).ToString("0.##")%
+                    @if (ProbabilityTotalExceeded)
+                    {
+                        <strong class="ms-2">機率總和不可超過 100%，請調整獎項機率後再儲存。</strong>
+                    }
+                </div>
+                <Button Color="Color.Secondary" Size="Size.Small" Clicked="AddPrize">新增獎項</Button>
+            }
+        </ModalBody>
+        <ModalFooter>
+            <div class="d-flex gap-2">
+                <Button Color="Color.Primary" Clicked="SaveAsync" Disabled="ProbabilityTotalExceeded || editing is null">儲存</Button>
+                <Button Color="Color.Secondary" Clicked="@CloseEditorAsync">取消</Button>
             </div>
-            <Button Color="Color.Secondary" Size="Size.Small" Clicked="AddPrize">新增獎項</Button>
-            <div class="d-flex gap-2 mt-4"><Button Color="Color.Primary" Clicked="SaveAsync" Disabled="ProbabilityTotalExceeded">儲存</Button><Button Color="Color.Secondary" Clicked="() => editing = null">取消</Button></div>
-        </CardBody>
-    </Card>
-}
+        </ModalFooter>
+    </ModalContent>
+</Modal>
 
 @if (!requiresAdminToken)
 {
@@ -90,7 +104,11 @@
 @code {
     private IReadOnlyList<DonateLotteryActivity> activities = [];
     private DonateLotteryActivity? editing;
+    private bool editorVisible;
     private bool requiresAdminToken;
+    private string EditorTitle => editing is null
+        ? "Donate 活動"
+        : editing.Id == 0 ? "新增 Donate 活動" : $"編輯 Donate 活動：{editing.Name}";
     private string StartDateText => editing?.StartsAtUtc.LocalDateTime.ToString("yyyy-MM-ddTHH:mm") ?? "";
     private string EndDateText => editing?.EndsAtUtc.LocalDateTime.ToString("yyyy-MM-ddTHH:mm") ?? "";
 
@@ -109,8 +127,44 @@
     private async Task ReloadAsync() => activities = await DonateLotteryActivityApiClient.ListAsync();
     private decimal PrizeProbabilityTotal => editing?.Prizes.Sum(prize => prize.Probability) ?? 0m;
     private bool ProbabilityTotalExceeded => PrizeProbabilityTotal > 100m;
-    private Task CreateAsync() { editing = new DonateLotteryActivity { StartsAtUtc = DateTimeOffset.UtcNow, EndsAtUtc = DateTimeOffset.UtcNow.AddDays(7), Prizes = [new DonateLotteryPrize { Probability = 100m }] }; return Task.CompletedTask; }
-    private void Edit(DonateLotteryActivity activity) => editing = new DonateLotteryActivity { Id = activity.Id, Name = activity.Name, Type = activity.Type, Animation = activity.Animation, MinimumDonationAmount = activity.MinimumDonationAmount, StartsAtUtc = activity.StartsAtUtc, EndsAtUtc = activity.EndsAtUtc, IsEnabled = activity.IsEnabled, Prizes = activity.Prizes.Select(prize => new DonateLotteryPrize { Id = prize.Id, Name = prize.Name, ImageUrl = prize.ImageUrl, Quantity = prize.Quantity, RemainingQuantity = prize.RemainingQuantity, Probability = prize.Probability, IsGrandPrize = prize.IsGrandPrize }).ToList() };
+    private Task CreateAsync()
+    {
+        editing = new DonateLotteryActivity
+        {
+            StartsAtUtc = DateTimeOffset.UtcNow,
+            EndsAtUtc = DateTimeOffset.UtcNow.AddDays(7),
+            Prizes = [new DonateLotteryPrize { Probability = 100m }]
+        };
+        editorVisible = true;
+        return Task.CompletedTask;
+    }
+
+    private void Edit(DonateLotteryActivity activity)
+    {
+        editing = new DonateLotteryActivity
+        {
+            Id = activity.Id,
+            Name = activity.Name,
+            Type = activity.Type,
+            Animation = activity.Animation,
+            MinimumDonationAmount = activity.MinimumDonationAmount,
+            StartsAtUtc = activity.StartsAtUtc,
+            EndsAtUtc = activity.EndsAtUtc,
+            IsEnabled = activity.IsEnabled,
+            Prizes = activity.Prizes.Select(prize => new DonateLotteryPrize
+            {
+                Id = prize.Id,
+                Name = prize.Name,
+                ImageUrl = prize.ImageUrl,
+                Quantity = prize.Quantity,
+                RemainingQuantity = prize.RemainingQuantity,
+                Probability = prize.Probability,
+                IsGrandPrize = prize.IsGrandPrize
+            }).ToList()
+        };
+        editorVisible = true;
+    }
+
     private void AddPrize() => editing?.Prizes.Add(new DonateLotteryPrize());
     private async Task SaveAsync()
     {
@@ -118,7 +172,7 @@
         try
         {
             await DonateLotteryActivityApiClient.SaveAsync(editing);
-            editing = null;
+            await CloseEditorAsync();
             await ReloadAsync();
             await MessageService.Success("Donate 活動已儲存。");
         }
@@ -128,6 +182,25 @@
             await MessageService.Error(exception.Message);
         }
     }
+
+    private Task CloseEditorAsync()
+    {
+        editorVisible = false;
+        editing = null;
+        return Task.CompletedTask;
+    }
+
+    private Task OnEditorVisibleChanged(bool visible)
+    {
+        editorVisible = visible;
+        if (!visible)
+        {
+            editing = null;
+        }
+
+        return Task.CompletedTask;
+    }
+
     private async Task DeleteAsync(DonateLotteryActivity activity)
     {
         var confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"確定要刪除「{activity.Name}」嗎？活動設定與獎項會被移除，但既有抽獎紀錄會保留。");
@@ -135,7 +208,10 @@
         try
         {
             await DonateLotteryActivityApiClient.DeleteAsync(activity.Id);
-            if (editing?.Id == activity.Id) editing = null;
+            if (editing?.Id == activity.Id)
+            {
+                await CloseEditorAsync();
+            }
             await ReloadAsync();
             await MessageService.Success("Donate 活動已刪除，既有抽獎紀錄會保留。");
         }

--- a/src/EasyLotteryWasm/wwwroot/index.html
+++ b/src/EasyLotteryWasm/wwwroot/index.html
@@ -202,7 +202,7 @@
             }
 
             const storageKey = "easy-lottery.overtime-feed";
-            const remoteFeedUrl = "/easy-lottery-overtime-feed.json";
+            const remoteFeedUrl = "/api/overtime-feed";
             let nextRemoteAttemptAt = 0;
 
             function getSafeContent(content) {


### PR DESCRIPTION
整理內容：
- 將 payment callback 的檔案 IO 拆成 repository，讓 processor 只負責流程協調
- 將 overtime feed 改成 repository + API route，不再直接讀寫 JSON 檔
- 保留 settings / activities / results 的 YAML 拆分結構，並清理 SettingsFileStore
- Donate 活動新增/編輯改成 Dialog，改善頁面資訊密度
- 前端 overtime feed 改走 /api/overtime-feed

驗證：
- dotnet test EasyLottery.generated.sln --no-restore
- git diff --check