### PR TITLE
Move config service registration to infrastructure

### DIFF
--- a/src/EasyLotteryAPI/Program.cs
+++ b/src/EasyLotteryAPI/Program.cs
@@ -1,13 +1,10 @@
 using System.Text;
 using EasyLotteryApplication.DonateActivities;
 using EasyLotteryApplication.Payments;
-using EasyLotteryApplication.Settings;
 using EasyLotteryInfrastructure;
-using EasyLotteryInfrastructure.Settings;
 using MediatR;
 using EasyLotteryApi;
 using EasyLotteryApi.Payments;
-using EasyLotteryDomain.Models.Config;
 using EasyLotteryDomain.Services;
 using EasyLotteryApi.Endpoints;
 
@@ -17,12 +14,8 @@ builder.Services.AddSingleton<TunnelRuntimeService>();
 builder.Services.AddSingleton<IPaymentProvider, EcpayBroadcasterPaymentProvider>();
 builder.Services.AddSingleton<IPaymentProvider, NewebPayDonationPaymentProvider>();
 builder.Services.AddSingleton<PaymentProviderFactory>();
-builder.Services.AddSingleton<ConfigSecretRedactor>();
 builder.Services.AddEasyLotteryInfrastructure();
 builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(typeof(GetDonateActivitiesQuery).Assembly, typeof(DependencyInjection).Assembly));
-builder.Services.AddSingleton<SettingsFileStore>();
-builder.Services.AddSingleton<IEasyLotteryConfigRepository>(sp => sp.GetRequiredService<SettingsFileStore>());
-builder.Services.AddSingleton<IEasyLotteryConfigStore>(sp => sp.GetRequiredService<SettingsFileStore>());
 builder.Services.AddSingleton<AdminAccess>();
 builder.Services.AddSingleton<PaymentCallbackProcessor>();
 

--- a/src/EasyLotteryInfrastructure/DependencyInjection.cs
+++ b/src/EasyLotteryInfrastructure/DependencyInjection.cs
@@ -5,6 +5,7 @@ using EasyLotteryInfrastructure.DonateActivities;
 using EasyLotteryInfrastructure.Payments;
 using EasyLotteryInfrastructure.Settings;
 using EasyLotteryInfrastructure.Storage;
+using EasyLotteryDomain.Services;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace EasyLotteryInfrastructure;
@@ -30,6 +31,10 @@ public static class DependencyInjection
         services.AddSingleton<IActivitiesYamlDocumentRepository>(sp => sp.GetRequiredService<YamlActivitiesDocumentRepository>());
         services.AddSingleton<YamlActivityResultsDocumentRepository>();
         services.AddSingleton<IActivityResultsYamlDocumentRepository>(sp => sp.GetRequiredService<YamlActivityResultsDocumentRepository>());
+        services.AddSingleton<ConfigSecretRedactor>();
+        services.AddSingleton<SettingsFileStore>();
+        services.AddSingleton<IEasyLotteryConfigRepository>(sp => sp.GetRequiredService<SettingsFileStore>());
+        services.AddSingleton<IEasyLotteryConfigStore>(sp => sp.GetRequiredService<SettingsFileStore>());
         return services;
     }
 }


### PR DESCRIPTION
這次接續整理：
- 將 ConfigSecretRedactor、SettingsFileStore 與設定服務註冊都移到 Infrastructure
- Program.cs 只保留啟動與模組掛載，不再背設定層 DI
- 保持既有行為不變，測試已通過

驗證：
- dotnet test EasyLottery.generated.sln --no-restore
- git diff --check