### PR TITLE
Move config repository and redactor to infrastructure

### DIFF
--- a/src/EasyLotteryAPI/Payments/PaymentCallbackProcessor.cs
+++ b/src/EasyLotteryAPI/Payments/PaymentCallbackProcessor.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Mail;
 using EasyLotteryApplication.Payments;
+using EasyLotteryApplication.Settings;
 using EasyLotteryApi;
 using EasyLotteryDomain.Models.Config;
 using EasyLotteryDomain.Models.Overtime;

--- a/src/EasyLotteryAPI/Program.cs
+++ b/src/EasyLotteryAPI/Program.cs
@@ -4,12 +4,14 @@ using System.Net.Mail;
 using System.Text.Json;
 using EasyLotteryApplication.DonateActivities;
 using EasyLotteryApplication.Payments;
+using EasyLotteryApplication.Settings;
 using EasyLotteryInfrastructure;
 using EasyLotteryDomain.Models.Overtime;
 using MediatR;
 using Microsoft.AspNetCore.SignalR;
 using EasyLotteryApi;
 using EasyLotteryApi.Payments;
+using EasyLotteryInfrastructure.Settings;
 using EasyLotteryDomain.Models.Config;
 using EasyLotteryDomain.Services;
 

--- a/src/EasyLotteryApplication/Settings/IEasyLotteryConfigRepository.cs
+++ b/src/EasyLotteryApplication/Settings/IEasyLotteryConfigRepository.cs
@@ -1,6 +1,6 @@
 using EasyLotteryDomain.Models.Config;
 
-namespace EasyLotteryApi;
+namespace EasyLotteryApplication.Settings;
 
 public interface IEasyLotteryConfigRepository
 {

--- a/src/EasyLotteryInfrastructure/Settings/ConfigSecretRedactor.cs
+++ b/src/EasyLotteryInfrastructure/Settings/ConfigSecretRedactor.cs
@@ -1,8 +1,8 @@
 using EasyLotteryDomain.Models.Config;
-using YamlDotNet.Serialization;
 using EasyLotteryDomain.Services;
+using YamlDotNet.Serialization;
 
-namespace EasyLotteryApi;
+namespace EasyLotteryInfrastructure.Settings;
 
 /// <summary>
 /// Keeps payment secrets in the server-side YAML while allowing the non-secret

--- a/src/EasyLotteryInfrastructure/Settings/SettingsFileStore.cs
+++ b/src/EasyLotteryInfrastructure/Settings/SettingsFileStore.cs
@@ -1,9 +1,9 @@
 using EasyLotteryDomain.Models.Config;
 using EasyLotteryDomain.Services;
-using EasyLotteryInfrastructure.Settings;
+using EasyLotteryApplication.Settings;
 using YamlDotNet.Serialization;
 
-namespace EasyLotteryApi;
+namespace EasyLotteryInfrastructure.Settings;
 
 /// <summary>YAML-backed repository for the EasyLottery configuration.</summary>
 public sealed class SettingsFileStore : IEasyLotteryConfigRepository, IEasyLotteryConfigStore

--- a/tests/EasyLotteryAPITests/ConfigSecretRedactorTests.cs
+++ b/tests/EasyLotteryAPITests/ConfigSecretRedactorTests.cs
@@ -1,5 +1,5 @@
-using EasyLotteryApi;
 using EasyLotteryDomain.Models.Config;
+using EasyLotteryInfrastructure.Settings;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 

--- a/tests/EasyLotteryAPITests/SettingsFileStoreTests.cs
+++ b/tests/EasyLotteryAPITests/SettingsFileStoreTests.cs
@@ -4,6 +4,7 @@ using EasyLotteryDomain.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.FileProviders;
+using EasyLotteryApplication.Settings;
 using EasyLotteryInfrastructure.Storage;
 using EasyLotteryInfrastructure.Settings;
 using YamlDotNet.Serialization;


### PR DESCRIPTION
這次接續整理：
- 將 IEasyLotteryConfigRepository 移到 Application.Settings
- 將 ConfigSecretRedactor 與 SettingsFileStore 移到 Infrastructure.Settings
- 保持既有設定讀寫、瀏覽器紅action、與 split YAML 行為不變
- 讓 API 端只保留組裝與路由，不再背設定實作

驗證：
- dotnet test EasyLottery.generated.sln --no-restore
- git diff --check