### PR TITLE
fix: 修正 Donate 活動 YAML 格式讀取

### DIFF
--- a/src/EasyLotteryInfrastructure/DonateActivities/YamlDonateActivityRepository.cs
+++ b/src/EasyLotteryInfrastructure/DonateActivities/YamlDonateActivityRepository.cs
@@ -65,9 +65,7 @@ public sealed class YamlDonateActivityRepository : IDonateLotteryActivityReposit
         }
 
         var yaml = await File.ReadAllTextAsync(SnapshotPath, cancellationToken);
-        var activities = string.IsNullOrWhiteSpace(yaml)
-            ? []
-            : _deserializer.Deserialize<List<DonateLotteryActivity>>(yaml) ?? [];
+        var activities = DeserializeActivities(yaml);
         var (normalized, changed) = NormalizeActivities(activities);
         if (changed)
         {
@@ -79,11 +77,35 @@ public sealed class YamlDonateActivityRepository : IDonateLotteryActivityReposit
 
     internal async Task WriteSnapshotUnsafeAsync(IReadOnlyList<DonateLotteryActivity> activities, CancellationToken cancellationToken = default)
     {
-        var snapshot = activities.OrderByDescending(activity => activity.Id).ToList();
+        var document = File.Exists(SnapshotPath)
+            ? DeserializeActivitiesDocument(await File.ReadAllTextAsync(SnapshotPath, cancellationToken))
+            : new ActivitiesYamlDocument();
+        document.DonateLotteryActivities = activities.OrderByDescending(activity => activity.Id).ToList();
         Directory.CreateDirectory(Path.GetDirectoryName(SnapshotPath) ?? ".");
         var temporaryPath = $"{SnapshotPath}.{Guid.NewGuid():N}.tmp";
-        await File.WriteAllTextAsync(temporaryPath, _serializer.Serialize(snapshot), cancellationToken);
+        await File.WriteAllTextAsync(temporaryPath, _serializer.Serialize(document), cancellationToken);
         File.Move(temporaryPath, SnapshotPath, overwrite: true);
+    }
+
+    private List<DonateLotteryActivity> DeserializeActivities(string yaml) =>
+        DeserializeActivitiesDocument(yaml).DonateLotteryActivities ?? [];
+
+    private ActivitiesYamlDocument DeserializeActivitiesDocument(string yaml)
+    {
+        if (string.IsNullOrWhiteSpace(yaml)) return new ActivitiesYamlDocument();
+
+        try
+        {
+            return _deserializer.Deserialize<ActivitiesYamlDocument>(yaml) ?? new ActivitiesYamlDocument();
+        }
+        catch (YamlDotNet.Core.YamlException)
+        {
+            // Snapshots produced before YAML repositories were split used a root list.
+            return new ActivitiesYamlDocument
+            {
+                DonateLotteryActivities = _deserializer.Deserialize<List<DonateLotteryActivity>>(yaml) ?? []
+            };
+        }
     }
 
     private static (List<DonateLotteryActivity> Activities, bool Changed) NormalizeActivities(IEnumerable<DonateLotteryActivity> activities)

--- a/tests/EasyLotteryAPITests/DonateActivityEventSourcingTests.cs
+++ b/tests/EasyLotteryAPITests/DonateActivityEventSourcingTests.cs
@@ -75,6 +75,25 @@ public sealed class DonateActivityEventSourcingTests
         Assert.AreEqual(DonateActivityEventTypes.Deleted, events[1].Type);
     }
 
+    [TestMethod]
+    public async Task ListAsync_ReadsDonateActivitiesFromSplitYamlDocument()
+    {
+        var services = CreateServices();
+        var repository = (YamlDonateActivityRepository)services.GetRequiredService<IDonateLotteryActivityRepository>();
+        await File.WriteAllTextAsync(repository.SnapshotPath, """
+            donateLotteryActivities:
+            - id: 7
+              publicId: 7b6e3891-53c3-4c6f-8433-75bdbb9b7f38
+              name: 拍立得
+            """);
+
+        var activities = await repository.ListAsync();
+
+        Assert.AreEqual(1, activities.Count);
+        Assert.AreEqual(7, activities[0].Id);
+        Assert.AreEqual("拍立得", activities[0].Name);
+    }
+
     private static ServiceProvider CreateServices()
     {
         var directory = Path.Combine(Path.GetTempPath(), $"easy-lottery-cqrs-{Guid.NewGuid():N}");


### PR DESCRIPTION
## 修改內容

- Donate 活動 repository 改為讀寫 split YAML 的根文件格式。
- 保留同檔中戳戳樂與轉盤資料，不再覆寫成純活動陣列。
- 相容舊版 root-list 活動 snapshot。
- 新增 mapping 格式的回歸測試。

## 測試

- `dotnet test EasyLottery.generated.sln --no-restore`
- `git diff --check`