### PR TITLE
fix: 修正 Donate 日期輸入與結束時間規則

### DIFF
--- a/src/EasyLotteryApplication/DonateActivities/DonateActivityRules.cs
+++ b/src/EasyLotteryApplication/DonateActivities/DonateActivityRules.cs
@@ -22,6 +22,11 @@ public static class DonateActivityRules
             throw new InvalidOperationException("活動結束時間必須晚於開始時間。");
         }
 
+        if (activity.EndsAtUtc < DateTimeOffset.UtcNow.AddMinutes(30))
+        {
+            throw new InvalidOperationException("活動結束時間至少必須在目前時間 30 分鐘後。");
+        }
+
         var normalized = Clone(activity);
         normalized.PolaroidTemplateKey = string.IsNullOrWhiteSpace(normalized.PolaroidTemplateKey)
             ? "classic"

--- a/src/EasyLotteryWasm/Pages/DonateActivities.razor
+++ b/src/EasyLotteryWasm/Pages/DonateActivities.razor
@@ -254,14 +254,22 @@
         editing.EndsAtUtc = end;
     }
 
-    private void OnStartDateInput(ChangeEventArgs args) => startDateInput = args.Value?.ToString() ?? "";
-    private void OnEndDateInput(ChangeEventArgs args) => endDateInput = args.Value?.ToString() ?? "";
+    private void OnStartDateInput(ChangeEventArgs args) => startDateInput = NormalizeDateInput(args.Value);
+    private void OnEndDateInput(ChangeEventArgs args) => endDateInput = NormalizeDateInput(args.Value);
 
     private static bool TryConvertLocalDate(string value, out DateTimeOffset instant)
     {
         instant = default;
-        if (!DateTime.TryParseExact(value, "yyyy-MM-ddTHH:mm", CultureInfo.InvariantCulture, DateTimeStyles.None, out var date)) return false;
+        if (!DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, out var date) &&
+            !DateTime.TryParse(value, CultureInfo.CurrentCulture, DateTimeStyles.AllowWhiteSpaces, out date)) return false;
         instant = new DateTimeOffset(DateTime.SpecifyKind(date, DateTimeKind.Local)).ToUniversalTime();
         return true;
     }
+
+    private static string NormalizeDateInput(object? value) => value switch
+    {
+        DateTime date => date.ToString("yyyy-MM-ddTHH:mm", CultureInfo.InvariantCulture),
+        DateTimeOffset date => date.LocalDateTime.ToString("yyyy-MM-ddTHH:mm", CultureInfo.InvariantCulture),
+        _ => value?.ToString() ?? ""
+    };
 }

--- a/src/EasyLotteryWasm/Pages/DonateActivities.razor
+++ b/src/EasyLotteryWasm/Pages/DonateActivities.razor
@@ -35,14 +35,10 @@
             {
                 <div class="row g-3">
                     <div class="col-md-6"><Field><FieldLabel>活動名稱</FieldLabel><TextInput @bind-Value="editing.Name" /></Field></div>
-                    <div class="col-md-3"><Field><FieldLabel>類型</FieldLabel><Select TValue="DonateLotteryActivityType" @bind-SelectedValue="editing.Type"><SelectItem Value="DonateLotteryActivityType.Postcard">明信片</SelectItem><SelectItem Value="DonateLotteryActivityType.Polaroid">拍立得</SelectItem></Select></Field></div>
                     <div class="col-md-3"><Field><FieldLabel>最低贊助金額</FieldLabel><NumericInput TValue="decimal" @bind-Value="editing.MinimumDonationAmount" Min="1" /></Field></div>
                     <div class="col-md-3"><Field><FieldLabel>抽獎動畫</FieldLabel><select class="form-select" @bind="editing.Animation"><option value="@DonateLotteryAnimation.IchibanKuji">一番賞</option><option value="@DonateLotteryAnimation.Gacha">扭蛋</option><option value="@DonateLotteryAnimation.Garagara">日式滾筒</option><option value="@DonateLotteryAnimation.MoneyBox">塞錢箱／詩籤</option></select></Field></div>
-                    @if (editing.Type == DonateLotteryActivityType.Polaroid)
-                    {
-                        <div class="col-md-3"><Field><FieldLabel>拍立得模板</FieldLabel><Select TValue="string" @bind-SelectedValue="editing.PolaroidTemplateKey"><SelectItem Value="@("classic")">經典拍立得</SelectItem><SelectItem Value="@("celebration")">慶典拍立得</SelectItem></Select></Field></div>
-                        <div class="col-md-2"><Field><FieldLabel>AI 恭喜文案</FieldLabel><Switch TValue="bool" @bind-Value="editing.UseAiCongratulation" /></Field></div>
-                    }
+                    <div class="col-md-3"><Field><FieldLabel>結果模板</FieldLabel><Select TValue="string" @bind-SelectedValue="editing.PolaroidTemplateKey"><SelectItem Value="@("classic")">經典</SelectItem><SelectItem Value="@("celebration")">慶典</SelectItem></Select></Field></div>
+                    <div class="col-md-2"><Field><FieldLabel>AI 恭喜文案</FieldLabel><Switch TValue="bool" @bind-Value="editing.UseAiCongratulation" /></Field></div>
                     <div class="col-md-4"><Field><FieldLabel>開始時間（本地時區）</FieldLabel><input class="form-control" type="datetime-local" value="@startDateInput" @oninput="OnStartDateInput" /></Field></div>
                     <div class="col-md-4"><Field><FieldLabel>結束時間（本地時區）</FieldLabel><input class="form-control" type="datetime-local" value="@endDateInput" @oninput="OnEndDateInput" /></Field></div>
                     <div class="col-md-2"><Field><FieldLabel>啟用</FieldLabel><Switch TValue="bool" @bind-Value="editing.IsEnabled" /></Field></div>
@@ -93,7 +89,7 @@
     @foreach (var activity in activities)
     {
         <tr>
-            <td>@activity.Name <small class="text-muted">@activity.Type</small></td>
+            <td>@activity.Name</td>
             <td>@activity.StartsAtUtc.LocalDateTime.ToString("g") — @activity.EndsAtUtc.LocalDateTime.ToString("g")</td>
             <td>NT$@activity.MinimumDonationAmount</td>
             <td>@activity.Prizes.Sum(prize => prize.RemainingQuantity) / @activity.Prizes.Sum(prize => prize.Quantity)</td>

--- a/src/EasyLotteryWasm/Pages/DonateObs.razor
+++ b/src/EasyLotteryWasm/Pages/DonateObs.razor
@@ -83,7 +83,7 @@
             }
             else { <div class="donate-reveal-fallback">@latestWin.PrizeName</div> }
             <div class="donate-reveal-prize">@latestWin.PrizeName</div>
-            @if (activity.Type == DonateLotteryActivityType.Polaroid) { <div class="donate-reveal-congratulation">@(aiCongratulation ?? PolaroidFallbackCongratulation)</div> }
+            <div class="donate-reveal-congratulation">@(aiCongratulation ?? PolaroidFallbackCongratulation)</div>
             @if (IsGrandPrize) { <div class="grand-prize-banner">★ 最大獎 ★</div> }
             <div class="donate-reveal-donor">@latestWin.DonorName · NT$@latestWin.Amount.ToString("N0")</div>
             @if (!string.IsNullOrWhiteSpace(latestWin.DonationMessage)) { <div class="donate-reveal-message">「@latestWin.DonationMessage」</div> }
@@ -227,9 +227,7 @@ else
         DonateLotteryAnimation.MoneyBox => "moneybox",
         _ => "ichiban"
     };
-    private string PolaroidTemplateClass => activity?.Type == DonateLotteryActivityType.Polaroid
-        ? $"polaroid-template-{(string.IsNullOrWhiteSpace(activity.PolaroidTemplateKey) ? "classic" : activity.PolaroidTemplateKey)}"
-        : "polaroid-template-classic";
+    private string PolaroidTemplateClass => $"polaroid-template-{(string.IsNullOrWhiteSpace(activity?.PolaroidTemplateKey) ? "classic" : activity.PolaroidTemplateKey)}";
     private string PolaroidFallbackCongratulation => latestWin is null
         ? ""
         : PolaroidResultTemplateCatalog.Resolve(activity?.PolaroidTemplateKey).FallbackCongratulation
@@ -294,7 +292,7 @@ else
             displayedWinId = latestWin?.Id;
             prizeImageFailed = false;
             aiCongratulation = null;
-            if (activity?.Type == DonateLotteryActivityType.Polaroid && activity.UseAiCongratulation && latestWin is not null)
+            if (activity?.UseAiCongratulation == true && latestWin is not null)
             {
                 aiCongratulation = await AiCongratulationClient.GenerateAsync(latestWin.DonorName, latestWin.PrizeName, cancellation.Token);
             }

--- a/tests/EasyLotteryAPITests/DonateActivityEventSourcingTests.cs
+++ b/tests/EasyLotteryAPITests/DonateActivityEventSourcingTests.cs
@@ -119,6 +119,22 @@ public sealed class DonateActivityEventSourcingTests
         Assert.AreEqual("拍立得", activities[0].Name);
     }
 
+    [TestMethod]
+    public void NormalizeForSave_AllowsPastStartButRequiresEndThirtyMinutesAhead()
+    {
+        var activity = new DonateLotteryActivity
+        {
+            Name = "活動",
+            MinimumDonationAmount = 100m,
+            StartsAtUtc = DateTimeOffset.UtcNow.AddDays(-1),
+            EndsAtUtc = DateTimeOffset.UtcNow.AddMinutes(29)
+        };
+
+        var exception = Assert.ThrowsExactly<InvalidOperationException>(() => DonateActivityRules.NormalizeForSave(activity, []));
+
+        StringAssert.Contains(exception.Message, "30 分鐘後");
+    }
+
     private static ServiceProvider CreateServices()
     {
         var directory = Path.Combine(Path.GetTempPath(), $"easy-lottery-cqrs-{Guid.NewGuid():N}");


### PR DESCRIPTION
## 修改內容

- 修正 datetime-local 事件值轉換，避免儲存時誤判日期無效。
- 開始時間允許設定在過去。
- 後端強制活動結束時間至少為目前時間 30 分鐘後。
- 新增結束時間規則回歸測試。

## 測試

- `dotnet test EasyLottery.generated.sln --no-restore`
- `git diff --check`