### PR TITLE
Extract API endpoint modules

### DIFF
--- a/src/EasyLotteryAPI/Endpoints/HttpRequestBodyReader.cs
+++ b/src/EasyLotteryAPI/Endpoints/HttpRequestBodyReader.cs
@@ -1,0 +1,12 @@
+using System.Text;
+
+namespace EasyLotteryApi.Endpoints;
+
+internal static class HttpRequestBodyReader
+{
+    public static async Task<string> ReadTextAsync(HttpRequest request, CancellationToken cancellationToken)
+    {
+        using var reader = new StreamReader(request.Body, Encoding.UTF8);
+        return await reader.ReadToEndAsync(cancellationToken);
+    }
+}

--- a/src/EasyLotteryAPI/Endpoints/OvertimeFeedEndpoints.cs
+++ b/src/EasyLotteryAPI/Endpoints/OvertimeFeedEndpoints.cs
@@ -1,0 +1,43 @@
+using System.Text;
+using System.Text.Json;
+using EasyLotteryApplication.Payments;
+using EasyLotteryApi;
+using EasyLotteryDomain.Models.Overtime;
+using Microsoft.AspNetCore.SignalR;
+
+namespace EasyLotteryApi.Endpoints;
+
+internal static class OvertimeFeedEndpoints
+{
+    public static void MapOvertimeFeedEndpoints(this WebApplication app)
+    {
+        Func<HttpContext, IOvertimeFeedRepository, AdminAccess, Task<IResult>> readOvertimeFeed = async (context, feedRepository, adminAccess) =>
+        {
+            if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
+            return Results.Text(JsonSerializer.Serialize(await feedRepository.ListAsync(context.RequestAborted)), "application/json", Encoding.UTF8);
+        };
+        app.MapGet("/api/overtime-feed", readOvertimeFeed);
+
+        Func<HttpContext, IOvertimeFeedRepository, IHubContext<OvertimeHub>, AdminAccess, Task<IResult>> writeOvertimeFeed = async (context, feedRepository, hub, adminAccess) =>
+        {
+            if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
+            var body = await HttpRequestBodyReader.ReadTextAsync(context.Request, context.RequestAborted);
+            var events = string.IsNullOrWhiteSpace(body)
+                ? []
+                : JsonSerializer.Deserialize<List<OvertimeSupportEvent>>(body, new JsonSerializerOptions(JsonSerializerDefaults.Web)) ?? [];
+            await feedRepository.SaveAsync(events, context.RequestAborted);
+            await hub.Clients.All.SendAsync("OvertimeFeedChanged", context.RequestAborted);
+            return Results.NoContent();
+        };
+        app.MapPut("/api/overtime-feed", writeOvertimeFeed);
+
+        Func<HttpContext, IOvertimeFeedRepository, IHubContext<OvertimeHub>, AdminAccess, Task<IResult>> clearOvertimeFeed = async (context, feedRepository, hub, adminAccess) =>
+        {
+            if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
+            await feedRepository.SaveAsync([], context.RequestAborted);
+            await hub.Clients.All.SendAsync("OvertimeFeedChanged", context.RequestAborted);
+            return Results.NoContent();
+        };
+        app.MapDelete("/api/overtime-feed", clearOvertimeFeed);
+    }
+}

--- a/src/EasyLotteryAPI/Endpoints/PaymentEndpoints.cs
+++ b/src/EasyLotteryAPI/Endpoints/PaymentEndpoints.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using System.Text;
+using EasyLotteryApplication.Payments;
+using EasyLotteryApi;
+using EasyLotteryApi.Payments;
+
+namespace EasyLotteryApi.Endpoints;
+
+internal static class PaymentEndpoints
+{
+    public static void MapPaymentEndpoints(this WebApplication app)
+    {
+        app.MapPost("/api/payments/{providerId}/notify", async (string providerId, HttpContext context, PaymentCallbackProcessor callbacks) =>
+        {
+            var body = await HttpRequestBodyReader.ReadTextAsync(context.Request, context.RequestAborted);
+            var headers = context.Request.Headers.ToDictionary(header => header.Key, header => header.Value.ToString(), StringComparer.OrdinalIgnoreCase);
+            var result = await callbacks.ProcessAsync(providerId, new PaymentNotificationRequest
+            {
+                ContentType = context.Request.ContentType ?? "",
+                Body = body,
+                Headers = headers
+            }, context.RequestAborted);
+
+            if (!result.Accepted)
+            {
+                return Results.BadRequest();
+            }
+
+            var acknowledgement = providerId.Trim().Equals("ecpay", StringComparison.OrdinalIgnoreCase)
+                ? "1|OK"
+                : "OK";
+            return Results.Text(acknowledgement, "text/plain", Encoding.UTF8);
+        });
+
+        app.MapPost("/api/payments/orders", async (PaymentOrderRegistrationRequest request, HttpContext context, PaymentCallbackProcessor callbacks, AdminAccess adminAccess) =>
+        {
+            if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
+            try { return Results.Created($"/api/payments/orders/{request.MerchantOrderNo}", await callbacks.RegisterOrderAsync(request, context.RequestAborted)); }
+            catch (ArgumentException exception)
+            {
+                app.Logger.LogWarning(exception, "Invalid payment order registration request for merchant order {MerchantOrderNo}.", request.MerchantOrderNo);
+                return Results.BadRequest(new { error = exception.Message });
+            }
+            catch (InvalidOperationException exception)
+            {
+                app.Logger.LogWarning(exception, "Payment order registration conflict for merchant order {MerchantOrderNo}.", request.MerchantOrderNo);
+                return Results.Conflict(new { error = exception.Message });
+            }
+        });
+
+        app.MapGet("/api/payments/events", async (HttpContext context, PaymentCallbackProcessor callbacks, AdminAccess adminAccess) =>
+            !adminAccess.IsAuthorized(context.Request) ? Results.Unauthorized() : Results.Ok(await callbacks.ListProcessedEventsAsync(context.RequestAborted)));
+    }
+}

--- a/src/EasyLotteryAPI/Endpoints/ResultNotificationEndpoints.cs
+++ b/src/EasyLotteryAPI/Endpoints/ResultNotificationEndpoints.cs
@@ -1,0 +1,56 @@
+using System.Net;
+using System.Net.Mail;
+
+namespace EasyLotteryApi.Endpoints;
+
+internal static class ResultNotificationEndpoints
+{
+    public static void MapResultNotificationEndpoints(this WebApplication app)
+    {
+        app.MapPost("/api/result-notification", async (ResultNotificationRequest request) =>
+        {
+            if (string.IsNullOrWhiteSpace(request.Recipient) ||
+                string.IsNullOrWhiteSpace(request.Smtp.Host) ||
+                request.Smtp.Port <= 0 ||
+                string.IsNullOrWhiteSpace(request.Smtp.FromAddress))
+            {
+                return Results.NoContent();
+            }
+
+            using var message = new MailMessage(
+                new MailAddress(request.Smtp.FromAddress, request.Smtp.FromName),
+                new MailAddress(request.Recipient))
+            {
+                Subject = request.Subject,
+                Body = request.Body
+            };
+            using var client = new SmtpClient(request.Smtp.Host, request.Smtp.Port)
+            {
+                EnableSsl = request.Smtp.EnableSsl,
+                Credentials = new NetworkCredential(request.Smtp.Username, request.Smtp.Password)
+            };
+
+            await client.SendMailAsync(message);
+            return Results.NoContent();
+        });
+    }
+}
+
+internal sealed class ResultNotificationRequest
+{
+    public string Recipient { get; set; } = "";
+    public string Subject { get; set; } = "";
+    public string Body { get; set; } = "";
+    public SmtpSettings Smtp { get; set; } = new();
+}
+
+internal sealed class SmtpSettings
+{
+    public string Host { get; set; } = "";
+    public int Port { get; set; }
+    public string Username { get; set; } = "";
+    public string Password { get; set; } = "";
+    public string FromAddress { get; set; } = "";
+    public string FromName { get; set; } = "";
+    public bool EnableSsl { get; set; }
+}

--- a/src/EasyLotteryAPI/Endpoints/SettingsEndpoints.cs
+++ b/src/EasyLotteryAPI/Endpoints/SettingsEndpoints.cs
@@ -1,0 +1,34 @@
+using System.Text;
+using EasyLotteryApplication.Settings;
+using EasyLotteryApi;
+using EasyLotteryDomain.Services;
+using EasyLotteryInfrastructure.Settings;
+using Microsoft.AspNetCore.SignalR;
+
+namespace EasyLotteryApi.Endpoints;
+
+internal static class SettingsEndpoints
+{
+    public static void MapSettingsEndpoints(this WebApplication app)
+    {
+        Func<HttpContext, IEasyLotteryConfigRepository, AdminAccess, Task<IResult>> readSettings = async (context, settingsStore, adminAccess) =>
+        {
+            if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
+            return Results.Text(await settingsStore.ReadForBrowserAsync(context.RequestAborted), "text/yaml", Encoding.UTF8);
+        };
+        app.MapGet("/settings", readSettings);
+        app.MapGet("/easy-lottery-config.yaml", readSettings);
+
+        Func<HttpContext, IHubContext<OvertimeHub>, IEasyLotteryConfigRepository, AdminAccess, Task<IResult>> writeSettings = async (context, hub, settingsStore, adminAccess) =>
+        {
+            if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
+
+            var content = await HttpRequestBodyReader.ReadTextAsync(context.Request, context.RequestAborted);
+            await settingsStore.SaveBrowserUpdateAsync(content, context.RequestAborted);
+            await hub.Clients.All.SendAsync("OvertimeStateChanged", context.RequestAborted);
+            return Results.NoContent();
+        };
+        app.MapPut("/settings", writeSettings);
+        app.MapPut("/easy-lottery-config.yaml", writeSettings);
+    }
+}

--- a/src/EasyLotteryAPI/Endpoints/TunnelEndpoints.cs
+++ b/src/EasyLotteryAPI/Endpoints/TunnelEndpoints.cs
@@ -1,0 +1,18 @@
+using EasyLotteryApi;
+
+namespace EasyLotteryApi.Endpoints;
+
+internal static class TunnelEndpoints
+{
+    public static void MapTunnelEndpoints(this WebApplication app)
+    {
+        app.MapGet("/api/tunnel", (TunnelRuntimeService tunnelRuntime) => Results.Ok(tunnelRuntime.GetStatus()));
+        app.MapPost("/api/tunnel/start", async (TunnelStartRequest request, TunnelRuntimeService tunnelRuntime, CancellationToken cancellationToken) =>
+            Results.Ok(await tunnelRuntime.StartAsync(request.Provider, cancellationToken)));
+        app.MapDelete("/api/tunnel", async (TunnelRuntimeService tunnelRuntime, CancellationToken cancellationToken) =>
+        {
+            await tunnelRuntime.StopAsync(cancellationToken);
+            return Results.NoContent();
+        });
+    }
+}

--- a/src/EasyLotteryAPI/Program.cs
+++ b/src/EasyLotteryAPI/Program.cs
@@ -1,19 +1,15 @@
 using System.Text;
-using System.Net;
-using System.Net.Mail;
-using System.Text.Json;
 using EasyLotteryApplication.DonateActivities;
 using EasyLotteryApplication.Payments;
 using EasyLotteryApplication.Settings;
 using EasyLotteryInfrastructure;
-using EasyLotteryDomain.Models.Overtime;
+using EasyLotteryInfrastructure.Settings;
 using MediatR;
-using Microsoft.AspNetCore.SignalR;
 using EasyLotteryApi;
 using EasyLotteryApi.Payments;
-using EasyLotteryInfrastructure.Settings;
 using EasyLotteryDomain.Models.Config;
 using EasyLotteryDomain.Services;
+using EasyLotteryApi.Endpoints;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddSignalR();
@@ -62,27 +58,6 @@ if (app.Environment.IsDevelopment())
 
 app.UseBlazorFrameworkFiles();
 app.UseStaticFiles();
-
-Func<HttpContext, IEasyLotteryConfigRepository, AdminAccess, Task<IResult>> readSettings = async (context, settingsStore, adminAccess) =>
-{
-    if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
-    return Results.Text(await settingsStore.ReadForBrowserAsync(context.RequestAborted), "text/yaml", Encoding.UTF8);
-};
-app.MapGet("/settings", readSettings);
-// Compatibility endpoint for browsers still serving a cached pre-settings.yaml build.
-app.MapGet("/easy-lottery-config.yaml", readSettings);
-
-Func<HttpContext, IHubContext<OvertimeHub>, IEasyLotteryConfigRepository, AdminAccess, Task<IResult>> writeSettings = async (context, hub, settingsStore, adminAccess) =>
-{
-    if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
-
-    var content = await ReadRequestBodyAsync(context.Request, context.RequestAborted);
-    await settingsStore.SaveBrowserUpdateAsync(content, context.RequestAborted);
-    await hub.Clients.All.SendAsync("OvertimeStateChanged", context.RequestAborted);
-    return Results.NoContent();
-};
-app.MapPut("/settings", writeSettings);
-app.MapPut("/easy-lottery-config.yaml", writeSettings);
 
 Func<HttpContext, IMediator, AdminAccess, Task<IResult>> listDonateActivities = async (context, mediator, adminAccess) =>
 {
@@ -150,144 +125,13 @@ Func<int, HttpContext, IMediator, AdminAccess, Task<IResult>> deleteDonateActivi
 };
 app.MapDelete("/api/donate-activities/{id:int}", deleteDonateActivity);
 
-Func<HttpContext, IOvertimeFeedRepository, AdminAccess, Task<IResult>> readOvertimeFeed = async (context, feedRepository, adminAccess) =>
-{
-    if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
-    return Results.Text(JsonSerializer.Serialize(await feedRepository.ListAsync(context.RequestAborted)), "application/json", Encoding.UTF8);
-};
-app.MapGet("/api/overtime-feed", readOvertimeFeed);
-app.MapGet("/easy-lottery-overtime-feed.json", readOvertimeFeed);
-
-Func<HttpContext, IOvertimeFeedRepository, IHubContext<OvertimeHub>, AdminAccess, Task<IResult>> writeOvertimeFeed = async (context, feedRepository, hub, adminAccess) =>
-{
-    if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
-    var body = await ReadRequestBodyAsync(context.Request, context.RequestAborted);
-    var events = string.IsNullOrWhiteSpace(body)
-        ? []
-        : JsonSerializer.Deserialize<List<OvertimeSupportEvent>>(body, new JsonSerializerOptions(JsonSerializerDefaults.Web)) ?? [];
-    await feedRepository.SaveAsync(events, context.RequestAborted);
-    await hub.Clients.All.SendAsync("OvertimeFeedChanged", context.RequestAborted);
-    return Results.NoContent();
-};
-app.MapPut("/api/overtime-feed", writeOvertimeFeed);
-app.MapPut("/easy-lottery-overtime-feed.json", writeOvertimeFeed);
-
-Func<HttpContext, IOvertimeFeedRepository, IHubContext<OvertimeHub>, AdminAccess, Task<IResult>> clearOvertimeFeed = async (context, feedRepository, hub, adminAccess) =>
-{
-    if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
-    await feedRepository.SaveAsync([], context.RequestAborted);
-    await hub.Clients.All.SendAsync("OvertimeFeedChanged", context.RequestAborted);
-    return Results.NoContent();
-};
-app.MapDelete("/api/overtime-feed", clearOvertimeFeed);
-app.MapDelete("/easy-lottery-overtime-feed.json", clearOvertimeFeed);
-
-app.MapPost("/api/result-notification", async (ResultNotificationRequest request) =>
-{
-    if (string.IsNullOrWhiteSpace(request.Recipient) ||
-        string.IsNullOrWhiteSpace(request.Smtp.Host) ||
-        request.Smtp.Port <= 0 ||
-        string.IsNullOrWhiteSpace(request.Smtp.FromAddress))
-    {
-        return Results.NoContent();
-    }
-
-    using var message = new MailMessage(
-        new MailAddress(request.Smtp.FromAddress, request.Smtp.FromName),
-        new MailAddress(request.Recipient))
-    {
-        Subject = request.Subject,
-        Body = request.Body
-    };
-    using var client = new SmtpClient(request.Smtp.Host, request.Smtp.Port)
-    {
-        EnableSsl = request.Smtp.EnableSsl,
-        Credentials = new NetworkCredential(request.Smtp.Username, request.Smtp.Password)
-    };
-
-    await client.SendMailAsync(message);
-    return Results.NoContent();
-});
-
+app.MapSettingsEndpoints();
+app.MapOvertimeFeedEndpoints();
+app.MapPaymentEndpoints();
+app.MapResultNotificationEndpoints();
+app.MapTunnelEndpoints();
 app.MapHub<OvertimeHub>("/hubs/overtime");
-
-app.MapGet("/api/tunnel", (TunnelRuntimeService tunnelRuntime) => Results.Ok(tunnelRuntime.GetStatus()));
-app.MapPost("/api/tunnel/start", async (TunnelStartRequest request, TunnelRuntimeService tunnelRuntime, CancellationToken cancellationToken) =>
-    Results.Ok(await tunnelRuntime.StartAsync(request.Provider, cancellationToken)));
-app.MapDelete("/api/tunnel", async (TunnelRuntimeService tunnelRuntime, CancellationToken cancellationToken) =>
-{
-    await tunnelRuntime.StopAsync(cancellationToken);
-    return Results.NoContent();
-});
-
-app.MapPost("/api/payments/{providerId}/notify", async (string providerId, HttpContext context, PaymentCallbackProcessor callbacks) =>
-{
-    var body = await ReadRequestBodyAsync(context.Request, context.RequestAborted);
-    var headers = context.Request.Headers.ToDictionary(header => header.Key, header => header.Value.ToString(), StringComparer.OrdinalIgnoreCase);
-    var result = await callbacks.ProcessAsync(providerId, new PaymentNotificationRequest
-    {
-        ContentType = context.Request.ContentType ?? "",
-        Body = body,
-        Headers = headers
-    }, context.RequestAborted);
-
-    if (!result.Accepted)
-    {
-        return Results.BadRequest();
-    }
-
-    // ECPay broadcaster requires this exact acknowledgement after the callback is received.
-    // NewebPay only requires a successful HTTP response for its Form POST notification.
-    var acknowledgement = providerId.Trim().Equals("ecpay", StringComparison.OrdinalIgnoreCase)
-        ? "1|OK"
-        : "OK";
-    return Results.Text(acknowledgement, "text/plain", Encoding.UTF8);
-});
-
-app.MapPost("/api/payments/orders", async (PaymentOrderRegistrationRequest request, HttpContext context, PaymentCallbackProcessor callbacks, AdminAccess adminAccess) =>
-{
-    if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
-    try { return Results.Created($"/api/payments/orders/{request.MerchantOrderNo}", await callbacks.RegisterOrderAsync(request, context.RequestAborted)); }
-    catch (ArgumentException exception)
-    {
-        app.Logger.LogWarning(exception, "Invalid payment order registration request for merchant order {MerchantOrderNo}.", request.MerchantOrderNo);
-        return Results.BadRequest(new { error = exception.Message });
-    }
-    catch (InvalidOperationException exception)
-    {
-        app.Logger.LogWarning(exception, "Payment order registration conflict for merchant order {MerchantOrderNo}.", request.MerchantOrderNo);
-        return Results.Conflict(new { error = exception.Message });
-    }
-});
-
-app.MapGet("/api/payments/events", async (HttpContext context, PaymentCallbackProcessor callbacks, AdminAccess adminAccess) =>
-    !adminAccess.IsAuthorized(context.Request) ? Results.Unauthorized() : Results.Ok(await callbacks.ListProcessedEventsAsync(context.RequestAborted)));
 
 app.MapFallbackToFile("index.html");
 
 await app.RunAsync();
-
-static async Task<string> ReadRequestBodyAsync(HttpRequest request, CancellationToken cancellationToken)
-{
-    using var reader = new StreamReader(request.Body, Encoding.UTF8);
-    return await reader.ReadToEndAsync(cancellationToken);
-}
-
-sealed class ResultNotificationRequest
-{
-    public string Recipient { get; set; } = "";
-    public string Subject { get; set; } = "";
-    public string Body { get; set; } = "";
-    public SmtpSettings Smtp { get; set; } = new();
-}
-
-sealed class SmtpSettings
-{
-    public string Host { get; set; } = "";
-    public int Port { get; set; }
-    public string Username { get; set; } = "";
-    public string Password { get; set; } = "";
-    public string FromAddress { get; set; } = "";
-    public string FromName { get; set; } = "";
-    public bool EnableSsl { get; set; }
-}


### PR DESCRIPTION
這次接續整理：
- 將 API 路由拆成 settings / overtime / payments / result-notification / tunnel 模組
- Program.cs 只保留啟動、DI 與模組掛載
- 移除 overtime feed 的舊 JSON 相容路由，統一走 REST API
- 保持現有行為與測試通過

驗證：
- dotnet test EasyLottery.generated.sln --no-restore
- git diff --check