### PR TITLE
fix: 讓 Donate OBS 測試正確觸發目前活動

### DIFF
--- a/src/EasyLotteryDomain/Services/DonateLotteryEngine.cs
+++ b/src/EasyLotteryDomain/Services/DonateLotteryEngine.cs
@@ -12,7 +12,9 @@ public static class DonateLotteryEngine
         DateTimeOffset occurredAtUtc,
         Func<double>? nextRandom = null,
         string? donationMessage = null,
-        string? paymentMethod = null)
+        string? paymentMethod = null,
+        int? targetActivityId = null,
+        bool bypassActivityEligibility = false)
     {
         if (string.IsNullOrWhiteSpace(paymentExternalId))
         {
@@ -28,7 +30,8 @@ public static class DonateLotteryEngine
         var results = new List<DonateLotteryDrawRecord>();
         var random = nextRandom ?? Random.Shared.NextDouble;
         foreach (var activity in document.DonateLotteryActivities.Where(activity =>
-                     activity.IsEnabled && occurredAtUtc >= activity.StartsAtUtc && occurredAtUtc <= activity.EndsAtUtc))
+                     (targetActivityId is null || activity.Id == targetActivityId) &&
+                     (bypassActivityEligibility || (activity.IsEnabled && occurredAtUtc >= activity.StartsAtUtc && occurredAtUtc <= activity.EndsAtUtc))))
         {
             var drawCount = activity.MinimumDonationAmount <= 0m ? 0 : (int)(amount / activity.MinimumDonationAmount);
             for (var draw = 0; draw < drawCount; draw++)

--- a/src/EasyLotteryWasm/Pages/DonateObs.razor
+++ b/src/EasyLotteryWasm/Pages/DonateObs.razor
@@ -249,9 +249,22 @@ else
         var document = await ConfigStore.LoadAsync(cancellation.Token);
         var activityKey = activity?.PublicId.ToString("N") ?? ActivityRouteKey;
         var testId = $"obs-test:{activityKey}:{Guid.NewGuid():N}";
-        var result = DonateLotteryEngine.Process(document, testId, testDonorName, testAmount, DateTimeOffset.UtcNow, donationMessage: testMessage, paymentMethod: testPaymentMethod);
+        if (activity is null)
+        {
+            testResult = "測試失敗：找不到目前 OBS 對應的 Donate 活動。";
+            return;
+        }
+
+        var recordsBefore = document.DonateLotteryDrawRecords.Count;
+        var result = DonateLotteryEngine.Process(document, testId, testDonorName, testAmount, DateTimeOffset.UtcNow,
+            donationMessage: testMessage, paymentMethod: testPaymentMethod, targetActivityId: activity.Id, bypassActivityEligibility: true);
         await ConfigStore.SaveAsync(document, cancellation.Token);
-        testResult = result.Wins.Count == 0 ? "測試完成：沒有符合條件的活動。" : $"測試通知已送出（{testPaymentMethod}）：{testDonorName} NT${testAmount:N0}，結果 {string.Join("、", result.Wins.Select(win => win.PrizeName))}。留言：{testMessage}";
+        var testRecords = document.DonateLotteryDrawRecords.Skip(recordsBefore).ToList();
+        testResult = !result.Processed
+            ? $"測試失敗：{result.Reason}"
+            : testRecords.Count == 0
+                ? $"測試完成：贊助金額未達活動門檻 NT${activity.MinimumDonationAmount:N0}。"
+                : $"測試通知已送出（{testPaymentMethod}）：{testDonorName} NT${testAmount:N0}，結果 {string.Join("、", testRecords.Select(win => win.PrizeName))}。留言：{testMessage}";
         await RefreshAsync();
     }
 

--- a/tests/EasyLotteryDomainTests/Services/DonateLotteryEngineTests.cs
+++ b/tests/EasyLotteryDomainTests/Services/DonateLotteryEngineTests.cs
@@ -71,6 +71,19 @@ public sealed class DonateLotteryEngineTests
         Assert.AreEqual("測試付款", result.Wins[0].PaymentMethod);
     }
 
+    [TestMethod]
+    public void Process_TestTargetCanBypassActivityEligibility()
+    {
+        var document = ActiveDocument();
+        document.DonateLotteryActivities[0].IsEnabled = false;
+        document.DonateLotteryActivities[0].StartsAtUtc = DateTimeOffset.UtcNow.AddDays(1);
+
+        var result = DonateLotteryEngine.Process(document, "obs-test", "Alice", 100m, DateTimeOffset.UtcNow, () => 0d,
+            targetActivityId: document.DonateLotteryActivities[0].Id, bypassActivityEligibility: true);
+
+        Assert.AreEqual(1, result.Wins.Count);
+    }
+
     private static EasyLotteryConfigDocument ActiveDocument() => new()
     {
         DonateLotteryActivities =


### PR DESCRIPTION
## 修改內容

- Donate OBS 測試只針對目前 URL 對應活動執行。
- 測試模式略過活動的啟用與日期限制，確保可驗證通知流程。
- 明確區分未達門檻、銘謝惠顧與找不到活動的結果。
- 新增測試模式 eligibility bypass 回歸測試。

## 測試

- `dotnet test EasyLottery.generated.sln --no-restore`
- `git diff --check`