### PR TITLE
fix: 修正 Donate 活動日期顯示與更新投影

### DIFF
--- a/src/EasyLotteryInfrastructure/DonateActivities/DonateActivityEventProjector.cs
+++ b/src/EasyLotteryInfrastructure/DonateActivities/DonateActivityEventProjector.cs
@@ -60,12 +60,15 @@ internal static class DonateActivityEventProjector
         new()
         {
             Id = source.Id,
+            PublicId = source.PublicId,
             Name = source.Name,
             Type = source.Type,
             MinimumDonationAmount = source.MinimumDonationAmount,
             StartsAtUtc = source.StartsAtUtc,
             EndsAtUtc = source.EndsAtUtc,
             Animation = source.Animation,
+            PolaroidTemplateKey = source.PolaroidTemplateKey,
+            UseAiCongratulation = source.UseAiCongratulation,
             IsEnabled = source.IsEnabled,
             Prizes = source.Prizes.Select(prize => new DonateLotteryPrize
             {

--- a/src/EasyLotteryWasm/Pages/DonateActivities.razor
+++ b/src/EasyLotteryWasm/Pages/DonateActivities.razor
@@ -94,7 +94,7 @@
     {
         <tr>
             <td>@activity.Name <small class="text-muted">@activity.Type</small></td>
-            <td>@activity.StartsAtUtc.LocalDateTime:g — @activity.EndsAtUtc.LocalDateTime:g</td>
+            <td>@activity.StartsAtUtc.LocalDateTime.ToString("g") — @activity.EndsAtUtc.LocalDateTime.ToString("g")</td>
             <td>NT$@activity.MinimumDonationAmount</td>
             <td>@activity.Prizes.Sum(prize => prize.RemainingQuantity) / @activity.Prizes.Sum(prize => prize.Quantity)</td>
             <td>@(activity.IsEnabled ? "啟用" : "停用")</td>

--- a/tests/EasyLotteryAPITests/DonateActivityEventSourcingTests.cs
+++ b/tests/EasyLotteryAPITests/DonateActivityEventSourcingTests.cs
@@ -76,6 +76,31 @@ public sealed class DonateActivityEventSourcingTests
     }
 
     [TestMethod]
+    public async Task SaveCommand_PersistsUpdatedAnimationAndDates()
+    {
+        var services = CreateServices();
+        var mediator = services.GetRequiredService<IMediator>();
+        var repository = services.GetRequiredService<IDonateLotteryActivityRepository>();
+        var saved = await mediator.Send(new SaveDonateActivityCommand(new DonateLotteryActivity
+        {
+            Name = "活動", MinimumDonationAmount = 100m, StartsAtUtc = DateTimeOffset.UtcNow.AddDays(-1), EndsAtUtc = DateTimeOffset.UtcNow.AddDays(1)
+        }));
+        var expectedStart = new DateTimeOffset(2026, 7, 26, 3, 0, 0, TimeSpan.Zero);
+        var expectedEnd = new DateTimeOffset(2026, 7, 31, 3, 0, 0, TimeSpan.Zero);
+
+        await mediator.Send(new SaveDonateActivityCommand(new DonateLotteryActivity
+        {
+            Id = saved.Id, PublicId = saved.PublicId, Name = saved.Name, MinimumDonationAmount = 100m,
+            StartsAtUtc = expectedStart, EndsAtUtc = expectedEnd, Animation = DonateLotteryAnimation.Garagara
+        }));
+
+        var updated = (await repository.ListAsync()).Single(activity => activity.Id == saved.Id);
+        Assert.AreEqual(expectedStart, updated.StartsAtUtc);
+        Assert.AreEqual(expectedEnd, updated.EndsAtUtc);
+        Assert.AreEqual(DonateLotteryAnimation.Garagara, updated.Animation);
+    }
+
+    [TestMethod]
     public async Task ListAsync_ReadsDonateActivitiesFromSplitYamlDocument()
     {
         var services = CreateServices();


### PR DESCRIPTION
## 修改內容

- 修正活動期間日期尾端顯示 `:g` 的 Razor 格式問題。
- 補齊 Donate event projector 的公開 ID、拍立得模板與 AI 文案設定複製。
- 新增更新活動日期與動畫後可從 repository 讀回新資料的回歸測試。

## 測試

- `dotnet test EasyLottery.generated.sln --no-restore`
- `git diff --check`