### PR TITLE
Split config repositories by YAML document

### DIFF
--- a/src/EasyLotteryAPI/SettingsFileStore.cs
+++ b/src/EasyLotteryAPI/SettingsFileStore.cs
@@ -1,7 +1,6 @@
 using EasyLotteryDomain.Models.Config;
 using EasyLotteryDomain.Services;
-using EasyLotteryInfrastructure.Storage;
-using Microsoft.Extensions.Hosting;
+using EasyLotteryInfrastructure.Settings;
 using YamlDotNet.Serialization;
 
 namespace EasyLotteryApi;
@@ -9,10 +8,12 @@ namespace EasyLotteryApi;
 /// <summary>YAML-backed repository for the EasyLottery configuration.</summary>
 public sealed class SettingsFileStore : IEasyLotteryConfigRepository, IEasyLotteryConfigStore
 {
-    private readonly IStorageGateProvider _storageGates;
     private readonly ConfigSecretRedactor _secrets;
-    private readonly IDeserializer _deserializer = YamlSerialization.CreateDeserializerBuilder().Build();
     private readonly ISerializer _serializer = YamlSerialization.CreateSerializerBuilder().Build();
+    private readonly IDeserializer _deserializer = YamlSerialization.CreateDeserializerBuilder().Build();
+    private readonly YamlSettingsDocumentRepository _settingsRepository;
+    private readonly YamlActivitiesDocumentRepository _activitiesRepository;
+    private readonly YamlActivityResultsDocumentRepository _resultsRepository;
 
     public string ConfigPath { get; }
 
@@ -20,131 +21,76 @@ public sealed class SettingsFileStore : IEasyLotteryConfigRepository, IEasyLotte
 
     public string ActivityResultsPath { get; }
 
-    public SettingsFileStore(IConfiguration configuration, IHostEnvironment environment, ConfigSecretRedactor secrets, IStorageGateProvider storageGates)
+    public SettingsFileStore(
+        ConfigSecretRedactor secrets,
+        YamlSettingsDocumentRepository settingsRepository,
+        YamlActivitiesDocumentRepository activitiesRepository,
+        YamlActivityResultsDocumentRepository resultsRepository)
     {
         _secrets = secrets;
-        _storageGates = storageGates;
-        var directory = configuration["Storage:Directory"] ?? Path.Combine(environment.ContentRootPath, "App_Data");
-        Directory.CreateDirectory(directory);
-
-        ConfigPath = Path.Combine(directory, "settings.yaml");
-        ActivitiesPath = Path.Combine(directory, "activities.yaml");
-        ActivityResultsPath = Path.Combine(directory, "activity-results.yaml");
-
-        EnsureRepositoryDocuments();
+        _settingsRepository = settingsRepository;
+        _activitiesRepository = activitiesRepository;
+        _resultsRepository = resultsRepository;
+        ConfigPath = settingsRepository.StoragePath;
+        ActivitiesPath = activitiesRepository.StoragePath;
+        ActivityResultsPath = resultsRepository.StoragePath;
     }
 
     public async Task<string> ReadForBrowserAsync(CancellationToken cancellationToken)
     {
-        await using var gate = await _storageGates.AcquireAsync(cancellationToken, ConfigPath, ActivitiesPath, ActivityResultsPath);
-        var document = await ReadMergedDocumentUnsafeAsync(cancellationToken);
+        var document = await ReadMergedDocumentAsync(cancellationToken);
         return _secrets.RedactForBrowser(_serializer.Serialize(document));
     }
 
     public async Task SaveBrowserUpdateAsync(string submittedYaml, CancellationToken cancellationToken)
     {
-        await using var gate = await _storageGates.AcquireAsync(cancellationToken, ConfigPath, ActivitiesPath, ActivityResultsPath);
-        var currentYaml = _serializer.Serialize(await ReadMergedDocumentUnsafeAsync(cancellationToken));
+        var currentYaml = _serializer.Serialize(await ReadMergedDocumentAsync(cancellationToken));
         var mergedYaml = _secrets.MergeBrowserUpdate(currentYaml, submittedYaml);
-        var document = DeserializeConfigDocument(mergedYaml);
-        await WriteSplitDocumentsAsync(document, cancellationToken);
-    }
-
-    public async Task<EasyLotteryConfigDocument> ReadAsync(CancellationToken cancellationToken)
-    {
-        await using var gate = await _storageGates.AcquireAsync(cancellationToken, ConfigPath, ActivitiesPath, ActivityResultsPath);
-        return await ReadMergedDocumentUnsafeAsync(cancellationToken);
-    }
-
-    public async Task<T> UpdateAsync<T>(Func<EasyLotteryConfigDocument, T> update, CancellationToken cancellationToken)
-    {
-        await using var gate = await _storageGates.AcquireAsync(cancellationToken, ConfigPath, ActivitiesPath, ActivityResultsPath);
-        var document = await ReadMergedDocumentUnsafeAsync(cancellationToken);
-        var result = update(document);
-        await WriteSplitDocumentsAsync(document, cancellationToken);
-        return result;
+        var document = string.IsNullOrWhiteSpace(mergedYaml)
+            ? new EasyLotteryConfigDocument()
+            : _deserializer.Deserialize<EasyLotteryConfigDocument>(mergedYaml) ?? new EasyLotteryConfigDocument();
+        await SaveSplitDocumentsAsync(document, cancellationToken);
     }
 
     public Task<EasyLotteryConfigDocument> LoadAsync(CancellationToken cancellationToken = default) =>
         ReadAsync(cancellationToken);
 
+    public Task<EasyLotteryConfigDocument> ReadAsync(CancellationToken cancellationToken)
+    {
+        return ReadMergedDocumentAsync(cancellationToken);
+    }
+
+    public Task<T> UpdateAsync<T>(Func<EasyLotteryConfigDocument, T> update, CancellationToken cancellationToken)
+    {
+        return UpdateAsyncInternal(update, cancellationToken);
+    }
+
     public async Task SaveAsync(EasyLotteryConfigDocument document, CancellationToken cancellationToken = default)
     {
-        await using var gate = await _storageGates.AcquireAsync(cancellationToken, ConfigPath, ActivitiesPath, ActivityResultsPath);
-        await WriteSplitDocumentsAsync(document, cancellationToken);
+        await SaveSplitDocumentsAsync(document, cancellationToken);
     }
 
-    private void EnsureRepositoryDocuments()
+    private async Task<T> UpdateAsyncInternal<T>(Func<EasyLotteryConfigDocument, T> update, CancellationToken cancellationToken)
     {
-        if (!File.Exists(ConfigPath))
-        {
-            WriteDocument(ConfigPath, new SettingsYamlDocument());
-        }
-
-        if (!File.Exists(ActivitiesPath))
-        {
-            WriteDocument(ActivitiesPath, new ActivitiesYamlDocument());
-        }
-
-        if (!File.Exists(ActivityResultsPath))
-        {
-            WriteDocument(ActivityResultsPath, new ActivityResultsYamlDocument());
-        }
+        var document = await ReadMergedDocumentAsync(cancellationToken);
+        var result = update(document);
+        await SaveSplitDocumentsAsync(document, cancellationToken);
+        return result;
     }
 
-    private async Task<EasyLotteryConfigDocument> ReadMergedDocumentUnsafeAsync(CancellationToken cancellationToken)
+    private async Task<EasyLotteryConfigDocument> ReadMergedDocumentAsync(CancellationToken cancellationToken)
     {
-        var settings = await ReadSettingsDocumentAsync(cancellationToken);
-        var activities = await ReadActivitiesDocumentAsync(cancellationToken);
-        var results = await ReadActivityResultsDocumentAsync(cancellationToken);
+        var settings = await _settingsRepository.ReadAsync(cancellationToken);
+        var activities = await _activitiesRepository.ReadAsync(cancellationToken);
+        var results = await _resultsRepository.ReadAsync(cancellationToken);
         return YamlRepositoryMapper.Merge(settings, activities, results);
     }
 
-    private async Task WriteSplitDocumentsAsync(EasyLotteryConfigDocument document, CancellationToken cancellationToken)
+    private async Task SaveSplitDocumentsAsync(EasyLotteryConfigDocument document, CancellationToken cancellationToken)
     {
         var parts = YamlRepositoryMapper.Split(document);
-        await WriteDocumentAsync(ConfigPath, parts.Settings, cancellationToken);
-        await WriteDocumentAsync(ActivitiesPath, parts.Activities, cancellationToken);
-        await WriteDocumentAsync(ActivityResultsPath, parts.Results, cancellationToken);
-    }
-
-    private async Task<SettingsYamlDocument> ReadSettingsDocumentAsync(CancellationToken cancellationToken) =>
-        await ReadDocumentAsync(ConfigPath, new SettingsYamlDocument(), cancellationToken);
-
-    private async Task<ActivitiesYamlDocument> ReadActivitiesDocumentAsync(CancellationToken cancellationToken) =>
-        await ReadDocumentAsync(ActivitiesPath, new ActivitiesYamlDocument(), cancellationToken);
-
-    private async Task<ActivityResultsYamlDocument> ReadActivityResultsDocumentAsync(CancellationToken cancellationToken) =>
-        await ReadDocumentAsync(ActivityResultsPath, new ActivityResultsYamlDocument(), cancellationToken);
-
-    private async Task<T> ReadDocumentAsync<T>(string path, T fallback, CancellationToken cancellationToken) where T : class
-    {
-        if (!File.Exists(path))
-        {
-            return fallback;
-        }
-
-        var yaml = await File.ReadAllTextAsync(path, cancellationToken);
-        return string.IsNullOrWhiteSpace(yaml) ? fallback : DeserializeDocument<T>(yaml) ?? fallback;
-    }
-
-    private EasyLotteryConfigDocument DeserializeConfigDocument(string yaml) =>
-        string.IsNullOrWhiteSpace(yaml) ? new EasyLotteryConfigDocument() : DeserializeDocument<EasyLotteryConfigDocument>(yaml) ?? new EasyLotteryConfigDocument();
-
-    private T DeserializeDocument<T>(string yaml) where T : class =>
-        _deserializer.Deserialize<T>(yaml) ?? throw new InvalidOperationException($"Unable to deserialize YAML document to {typeof(T).Name}.");
-
-    private async Task WriteDocumentAsync<T>(string path, T document, CancellationToken cancellationToken) where T : class
-    {
-        var temporaryPath = $"{path}.{Guid.NewGuid():N}.tmp";
-        await File.WriteAllTextAsync(temporaryPath, _serializer.Serialize(document), cancellationToken);
-        File.Move(temporaryPath, path, overwrite: true);
-    }
-
-    private void WriteDocument<T>(string path, T document) where T : class
-    {
-        var temporaryPath = $"{path}.{Guid.NewGuid():N}.tmp";
-        File.WriteAllText(temporaryPath, _serializer.Serialize(document));
-        File.Move(temporaryPath, path, overwrite: true);
+        await _settingsRepository.SaveAsync(parts.Settings, cancellationToken);
+        await _activitiesRepository.SaveAsync(parts.Activities, cancellationToken);
+        await _resultsRepository.SaveAsync(parts.Results, cancellationToken);
     }
 }

--- a/src/EasyLotteryApplication/Settings/SettingsDocumentRepositories.cs
+++ b/src/EasyLotteryApplication/Settings/SettingsDocumentRepositories.cs
@@ -1,0 +1,21 @@
+using EasyLotteryDomain.Models.Config;
+
+namespace EasyLotteryApplication.Settings;
+
+public interface ISettingsYamlDocumentRepository
+{
+    Task<SettingsYamlDocument> ReadAsync(CancellationToken cancellationToken = default);
+    Task SaveAsync(SettingsYamlDocument document, CancellationToken cancellationToken = default);
+}
+
+public interface IActivitiesYamlDocumentRepository
+{
+    Task<ActivitiesYamlDocument> ReadAsync(CancellationToken cancellationToken = default);
+    Task SaveAsync(ActivitiesYamlDocument document, CancellationToken cancellationToken = default);
+}
+
+public interface IActivityResultsYamlDocumentRepository
+{
+    Task<ActivityResultsYamlDocument> ReadAsync(CancellationToken cancellationToken = default);
+    Task SaveAsync(ActivityResultsYamlDocument document, CancellationToken cancellationToken = default);
+}

--- a/src/EasyLotteryInfrastructure/DependencyInjection.cs
+++ b/src/EasyLotteryInfrastructure/DependencyInjection.cs
@@ -1,7 +1,9 @@
 using EasyLotteryApplication.DonateActivities;
 using EasyLotteryApplication.Payments;
+using EasyLotteryApplication.Settings;
 using EasyLotteryInfrastructure.DonateActivities;
 using EasyLotteryInfrastructure.Payments;
+using EasyLotteryInfrastructure.Settings;
 using EasyLotteryInfrastructure.Storage;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -22,6 +24,12 @@ public static class DependencyInjection
         services.AddSingleton<IPaymentOrderRepository>(sp => sp.GetRequiredService<JsonPaymentOrderRepository>());
         services.AddSingleton<JsonOvertimeFeedRepository>();
         services.AddSingleton<IOvertimeFeedRepository>(sp => sp.GetRequiredService<JsonOvertimeFeedRepository>());
+        services.AddSingleton<YamlSettingsDocumentRepository>();
+        services.AddSingleton<ISettingsYamlDocumentRepository>(sp => sp.GetRequiredService<YamlSettingsDocumentRepository>());
+        services.AddSingleton<YamlActivitiesDocumentRepository>();
+        services.AddSingleton<IActivitiesYamlDocumentRepository>(sp => sp.GetRequiredService<YamlActivitiesDocumentRepository>());
+        services.AddSingleton<YamlActivityResultsDocumentRepository>();
+        services.AddSingleton<IActivityResultsYamlDocumentRepository>(sp => sp.GetRequiredService<YamlActivityResultsDocumentRepository>());
         return services;
     }
 }

--- a/src/EasyLotteryInfrastructure/Settings/YamlDocumentRepositories.cs
+++ b/src/EasyLotteryInfrastructure/Settings/YamlDocumentRepositories.cs
@@ -1,0 +1,83 @@
+using EasyLotteryApplication.Settings;
+using EasyLotteryDomain.Models.Config;
+using EasyLotteryDomain.Services;
+using EasyLotteryInfrastructure.Storage;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using YamlDotNet.Serialization;
+
+namespace EasyLotteryInfrastructure.Settings;
+
+public abstract class YamlDocumentRepositoryBase<T> where T : class, new()
+{
+    private readonly IStorageGateProvider _storageGates;
+    private readonly ISerializer _serializer = YamlSerialization.CreateSerializerBuilder().Build();
+    private readonly IDeserializer _deserializer = YamlSerialization.CreateDeserializerBuilder().Build();
+
+    protected YamlDocumentRepositoryBase(IConfiguration configuration, IHostEnvironment environment, IStorageGateProvider storageGates, string fileName)
+    {
+        _storageGates = storageGates;
+        var storageDirectory = configuration["Storage:Directory"] ?? Path.Combine(environment.ContentRootPath, "App_Data");
+        Directory.CreateDirectory(storageDirectory);
+        StoragePath = Path.Combine(storageDirectory, fileName);
+        EnsureExists();
+    }
+
+    public string StoragePath { get; }
+
+    public async Task<T> ReadAsync(CancellationToken cancellationToken = default)
+    {
+        await using var gate = await _storageGates.AcquireAsync(cancellationToken, StoragePath);
+        if (!File.Exists(StoragePath))
+        {
+            return new T();
+        }
+
+        var yaml = await File.ReadAllTextAsync(StoragePath, cancellationToken);
+        return string.IsNullOrWhiteSpace(yaml) ? new T() : _deserializer.Deserialize<T>(yaml) ?? new T();
+    }
+
+    public async Task SaveAsync(T document, CancellationToken cancellationToken = default)
+    {
+        await using var gate = await _storageGates.AcquireAsync(cancellationToken, StoragePath);
+        var temporaryPath = $"{StoragePath}.{Guid.NewGuid():N}.tmp";
+        await File.WriteAllTextAsync(temporaryPath, _serializer.Serialize(document), cancellationToken);
+        File.Move(temporaryPath, StoragePath, overwrite: true);
+    }
+
+    private void EnsureExists()
+    {
+        if (File.Exists(StoragePath))
+        {
+            return;
+        }
+
+        var temporaryPath = $"{StoragePath}.{Guid.NewGuid():N}.tmp";
+        File.WriteAllText(temporaryPath, _serializer.Serialize(new T()));
+        File.Move(temporaryPath, StoragePath, overwrite: true);
+    }
+}
+
+public sealed class YamlSettingsDocumentRepository : YamlDocumentRepositoryBase<SettingsYamlDocument>, ISettingsYamlDocumentRepository
+{
+    public YamlSettingsDocumentRepository(IConfiguration configuration, IHostEnvironment environment, IStorageGateProvider storageGates)
+        : base(configuration, environment, storageGates, "settings.yaml")
+    {
+    }
+}
+
+public sealed class YamlActivitiesDocumentRepository : YamlDocumentRepositoryBase<ActivitiesYamlDocument>, IActivitiesYamlDocumentRepository
+{
+    public YamlActivitiesDocumentRepository(IConfiguration configuration, IHostEnvironment environment, IStorageGateProvider storageGates)
+        : base(configuration, environment, storageGates, "activities.yaml")
+    {
+    }
+}
+
+public sealed class YamlActivityResultsDocumentRepository : YamlDocumentRepositoryBase<ActivityResultsYamlDocument>, IActivityResultsYamlDocumentRepository
+{
+    public YamlActivityResultsDocumentRepository(IConfiguration configuration, IHostEnvironment environment, IStorageGateProvider storageGates)
+        : base(configuration, environment, storageGates, "activity-results.yaml")
+    {
+    }
+}

--- a/tests/EasyLotteryAPITests/SettingsFileStoreTests.cs
+++ b/tests/EasyLotteryAPITests/SettingsFileStoreTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.FileProviders;
 using EasyLotteryInfrastructure.Storage;
+using EasyLotteryInfrastructure.Settings;
 using YamlDotNet.Serialization;
 
 namespace EasyLotteryApiTests;
@@ -139,7 +140,13 @@ public sealed class SettingsFileStoreTests
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?> { ["Storage:Directory"] = directory })
             .Build();
-        return new SettingsFileStore(configuration, new TestEnvironment(), new ConfigSecretRedactor(), new StorageGateProvider());
+        var environment = new TestEnvironment();
+        var storageGates = new StorageGateProvider();
+        return new SettingsFileStore(
+            new ConfigSecretRedactor(),
+            new YamlSettingsDocumentRepository(configuration, environment, storageGates),
+            new YamlActivitiesDocumentRepository(configuration, environment, storageGates),
+            new YamlActivityResultsDocumentRepository(configuration, environment, storageGates));
     }
 
     private static string CreateTempDirectory()


### PR DESCRIPTION
這次接續整理：
- 將設定層切成獨立 YAML repository：settings / activities / activity-results
- SettingsFileStore 改成薄組裝層，只負責合併、拆分與瀏覽器相容輸出
- 保留既有設定讀寫行為，避免影響現有頁面與 API
- 更新 DI 與 SettingsFileStore 測試，以對應新的 repository 建構方式

驗證：
- dotnet test EasyLottery.generated.sln --no-restore
- git diff --check