### PR TITLE
Extract donate activity endpoints

### DIFF
--- a/src/EasyLotteryAPI/Endpoints/DonateActivityEndpoints.cs
+++ b/src/EasyLotteryAPI/Endpoints/DonateActivityEndpoints.cs
@@ -1,0 +1,77 @@
+using EasyLotteryApplication.DonateActivities;
+using EasyLotteryDomain.Models.Config;
+using MediatR;
+
+namespace EasyLotteryApi.Endpoints;
+
+internal static class DonateActivityEndpoints
+{
+    public static void MapDonateActivityEndpoints(this WebApplication app)
+    {
+        Func<HttpContext, IMediator, AdminAccess, Task<IResult>> listDonateActivities = async (context, mediator, adminAccess) =>
+        {
+            if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
+            return Results.Ok(await mediator.Send(new GetDonateActivitiesQuery(), context.RequestAborted));
+        };
+        app.MapGet("/api/donate-activities", listDonateActivities);
+
+        Func<int, HttpContext, IMediator, AdminAccess, Task<IResult>> getDonateActivityById = async (id, context, mediator, adminAccess) =>
+        {
+            if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
+            var activity = await mediator.Send(new GetDonateActivityByIdQuery(id), context.RequestAborted);
+            return activity is null ? Results.NotFound(new { error = "找不到 Donate 活動。" }) : Results.Ok(activity);
+        };
+        app.MapGet("/api/donate-activities/{id:int}", getDonateActivityById);
+
+        Func<DonateLotteryActivity, HttpContext, IMediator, AdminAccess, Task<IResult>> createDonateActivity = async (activity, context, mediator, adminAccess) =>
+        {
+            if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
+            try
+            {
+                var saved = await mediator.Send(new SaveDonateActivityCommand(activity), context.RequestAborted);
+                return Results.Created($"/api/donate-activities/{saved.Id}", saved);
+            }
+            catch (InvalidOperationException exception)
+            {
+                return Results.BadRequest(new { error = exception.Message });
+            }
+        };
+        app.MapPost("/api/donate-activities", createDonateActivity);
+
+        Func<int, DonateLotteryActivity, HttpContext, IMediator, AdminAccess, Task<IResult>> updateDonateActivity = async (id, activity, context, mediator, adminAccess) =>
+        {
+            if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
+            if (activity.Id != 0 && activity.Id != id)
+            {
+                return Results.BadRequest(new { error = "路由 ID 與活動 ID 不一致。" });
+            }
+
+            try
+            {
+                activity.Id = id;
+                var saved = await mediator.Send(new SaveDonateActivityCommand(activity), context.RequestAborted);
+                return Results.Ok(saved);
+            }
+            catch (InvalidOperationException exception)
+            {
+                return Results.BadRequest(new { error = exception.Message });
+            }
+        };
+        app.MapPut("/api/donate-activities/{id:int}", updateDonateActivity);
+
+        Func<int, HttpContext, IMediator, AdminAccess, Task<IResult>> deleteDonateActivity = async (id, context, mediator, adminAccess) =>
+        {
+            if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
+            try
+            {
+                await mediator.Send(new DeleteDonateActivityCommand(id), context.RequestAborted);
+                return Results.NoContent();
+            }
+            catch (InvalidOperationException exception)
+            {
+                return Results.NotFound(new { error = exception.Message });
+            }
+        };
+        app.MapDelete("/api/donate-activities/{id:int}", deleteDonateActivity);
+    }
+}

--- a/src/EasyLotteryAPI/Program.cs
+++ b/src/EasyLotteryAPI/Program.cs
@@ -59,75 +59,10 @@ if (app.Environment.IsDevelopment())
 app.UseBlazorFrameworkFiles();
 app.UseStaticFiles();
 
-Func<HttpContext, IMediator, AdminAccess, Task<IResult>> listDonateActivities = async (context, mediator, adminAccess) =>
-{
-    if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
-    return Results.Ok(await mediator.Send(new GetDonateActivitiesQuery(), context.RequestAborted));
-};
-app.MapGet("/api/donate-activities", listDonateActivities);
-
-Func<int, HttpContext, IMediator, AdminAccess, Task<IResult>> getDonateActivityById = async (id, context, mediator, adminAccess) =>
-{
-    if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
-    var activity = await mediator.Send(new GetDonateActivityByIdQuery(id), context.RequestAborted);
-    return activity is null ? Results.NotFound(new { error = "找不到 Donate 活動。" }) : Results.Ok(activity);
-};
-app.MapGet("/api/donate-activities/{id:int}", getDonateActivityById);
-
-Func<DonateLotteryActivity, HttpContext, IMediator, AdminAccess, Task<IResult>> createDonateActivity = async (activity, context, mediator, adminAccess) =>
-{
-    if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
-    try
-    {
-        var saved = await mediator.Send(new SaveDonateActivityCommand(activity), context.RequestAborted);
-        return Results.Created($"/api/donate-activities/{saved.Id}", saved);
-    }
-    catch (InvalidOperationException exception)
-    {
-        return Results.BadRequest(new { error = exception.Message });
-    }
-};
-app.MapPost("/api/donate-activities", createDonateActivity);
-
-Func<int, DonateLotteryActivity, HttpContext, IMediator, AdminAccess, Task<IResult>> updateDonateActivity = async (id, activity, context, mediator, adminAccess) =>
-{
-    if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
-    if (activity.Id != 0 && activity.Id != id)
-    {
-        return Results.BadRequest(new { error = "路由 ID 與活動 ID 不一致。" });
-    }
-
-    try
-    {
-        activity.Id = id;
-        var saved = await mediator.Send(new SaveDonateActivityCommand(activity), context.RequestAborted);
-        return Results.Ok(saved);
-    }
-    catch (InvalidOperationException exception)
-    {
-        return Results.BadRequest(new { error = exception.Message });
-    }
-};
-app.MapPut("/api/donate-activities/{id:int}", updateDonateActivity);
-
-Func<int, HttpContext, IMediator, AdminAccess, Task<IResult>> deleteDonateActivity = async (id, context, mediator, adminAccess) =>
-{
-    if (!adminAccess.IsAuthorized(context.Request)) return Results.Unauthorized();
-    try
-    {
-        await mediator.Send(new DeleteDonateActivityCommand(id), context.RequestAborted);
-        return Results.NoContent();
-    }
-    catch (InvalidOperationException exception)
-    {
-        return Results.NotFound(new { error = exception.Message });
-    }
-};
-app.MapDelete("/api/donate-activities/{id:int}", deleteDonateActivity);
-
 app.MapSettingsEndpoints();
 app.MapOvertimeFeedEndpoints();
 app.MapPaymentEndpoints();
+app.MapDonateActivityEndpoints();
 app.MapResultNotificationEndpoints();
 app.MapTunnelEndpoints();
 app.MapHub<OvertimeHub>("/hubs/overtime");


### PR DESCRIPTION
這次接續整理：
- 將 Donate 活動 CRUD 路由從 Program.cs 抽成獨立 endpoint module
- Program.cs 再度瘦身，只保留啟動與模組掛載
- 保持原本的 MediatR / AdminAccess 驗證與 API 行為不變

驗證：
- dotnet test EasyLottery.generated.sln --no-restore
- git diff --check