### PR TITLE
fix: 修正 Donate 金額格式文字

### DIFF
--- a/src/EasyLotteryWasm/Pages/ActivityResults.razor
+++ b/src/EasyLotteryWasm/Pages/ActivityResults.razor
@@ -18,7 +18,7 @@
 
 @if (donateSummary is not null)
 {
-    <Card class="mb-4"><CardBody><h4>Donate 統計</h4><div class="row"><div class="col">贊助筆數：@donateSummary.Value.Count</div><div class="col">總金額：NT$@donateSummary.Value.Total:N0</div><div class="col">平均金額：NT$@donateSummary.Value.Average:N0</div><div class="col">中獎結果：@donateSummary.Value.Wins</div></div></CardBody></Card>
+    <Card class="mb-4"><CardBody><h4>Donate 統計</h4><div class="row"><div class="col">贊助筆數：@donateSummary.Value.Count</div><div class="col">總金額：NT$@donateSummary.Value.Total.ToString("N0")</div><div class="col">平均金額：NT$@donateSummary.Value.Average.ToString("N0")</div><div class="col">中獎結果：@donateSummary.Value.Wins</div></div></CardBody></Card>
 }
 
 <div class="activity-results-page">

--- a/src/EasyLotteryWasm/Pages/DonateObs.razor
+++ b/src/EasyLotteryWasm/Pages/DonateObs.razor
@@ -85,7 +85,7 @@
             <div class="donate-reveal-prize">@latestWin.PrizeName</div>
             @if (activity.Type == DonateLotteryActivityType.Polaroid) { <div class="donate-reveal-congratulation">@(aiCongratulation ?? PolaroidFallbackCongratulation)</div> }
             @if (IsGrandPrize) { <div class="grand-prize-banner">★ 最大獎 ★</div> }
-            <div class="donate-reveal-donor">@latestWin.DonorName · NT$@latestWin.Amount:N0</div>
+            <div class="donate-reveal-donor">@latestWin.DonorName · NT$@latestWin.Amount.ToString("N0")</div>
             @if (!string.IsNullOrWhiteSpace(latestWin.DonationMessage)) { <div class="donate-reveal-message">「@latestWin.DonationMessage」</div> }
             @if (!string.IsNullOrWhiteSpace(latestWin.PaymentMethod)) { <small>@latestWin.PaymentMethod</small> }
         </div>


### PR DESCRIPTION
## 修改內容

- 修正 OBS 結果畫面把 Razor 格式字串 `:N0` 直接顯示在金額後的問題。
- 統一 Donate 統計總額與平均金額為千分位整數格式。

## 測試

- `dotnet test EasyLottery.generated.sln --no-restore`
- `git diff --check`